### PR TITLE
feat: add cron to process notifications queue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@nestjs/config": "^3.0.0",
         "@nestjs/core": "^10.0.0",
         "@nestjs/platform-express": "^10.0.0",
+        "@nestjs/schedule": "^3.0.3",
         "@nestjs/typeorm": "^10.0.0",
         "bull": "^4.11.3",
         "mysql2": "^3.6.0",
@@ -1707,6 +1708,20 @@
       "peerDependencies": {
         "@nestjs/common": "^10.0.0",
         "@nestjs/core": "^10.0.0"
+      }
+    },
+    "node_modules/@nestjs/schedule": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-3.0.3.tgz",
+      "integrity": "sha512-xsMA4dmP3LcW3rt2iMPfm88bDbCj/hLuDsLrKmJQlbnxyCYtBwLtmu/4cSfZELLM7pTDT+E8QDAqGwhYyUUjxg==",
+      "dependencies": {
+        "cron": "2.4.1",
+        "uuid": "9.0.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "@nestjs/core": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "reflect-metadata": "^0.1.12"
       }
     },
     "node_modules/@nestjs/schematics": {
@@ -3658,6 +3673,14 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "devOptional": true
+    },
+    "node_modules/cron": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-2.4.1.tgz",
+      "integrity": "sha512-ty0hUSPuENwDtIShDFxUxWEIsqiu2vhoFtt6Vwrbg4lHGtJX2/cV2p0hH6/qaEM9Pj+i6mQoau48BO5wBpkP4w==",
+      "dependencies": {
+        "luxon": "^3.2.1"
+      }
     },
     "node_modules/cron-parser": {
       "version": "4.9.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@nestjs/config": "^3.0.0",
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/schedule": "^3.0.3",
     "@nestjs/typeorm": "^10.0.0",
     "bull": "^4.11.3",
     "mysql2": "^3.6.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,12 +3,14 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { ScheduleModule } from '@nestjs/schedule';
 import { DatabaseConfiguration } from './config/database/configuration';
 import { NotificationsModule } from './models/notifications/notifications.module';
 
 @Module({
   imports: [
     ConfigModule.forRoot(),
+    ScheduleModule.forRoot(),
     TypeOrmModule.forRootAsync({
       imports: [ConfigModule],
       useClass: DatabaseConfiguration,

--- a/src/jobs/consumers/notifications/smtp-notifications.job.consumer.ts
+++ b/src/jobs/consumers/notifications/smtp-notifications.job.consumer.ts
@@ -16,7 +16,6 @@ export class SmtpNotificationConsumer {
   async processSmtpNotificationQueue(job: Job): Promise<void> {
     const notification = job.data;
     try {
-      notification.deliveryStatus = DeliveryStatus.IN_PROGRESS;
       // TODO: Send the email, update notification values
       notification.deliveryStatus = DeliveryStatus.SUCCESS;
     } catch (error) {

--- a/src/jobs/producers/notifications/notifications.job.producer.ts
+++ b/src/jobs/producers/notifications/notifications.job.producer.ts
@@ -8,6 +8,6 @@ export class NotificationQueueProducer {
   constructor(@InjectQueue('smtpNotifications') private readonly smtpQueue: Queue) {}
 
   async addNotificationToQueue(notification: Notification): Promise<void> {
-    await this.smtpQueue.add(notification);
+    await this.smtpQueue.add(notification.id);
   }
 }

--- a/src/jobs/producers/notifications/notifications.job.producer.ts
+++ b/src/jobs/producers/notifications/notifications.job.producer.ts
@@ -7,7 +7,7 @@ import { Notification } from 'src/models/notifications/entities/notification.ent
 export class NotificationQueueProducer {
   constructor(@InjectQueue('smtpNotifications') private readonly smtpQueue: Queue) {}
 
-  async addNotificationToQueue(notification: Notification[]): Promise<void> {
+  async addNotificationToQueue(notification: Notification): Promise<void> {
     await this.smtpQueue.add(notification);
   }
 }

--- a/src/models/notifications/notifications.service.ts
+++ b/src/models/notifications/notifications.service.ts
@@ -26,6 +26,7 @@ export class NotificationsService {
     return result;
   }
 
+  // TODO: Move to its own separate file
   @Cron(CronExpression.EVERY_MINUTE)
   async addNotificationsToQueue(): Promise<void> {
     if (this.isProcessingQueue) {


### PR DESCRIPTION
This PR implements the functionality of CRON to add pending notifications as fetched from database to notifications queue, scheduled to run every minute.

Related changes:
- Add @nestjs/schedule package, import ScheduleModule in app.module
- Add getPendingNotifications to get all notifications in pending status from database
- Add addNotificationQueue function with Cron() decorator to run every 1 minute, update status to IN_PROGRESS and add pending notifications to queue 
- Add and set isProcessingQueue flag for when cron is running