### PR TITLE
feat: add ESLint rules for code quality improvement

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,8 +18,21 @@ module.exports = {
   ignorePatterns: ['.eslintrc.js'],
   rules: {
     '@typescript-eslint/interface-name-prefix': 'off',
-    '@typescript-eslint/explicit-function-return-type': 'off',
+    '@typescript-eslint/explicit-function-return-type': ['error', { allowExpressions: true }],
     '@typescript-eslint/explicit-module-boundary-types': 'off',
-    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-explicit-any': 'error',
+    '@typescript-eslint/no-unused-vars': 'error',
+    'no-console': 'warn',
+    'padding-line-between-statements': [
+      'error',
+      { 'blankLine': 'always', 'prev': '*', 'next': 'function' },
+      { 'blankLine': 'always', 'prev': 'function', 'next': '*' },
+      { 'blankLine': 'always', 'prev': '*', 'next': 'if' },
+      { 'blankLine': 'always', 'prev': 'if', 'next': '*' },
+      { 'blankLine': 'always', 'prev': '*', 'next': 'for' },
+      { 'blankLine': 'always', 'prev': 'for', 'next': '*' },
+      { 'blankLine': 'always', 'prev': '*', 'next': 'while' },
+      { 'blankLine': 'always', 'prev': 'while', 'next': '*' }
+    ]
   },
 };


### PR DESCRIPTION
### The following rules have been updated.

1. `'@typescript-eslint/explicit-function-return-type': ['error', { allowExpressions: true }]`: Enforces explicit return types for functions in TypeScript, allowing expression-style functions to omit return type annotations.
2. `'@typescript-eslint/no-explicit-any': 'error'`: Flags usages of **any** type in TypeScript as errors.
3. `'@typescript-eslint/no-unused-vars': 'error'`: Reports unused variables in TypeScript as errors.
4. `'no-console': 'warn'`: Generates warnings for the use of console statements.
5. `'padding-line-between-statements': [...]`: Enforces blank lines between specific statement types (e.g., functions, if statements, loops) to enhance code readability.