### PR TITLE
feat: implement queue for processing notifications

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,13 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
+        "@nestjs/bull": "^10.0.1",
         "@nestjs/common": "^10.0.0",
         "@nestjs/config": "^3.0.0",
         "@nestjs/core": "^10.0.0",
         "@nestjs/platform-express": "^10.0.0",
         "@nestjs/typeorm": "^10.0.0",
+        "bull": "^4.11.3",
         "mysql2": "^3.6.0",
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.8.1",
@@ -983,6 +985,11 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
+    "node_modules/@ioredis/commands": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
+      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg=="
+    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -1434,6 +1441,114 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.2.tgz",
+      "integrity": "sha512-9bfjwDxIDWmmOKusUcqdS4Rw+SETlp9Dy39Xui9BEGEk19dDwH0jhipwFzEff/pFg95NKymc6TOTbRKcWeRqyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.2.tgz",
+      "integrity": "sha512-lwriRAHm1Yg4iDf23Oxm9n/t5Zpw1lVnxYU3HnJPTi2lJRkKTrps1KVgvL6m7WvmhYVt/FIsssWay+k45QHeuw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.2.tgz",
+      "integrity": "sha512-MOI9Dlfrpi2Cuc7i5dXdxPbFIgbDBGgKR5F2yWEa6FVEtSWncfVNKW5AKjImAQ6CZlBK9tympdsZJ2xThBiWWA==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.2.tgz",
+      "integrity": "sha512-FU20Bo66/f7He9Fp9sP2zaJ1Q8L9uLPZQDub/WlUip78JlPeMbVL8546HbZfcW9LNciEXc8d+tThSJjSC+tmsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.2.tgz",
+      "integrity": "sha512-gsWNDCklNy7Ajk0vBBf9jEx04RUxuDQfBse918Ww+Qb9HCPoGzS+XJTLe96iN3BVK7grnLiYghP/M4L8VsaHeA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.2.tgz",
+      "integrity": "sha512-O+6Gs8UeDbyFpbSh2CPEz/UOrrdWPTBYNblZK5CxxLisYt4kGX3Sc+czffFonyjiGSq3jWLwJS/CCJc7tBr4sQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@nestjs/bull": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/bull/-/bull-10.0.1.tgz",
+      "integrity": "sha512-1GcJ8BkHDgQdBMZ7SqAqgUHiFnISXmpGvewFeTc8wf87JLk2PweiKv9j9/KQKU+NI237pCe82XB0bXzTnsdxSw==",
+      "dependencies": {
+        "@nestjs/bull-shared": "^10.0.1",
+        "tslib": "2.6.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "@nestjs/core": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "bull": "^3.3 || ^4.0.0"
+      }
+    },
+    "node_modules/@nestjs/bull-shared": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/bull-shared/-/bull-shared-10.0.1.tgz",
+      "integrity": "sha512-8Td36l2i5x9+iQWjPB5Bd5+6u5Eangb5DclNcwrdwKqvd28xE92MSW97P4JV52C2kxrTjZwx8ck/wObAwtpQPw==",
+      "dependencies": {
+        "tslib": "2.6.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "@nestjs/core": "^8.0.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/@nestjs/bull-shared/node_modules/tslib": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+    },
+    "node_modules/@nestjs/bull/node_modules/tslib": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
     },
     "node_modules/@nestjs/cli": {
       "version": "10.1.12",
@@ -3000,6 +3115,31 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
+    "node_modules/bull": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/bull/-/bull-4.11.3.tgz",
+      "integrity": "sha512-DhS0XtiAuejkAY08iGOdDK35eex/yGNoezlWqGJTu9FqWFF/oBjUhpsusE9SXiI4culyDbOoFs+l3ar0VXhFqQ==",
+      "dependencies": {
+        "cron-parser": "^4.2.1",
+        "get-port": "^5.1.1",
+        "ioredis": "^5.3.2",
+        "lodash": "^4.17.21",
+        "msgpackr": "^1.5.2",
+        "semver": "^7.5.2",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/bull/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/bundle-name": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-3.0.0.tgz",
@@ -3328,6 +3468,14 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -3510,6 +3658,17 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "devOptional": true
+    },
+    "node_modules/cron-parser": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.9.0.tgz",
+      "integrity": "sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==",
+      "dependencies": {
+        "luxon": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -4725,6 +4884,17 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/get-port": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
+      "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-stream": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
@@ -5049,6 +5219,29 @@
       "dev": true,
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/ioredis": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.3.2.tgz",
+      "integrity": "sha512-1DKMMzlIHM02eBBVOFQ1+AolGjs6+xEcM4PDL7NqOS6szq7H9jSaEkIUH6/a5Hl241LzW6JLSiAbNvTQjUupUA==",
+      "dependencies": {
+        "@ioredis/commands": "^1.1.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
       }
     },
     "node_modules/ipaddr.js": {
@@ -6056,6 +6249,16 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -6096,6 +6299,14 @@
       "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.2.tgz",
+      "integrity": "sha512-uBoAVCVcajsrqy3pv7eo5jEUz1oeLmCcnMv8n4AJpT5hbpN9lUssAXibNElpbLce3Mhm9dyBzwYLs9zctM/0tA==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/macos-release": {
@@ -6297,6 +6508,35 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "node_modules/msgpackr": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.9.7.tgz",
+      "integrity": "sha512-baUNaLvKQvVhzfWTNO07njwbZK1Lxjtb0P1JL6/EhXdLTHzR57/mZqqJC39TtQKvOmkJA4pcejS4dbk7BDgLLA==",
+      "optionalDependencies": {
+        "msgpackr-extract": "^3.0.2"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.2.tgz",
+      "integrity": "sha512-SdzXp4kD/Qf8agZ9+iTu6eql0m3kWm1A2y1hkpTeVNENutaB0BwHlSvAIaMxwntmRUAUjon2V4L8Z/njd0Ct8A==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.0.7"
+      },
+      "bin": {
+        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.2",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.2",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.2",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.2",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.2",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.2"
+      }
+    },
     "node_modules/multer": {
       "version": "1.4.4-lts.1",
       "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.4-lts.1.tgz",
@@ -6438,6 +6678,17 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.7.tgz",
+      "integrity": "sha512-YlCCc6Wffkx0kHkmam79GKvDQ6x+QZkMjFGrIMxgFNILFvGSbCp2fCBC55pGTT9gVaz8Na5CLmxt/urtzRv36w==",
+      "optional": true,
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
       }
     },
     "node_modules/node-int64": {
@@ -7123,6 +7374,25 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/reflect-metadata": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
@@ -7430,7 +7700,6 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -7445,7 +7714,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -7456,8 +7724,7 @@
     "node_modules/semver/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/send": {
       "version": "0.18.0",
@@ -7679,6 +7946,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
     },
     "node_modules/statuses": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -23,11 +23,13 @@
     "typeorm:revert-migration": "typeorm-ts-node-commonjs migration:revert -d src/config/typeorm/configuration.ts"
   },
   "dependencies": {
+    "@nestjs/bull": "^10.0.1",
     "@nestjs/common": "^10.0.0",
     "@nestjs/config": "^3.0.0",
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
     "@nestjs/typeorm": "^10.0.0",
+    "bull": "^4.11.3",
     "mysql2": "^3.6.0",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1",

--- a/src/common/types/NotificationData.ts
+++ b/src/common/types/NotificationData.ts
@@ -1,0 +1,3 @@
+// TODO: Update and define NotificationData type
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type NotificationData = any;

--- a/src/jobs/consumers/notifications/notifications.job.consumer.ts
+++ b/src/jobs/consumers/notifications/notifications.job.consumer.ts
@@ -1,0 +1,28 @@
+import { Processor, Process } from '@nestjs/bull';
+import { Job } from 'bull';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Notification } from 'src/models/notifications/entities/notification.entity';
+import { DeliveryStatus } from 'src/common/constants/notifications';
+
+@Processor('emailNotifications')
+export class EmailNotificationConsumerService {
+  constructor(
+    @InjectRepository(Notification)
+    private readonly notificationRepository: Repository<Notification>,
+  ) {}
+
+  @Process()
+  async processEmailNotificationQueue(job: Job) {
+    const notification = job.data;
+    try {
+      notification.deliveryStatus = DeliveryStatus.IN_PROGRESS;
+      // TODO: Send the email, update notification values
+      notification.deliveryStatus = DeliveryStatus.SUCCESS;
+    } catch (error) {
+      notification.deliveryStatus = DeliveryStatus.FAILED;
+    } finally {
+      await this.notificationRepository.save(notification);
+    }
+  }
+}

--- a/src/jobs/consumers/notifications/smtp-notifications.job.consumer.ts
+++ b/src/jobs/consumers/notifications/smtp-notifications.job.consumer.ts
@@ -6,7 +6,7 @@ import { Notification } from 'src/models/notifications/entities/notification.ent
 import { DeliveryStatus } from 'src/common/constants/notifications';
 
 @Processor('smtpNotifications')
-export class SmtpNotificationConsumerService {
+export class SmtpNotificationConsumer {
   constructor(
     @InjectRepository(Notification)
     private readonly notificationRepository: Repository<Notification>,

--- a/src/jobs/consumers/notifications/smtp-notifications.job.consumer.ts
+++ b/src/jobs/consumers/notifications/smtp-notifications.job.consumer.ts
@@ -5,15 +5,15 @@ import { Repository } from 'typeorm';
 import { Notification } from 'src/models/notifications/entities/notification.entity';
 import { DeliveryStatus } from 'src/common/constants/notifications';
 
-@Processor('emailNotifications')
-export class EmailNotificationConsumerService {
+@Processor('smtpNotifications')
+export class SmtpNotificationConsumerService {
   constructor(
     @InjectRepository(Notification)
     private readonly notificationRepository: Repository<Notification>,
   ) {}
 
   @Process()
-  async processEmailNotificationQueue(job: Job) {
+  async processSmtpNotificationQueue(job: Job) {
     const notification = job.data;
     try {
       notification.deliveryStatus = DeliveryStatus.IN_PROGRESS;

--- a/src/jobs/consumers/notifications/smtp-notifications.job.consumer.ts
+++ b/src/jobs/consumers/notifications/smtp-notifications.job.consumer.ts
@@ -13,7 +13,7 @@ export class SmtpNotificationConsumer {
   ) {}
 
   @Process()
-  async processSmtpNotificationQueue(job: Job) {
+  async processSmtpNotificationQueue(job: Job): Promise<void> {
     const notification = job.data;
     try {
       notification.deliveryStatus = DeliveryStatus.IN_PROGRESS;

--- a/src/jobs/producers/notifications/notifications.job.producer.ts
+++ b/src/jobs/producers/notifications/notifications.job.producer.ts
@@ -5,9 +5,7 @@ import { Notification } from 'src/models/notifications/entities/notification.ent
 
 @Injectable()
 export class NotificationQueueProducer {
-  constructor(
-    @InjectQueue('smtpNotifications') private readonly smtpQueue: Queue,
-  ) {}
+  constructor(@InjectQueue('smtpNotifications') private readonly smtpQueue: Queue) {}
 
   async addNotificationToQueue(notification: Notification[]): Promise<void> {
     await this.smtpQueue.add(notification);

--- a/src/jobs/producers/notifications/notifications.job.producer.ts
+++ b/src/jobs/producers/notifications/notifications.job.producer.ts
@@ -3,7 +3,7 @@ import { InjectQueue } from '@nestjs/bull';
 import { Queue } from 'bull';
 
 @Injectable()
-export class NotificationQueueService {
+export class NotificationQueueProducer {
   constructor(
     @InjectQueue('smtpNotifications') private readonly smtpQueue: Queue,
   ) {}

--- a/src/jobs/producers/notifications/notifications.job.producer.ts
+++ b/src/jobs/producers/notifications/notifications.job.producer.ts
@@ -5,10 +5,10 @@ import { Queue } from 'bull';
 @Injectable()
 export class NotificationQueueService {
   constructor(
-    @InjectQueue('emailNotifications') private readonly emailQueue: Queue,
+    @InjectQueue('smtpNotifications') private readonly smtpQueue: Queue,
   ) {}
 
   async addNotificationToQueue(notification: any) {
-    await this.emailQueue.add(notification);
+    await this.smtpQueue.add(notification);
   }
 }

--- a/src/jobs/producers/notifications/notifications.job.producer.ts
+++ b/src/jobs/producers/notifications/notifications.job.producer.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectQueue } from '@nestjs/bull';
 import { Queue } from 'bull';
+import { Notification } from 'src/models/notifications/entities/notification.entity';
 
 @Injectable()
 export class NotificationQueueProducer {
@@ -8,7 +9,7 @@ export class NotificationQueueProducer {
     @InjectQueue('smtpNotifications') private readonly smtpQueue: Queue,
   ) {}
 
-  async addNotificationToQueue(notification: any) {
+  async addNotificationToQueue(notification: Notification[]): Promise<void> {
     await this.smtpQueue.add(notification);
   }
 }

--- a/src/jobs/producers/notifications/notifications.job.producer.ts
+++ b/src/jobs/producers/notifications/notifications.job.producer.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@nestjs/common';
+import { InjectQueue } from '@nestjs/bull';
+import { Queue } from 'bull';
+
+@Injectable()
+export class NotificationQueueService {
+  constructor(
+    @InjectQueue('emailNotifications') private readonly emailQueue: Queue,
+  ) {}
+
+  async addNotificationToQueue(notification: any) {
+    await this.emailQueue.add(notification);
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,9 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 
-async function bootstrap() {
+async function bootstrap(): Promise<void> {
   const app = await NestFactory.create(AppModule);
   await app.listen(3000);
 }
+
 bootstrap();

--- a/src/models/notifications/notifications.controller.ts
+++ b/src/models/notifications/notifications.controller.ts
@@ -11,8 +11,7 @@ export class NotificationsController {
   async addNotification(
     @Body() notificationData: NotificationData,
   ): Promise<{ notification: Notification[] }> {
-    const createdNotification =
-      await this.notificationService.createNotification(notificationData);
+    const createdNotification = await this.notificationService.createNotification(notificationData);
     return {
       notification: createdNotification,
     };

--- a/src/models/notifications/notifications.controller.ts
+++ b/src/models/notifications/notifications.controller.ts
@@ -1,12 +1,16 @@
 import { Controller, Post, Body } from '@nestjs/common';
 import { NotificationsService } from './notifications.service';
+import { NotificationData } from 'src/common/types/NotificationData';
+import { Notification } from './entities/notification.entity';
 
 @Controller('notifications')
 export class NotificationsController {
   constructor(private readonly notificationService: NotificationsService) {}
 
   @Post()
-  async addNotification(@Body() notificationData: any) {
+  async addNotification(
+    @Body() notificationData: NotificationData,
+  ): Promise<{ notification: Notification[] }> {
     const createdNotification =
       await this.notificationService.createNotification(notificationData);
     return {

--- a/src/models/notifications/notifications.module.ts
+++ b/src/models/notifications/notifications.module.ts
@@ -14,11 +14,7 @@ import { SmtpNotificationConsumer } from 'src/jobs/consumers/notifications/smtp-
       name: 'smtpNotifications',
     }),
   ],
-  providers: [
-    NotificationQueueProducer,
-    SmtpNotificationConsumer,
-    NotificationsService,
-  ],
+  providers: [NotificationQueueProducer, SmtpNotificationConsumer, NotificationsService],
   exports: [NotificationsService],
   controllers: [NotificationsController],
 })

--- a/src/models/notifications/notifications.module.ts
+++ b/src/models/notifications/notifications.module.ts
@@ -5,18 +5,18 @@ import { Notification } from './entities/notification.entity';
 import { NotificationsService } from './notifications.service';
 import { NotificationsController } from './notifications.controller';
 import { NotificationQueueService } from 'src/jobs/producers/notifications/notifications.job.producer';
-import { EmailNotificationConsumerService } from 'src/jobs/consumers/notifications/notifications.job.consumer';
+import { SmtpNotificationConsumerService } from 'src/jobs/consumers/notifications/smtp-notifications.job.consumer';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Notification]),
     BullModule.registerQueue({
-      name: 'emailNotifications',
+      name: 'smtpNotifications',
     }),
   ],
   providers: [
     NotificationQueueService,
-    EmailNotificationConsumerService,
+    SmtpNotificationConsumerService,
     NotificationsService,
   ],
   exports: [NotificationsService],

--- a/src/models/notifications/notifications.module.ts
+++ b/src/models/notifications/notifications.module.ts
@@ -1,12 +1,24 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { BullModule } from '@nestjs/bull';
 import { Notification } from './entities/notification.entity';
 import { NotificationsService } from './notifications.service';
 import { NotificationsController } from './notifications.controller';
+import { NotificationQueueService } from 'src/jobs/producers/notifications/notifications.job.producer';
+import { EmailNotificationConsumerService } from 'src/jobs/consumers/notifications/notifications.job.consumer';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Notification])],
-  providers: [NotificationsService],
+  imports: [
+    TypeOrmModule.forFeature([Notification]),
+    BullModule.registerQueue({
+      name: 'emailNotifications',
+    }),
+  ],
+  providers: [
+    NotificationQueueService,
+    EmailNotificationConsumerService,
+    NotificationsService,
+  ],
   exports: [NotificationsService],
   controllers: [NotificationsController],
 })

--- a/src/models/notifications/notifications.module.ts
+++ b/src/models/notifications/notifications.module.ts
@@ -4,8 +4,8 @@ import { BullModule } from '@nestjs/bull';
 import { Notification } from './entities/notification.entity';
 import { NotificationsService } from './notifications.service';
 import { NotificationsController } from './notifications.controller';
-import { NotificationQueueService } from 'src/jobs/producers/notifications/notifications.job.producer';
-import { SmtpNotificationConsumerService } from 'src/jobs/consumers/notifications/smtp-notifications.job.consumer';
+import { NotificationQueueProducer } from 'src/jobs/producers/notifications/notifications.job.producer';
+import { SmtpNotificationConsumer } from 'src/jobs/consumers/notifications/smtp-notifications.job.consumer';
 
 @Module({
   imports: [
@@ -15,8 +15,8 @@ import { SmtpNotificationConsumerService } from 'src/jobs/consumers/notification
     }),
   ],
   providers: [
-    NotificationQueueService,
-    SmtpNotificationConsumerService,
+    NotificationQueueProducer,
+    SmtpNotificationConsumer,
     NotificationsService,
   ],
   exports: [NotificationsService],

--- a/src/models/notifications/notifications.service.ts
+++ b/src/models/notifications/notifications.service.ts
@@ -14,9 +14,7 @@ export class NotificationsService {
     private readonly notificationQueueService: NotificationQueueProducer,
   ) {}
 
-  async createNotification(
-    notificationData: NotificationData,
-  ): Promise<Notification[]> {
+  async createNotification(notificationData: NotificationData): Promise<Notification[]> {
     const currentDate = new Date();
     notificationData.createdOn = currentDate.toISOString();
     notificationData.deliveryStatus = DeliveryStatus.PENDING;

--- a/src/models/notifications/notifications.service.ts
+++ b/src/models/notifications/notifications.service.ts
@@ -3,14 +3,14 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Notification } from './entities/notification.entity';
 import { DeliveryStatus } from 'src/common/constants/notifications';
-import { NotificationQueueService } from 'src/jobs/producers/notifications/notifications.job.producer';
+import { NotificationQueueProducer } from 'src/jobs/producers/notifications/notifications.job.producer';
 
 @Injectable()
 export class NotificationsService {
   constructor(
     @InjectRepository(Notification)
     private readonly notificationRepository: Repository<Notification>,
-    private readonly notificationQueueService: NotificationQueueService,
+    private readonly notificationQueueService: NotificationQueueProducer,
   ) {}
 
   async createNotification(notificationData: any) {

--- a/src/models/notifications/notifications.service.ts
+++ b/src/models/notifications/notifications.service.ts
@@ -4,6 +4,7 @@ import { Repository } from 'typeorm';
 import { Notification } from './entities/notification.entity';
 import { DeliveryStatus } from 'src/common/constants/notifications';
 import { NotificationQueueProducer } from 'src/jobs/producers/notifications/notifications.job.producer';
+import { NotificationData } from 'src/common/types/NotificationData';
 
 @Injectable()
 export class NotificationsService {
@@ -13,7 +14,9 @@ export class NotificationsService {
     private readonly notificationQueueService: NotificationQueueProducer,
   ) {}
 
-  async createNotification(notificationData: any) {
+  async createNotification(
+    notificationData: NotificationData,
+  ): Promise<Notification[]> {
     const currentDate = new Date();
     notificationData.createdOn = currentDate.toISOString();
     notificationData.deliveryStatus = DeliveryStatus.PENDING;

--- a/src/models/notifications/notifications.service.ts
+++ b/src/models/notifications/notifications.service.ts
@@ -3,12 +3,14 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Notification } from './entities/notification.entity';
 import { DeliveryStatus } from 'src/common/constants/notifications';
+import { NotificationQueueService } from 'src/jobs/producers/notifications/notifications.job.producer';
 
 @Injectable()
 export class NotificationsService {
   constructor(
     @InjectRepository(Notification)
     private readonly notificationRepository: Repository<Notification>,
+    private readonly notificationQueueService: NotificationQueueService,
   ) {}
 
   async createNotification(notificationData: any) {
@@ -17,6 +19,7 @@ export class NotificationsService {
     notificationData.deliveryStatus = DeliveryStatus.PENDING;
     const notification = this.notificationRepository.create(notificationData);
     const result = await this.notificationRepository.save(notification);
+    await this.notificationQueueService.addNotificationToQueue(notification);
     return result;
   }
 }

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -16,9 +16,6 @@ describe('AppController (e2e)', () => {
   });
 
   it('/ (GET)', () => {
-    return request(app.getHttpServer())
-      .get('/')
-      .expect(200)
-      .expect('Hello World!');
+    return request(app.getHttpServer()).get('/').expect(200).expect('Hello World!');
   });
 });


### PR DESCRIPTION
This PR implements the functionality of queues for processing notifications. Currently, only notification queue is added (for email), but new queues can be created for different channels (such as SMS, chat, etc).

Related changes:
- Add bull package for queue system
- Add notifications producers and consumers for adding jobs to and processing jobs in queue respectively
- Update notifications service to also add notification to queue during creation
- Update notifications module to import bull, queue services; register queue