### PR TITLE
feat: add GitHub actions for linting & building

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,44 @@
+name: Standard Nest.js App Flow
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18' 
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Lint code
+        run: npm run lint
+
+  build:
+    needs: lint
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18' 
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build Nest.js app
+        run: npm run build


### PR DESCRIPTION
### Description

This PR adds a GitHub Actions workflow for linting and building the Nest.js app.

### Workflow Details

- **Name**: Standard Nest.js App Flow
- **Trigger**: Pull requests to the `main` branch

### Workflow Jobs

#### Lint Job
- **Runs on**: Ubuntu Latest
- **Steps**:
  1. Checkout code
  2. Set up Node.js (v18)
  3. Install dependencies
  4. Lint code with `npm run lint`

#### Build Job
- **Needs**: Lint Job (success)
- **Runs on**: Ubuntu Latest
- **Steps**:
  1. Checkout code
  2. Set up Node.js (v18)
  3. Install dependencies
  4. Build Nest.js app using `npm run build`

### Changes Made

- Added GitHub Actions workflow for linting and building.
- Defined separate "lint" and "build" jobs with specific steps and dependencies.
- "Build" job depends on successful "lint" job completion.
