### PR TITLE
refactor: add 'notifi_' prefix to all table names

### DIFF
--- a/src/database/migrations/1692870736644-migration.ts
+++ b/src/database/migrations/1692870736644-migration.ts
@@ -6,7 +6,7 @@ export class Migration1692870736644 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.createTable(
       new Table({
-        name: 'notifications',
+        name: 'notify_notifications',
         columns: [
           {
             name: 'id',

--- a/src/models/notifications/entities/notification.entity.ts
+++ b/src/models/notifications/entities/notification.entity.ts
@@ -9,7 +9,7 @@ import { IsEnum, IsOptional, IsJSON } from 'class-validator';
 import { Status } from 'src/common/constants/database';
 import { ChannelType, DeliveryStatus } from 'src/common/constants/notifications';
 
-@Entity({ name: 'notifications' })
+@Entity({ name: 'notify_notifications' })
 export class Notification {
   @PrimaryGeneratedColumn()
   id: number;


### PR DESCRIPTION
Modified the codebase to prefix all database references with 'notifi_' to maintain a consistent naming convention.