### PR TITLE
fix: use tinyint for delivery_status

### DIFF
--- a/src/common/constants/notifications.ts
+++ b/src/common/constants/notifications.ts
@@ -1,0 +1,6 @@
+export const DeliveryStatus = {
+  PENDING: 1,
+  IN_PROGRESS: 2,
+  SUCCESS: 3,
+  FAILED: 4,
+};

--- a/src/database/migrations/1692870736644-migration.ts
+++ b/src/database/migrations/1692870736644-migration.ts
@@ -5,7 +5,7 @@ export class Migration1692870736644 implements MigrationInterface {
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `CREATE TABLE \`notifications\` (\`id\` int NOT NULL AUTO_INCREMENT, \`channel_type\` varchar(255) NOT NULL, \`data\` json NOT NULL, \`delivery_status\` int(1) NOT NULL DEFAULT '1', \`result\` json NULL, \`created_by\` varchar(255) NOT NULL, \`created_on\` datetime NOT NULL, \`modified_by\` varchar(255) NULL, \`modified_on\` datetime NULL, PRIMARY KEY (\`id\`)) ENGINE=InnoDB`,
+      `CREATE TABLE \`notifications\` (\`id\` int NOT NULL AUTO_INCREMENT, \`channel_type\` varchar(255) NOT NULL, \`data\` json NOT NULL, \`delivery_status\` tinyint(1) NOT NULL DEFAULT '1', \`result\` json NULL, \`created_by\` varchar(255) NOT NULL, \`created_on\` datetime NOT NULL, \`modified_by\` varchar(255) NULL, \`modified_on\` datetime NULL, PRIMARY KEY (\`id\`)) ENGINE=InnoDB`,
     );
   }
 

--- a/src/models/notifications/entities/notification.entity.ts
+++ b/src/models/notifications/entities/notification.entity.ts
@@ -1,3 +1,4 @@
+import { DeliveryStatus } from '../../../common/constants/notifications';
 import { Entity, Column, PrimaryGeneratedColumn } from 'typeorm';
 
 @Entity({ name: 'notifications' })
@@ -11,7 +12,12 @@ export class Notification {
   @Column({ type: 'json' })
   data: string;
 
-  @Column({ name: 'delivery_status', width: 1, default: 1 })
+  @Column({
+    name: 'delivery_status',
+    type: 'tinyint',
+    width: 1,
+    default: DeliveryStatus.PENDING,
+  })
   deliveryStatus: number;
 
   @Column({ type: 'json', nullable: true })


### PR DESCRIPTION
This PR makes some database related changes and improvements.

Related changes:
- Add constants/notifications.ts file for DeliveryStatus, tinyint for delivery_status
- Update notifications.entity file to use created constant values
- Update migration file to use tinyint for delivery_status