### PR TITLE
feat: add database migrations to create notifications table

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,11 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "typeorm:create-migration": "typeorm-ts-node-commonjs migration:create src/database/migrations/migration",
+    "typeorm:generate-migration": "typeorm-ts-node-commonjs migration:generate -d src/config/typeorm/configuration.ts src/database/migrations/migration",
+    "typeorm:run-migration": "typeorm-ts-node-commonjs migration:run -d src/config/typeorm/configuration.ts",
+    "typeorm:revert-migration": "typeorm-ts-node-commonjs migration:revert -d src/config/typeorm/configuration.ts"
   },
   "dependencies": {
     "@nestjs/common": "^10.0.0",

--- a/src/config/typeorm/configuration.ts
+++ b/src/config/typeorm/configuration.ts
@@ -1,0 +1,19 @@
+import { DataSource, DatabaseType, DataSourceOptions } from 'typeorm';
+import { config } from 'dotenv';
+import { ConfigService } from '@nestjs/config';
+
+config();
+
+const configService = new ConfigService();
+
+export default new DataSource({
+  type: configService.getOrThrow<DatabaseType>('DB_TYPE'),
+  host: configService.getOrThrow<string>('DB_HOST'),
+  port: +configService.getOrThrow<number>('DB_PORT'),
+  username: configService.getOrThrow<string>('DB_USERNAME'),
+  password: configService.getOrThrow<string>('DB_PASSWORD'),
+  database: configService.getOrThrow<string>('DB_NAME'),
+  entities: ['src/**/*.entity{.ts,.js}'],
+  migrations: ['src/database/migrations/**'],
+  synchronize: false,
+} as DataSourceOptions);

--- a/src/database/migrations/1692870736644-migration.ts
+++ b/src/database/migrations/1692870736644-migration.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class Migration1692870736644 implements MigrationInterface {
+    name = 'Migration1692870736644'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE \`notifications\` (\`id\` int NOT NULL AUTO_INCREMENT, \`channel_type\` varchar(255) NOT NULL, \`data\` json NOT NULL, \`delivery_status\` int(1) NOT NULL DEFAULT '1', \`result\` json NULL, \`created_by\` varchar(255) NOT NULL, \`created_on\` datetime NOT NULL, \`modified_by\` varchar(255) NULL, \`modified_on\` datetime NULL, PRIMARY KEY (\`id\`)) ENGINE=InnoDB`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP TABLE \`notifications\``);
+    }
+
+}

--- a/src/database/migrations/1692870736644-migration.ts
+++ b/src/database/migrations/1692870736644-migration.ts
@@ -1,14 +1,15 @@
-import { MigrationInterface, QueryRunner } from "typeorm";
+import { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class Migration1692870736644 implements MigrationInterface {
-    name = 'Migration1692870736644'
+  name = 'Migration1692870736644';
 
-    public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`CREATE TABLE \`notifications\` (\`id\` int NOT NULL AUTO_INCREMENT, \`channel_type\` varchar(255) NOT NULL, \`data\` json NOT NULL, \`delivery_status\` int(1) NOT NULL DEFAULT '1', \`result\` json NULL, \`created_by\` varchar(255) NOT NULL, \`created_on\` datetime NOT NULL, \`modified_by\` varchar(255) NULL, \`modified_on\` datetime NULL, PRIMARY KEY (\`id\`)) ENGINE=InnoDB`);
-    }
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE \`notifications\` (\`id\` int NOT NULL AUTO_INCREMENT, \`channel_type\` varchar(255) NOT NULL, \`data\` json NOT NULL, \`delivery_status\` int(1) NOT NULL DEFAULT '1', \`result\` json NULL, \`created_by\` varchar(255) NOT NULL, \`created_on\` datetime NOT NULL, \`modified_by\` varchar(255) NULL, \`modified_on\` datetime NULL, PRIMARY KEY (\`id\`)) ENGINE=InnoDB`,
+    );
+  }
 
-    public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`DROP TABLE \`notifications\``);
-    }
-
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE \`notifications\``);
+  }
 }

--- a/src/models/notifications/entities/notification.entity.ts
+++ b/src/models/notifications/entities/notification.entity.ts
@@ -1,0 +1,31 @@
+import { Entity, Column, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity({ name: 'notifications' })
+export class Notification {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ name: 'channel_type' })
+  channelType: string;
+
+  @Column({ type: 'json' })
+  data: string;
+
+  @Column({ name: 'delivery_status', width: 1, default: 1 })
+  deliveryStatus: number;
+
+  @Column({ type: 'json', nullable: true })
+  result: string;
+
+  @Column({ name: 'created_by' })
+  createdBy: string;
+
+  @Column({ name: 'created_on' })
+  createdOn: Date;
+
+  @Column({ name: 'modified_by', nullable: true })
+  modifiedBy: string;
+
+  @Column({ name: 'modified_on', nullable: true })
+  modifiedOn: Date;
+}


### PR DESCRIPTION
This PR adds the migrations functionality for database changes through TypeORM.

Related changes:
- `notification.entity.ts` file has been created to map values to database.
- `typeorm/configuration.ts` exports the required DataSource to be used when running migrations commands
- `package.json` to configure the different typeorm scripts