### PR TITLE
fix: fetch typeorm database type value from .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 # Database configuration
+DB_TYPE=
 DB_HOST=
 DB_PORT=
 DB_USERNAME=

--- a/src/config/database/configuration.ts
+++ b/src/config/database/configuration.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { DatabaseType } from 'typeorm';
 import { TypeOrmModuleOptions, TypeOrmOptionsFactory } from '@nestjs/typeorm';
 import { ConfigService } from '@nestjs/config';
 
@@ -8,14 +9,14 @@ export class DatabaseConfiguration implements TypeOrmOptionsFactory {
 
   createTypeOrmOptions(): TypeOrmModuleOptions {
     return {
-      type: 'mysql',
-      host: this.configService.get<string>('DB_HOST'),
-      port: +this.configService.get<number>('DB_PORT'),
-      username: this.configService.get<string>('DB_USERNAME'),
-      password: this.configService.get<string>('DB_PASSWORD'),
-      database: this.configService.get<string>('DB_NAME'),
+      type: this.configService.getOrThrow<DatabaseType>('DB_TYPE'),
+      host: this.configService.getOrThrow<string>('DB_HOST'),
+      port: +this.configService.getOrThrow<number>('DB_PORT'),
+      username: this.configService.getOrThrow<string>('DB_USERNAME'),
+      password: this.configService.getOrThrow<string>('DB_PASSWORD'),
+      database: this.configService.getOrThrow<string>('DB_NAME'),
       entities: [__dirname + '/**/*.entity{.ts,.js}'],
       synchronize: false,
-    };
+    } as TypeOrmModuleOptions;
   }
 }

--- a/src/config/database/configuration.ts
+++ b/src/config/database/configuration.ts
@@ -15,7 +15,7 @@ export class DatabaseConfiguration implements TypeOrmOptionsFactory {
       username: this.configService.getOrThrow<string>('DB_USERNAME'),
       password: this.configService.getOrThrow<string>('DB_PASSWORD'),
       database: this.configService.getOrThrow<string>('DB_NAME'),
-      entities: [__dirname + '/**/*.entity{.ts,.js}'],
+      entities: ['src/**/*.entity{.ts,.js}'],
       synchronize: false,
     } as TypeOrmModuleOptions;
   }


### PR DESCRIPTION
This PR updates the datatabase TypeORM configuration to get the database type value from `.env` file instead of being hardcoded.

Other related changes:
- Update `.env.example` to add `DB_TYPE`
- Use `getOrThrow` instead of `get` in `configService`

Fixes #5