### PR TITLE
docs: add production setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Imagine having a central hub where you can create and send notifications seamles
 ## Documentation
 
 - [Development Setup](docs/development-setup.md)
+- [Production Setup](docs/production-setup.md)
 
 ## Contributing
 

--- a/docs/production-setup.md
+++ b/docs/production-setup.md
@@ -19,24 +19,24 @@ These prerequisites are essential for deploying and running Osmo-Notify in a env
 
 1. **Environment Variables:** Set the necessary environment variables on your production server. These variables include database configuration, SMTP settings, and any other variables your application requires. Ensure the `.env` file is properly configured with production values.
 
-```env
-# Server
-SERVER_PORT=3000
+  ```env
+  # Server
+  SERVER_PORT=3000
 
-# Database configuration
-DB_TYPE=mysql
-DB_HOST=localhost
-DB_PORT=3306
-DB_USERNAME=root
-DB_PASSWORD=your-password
-DB_NAME=your-database
+  # Database configuration
+  DB_TYPE=mysql
+  DB_HOST=localhost
+  DB_PORT=3306
+  DB_USERNAME=root
+  DB_PASSWORD=your-password
+  DB_NAME=your-database
 
-# SMTP
-SMTP_HOST=smtp.example.com
-SMTP_PORT=587
-SMTP_USERNAME=your-smtp-username
-SMTP_PASSWORD=your-smtp-password
-```
+  # SMTP
+  SMTP_HOST=smtp.example.com
+  SMTP_PORT=587
+  SMTP_USERNAME=your-smtp-username
+  SMTP_PASSWORD=your-smtp-password
+  ```
 
 Make sure to replace `your-password`, `your-database`, `your-smtp-username`, and `your-smtp-password` with appropriate values. Server Port is `3000`, you can update it if you want to use a different port of your choice.
 
@@ -48,48 +48,48 @@ Make sure to replace `your-password`, `your-database`, `your-smtp-username`, and
    npm run build
    ```
 
-   This command compiles your TypeScript code into JavaScript and generates the necessary build files.
+  This command compiles your TypeScript code into JavaScript and generates the necessary build files.
 
 ## Starting the Server
 
 1. **PM2 Configuration:** Create an ecosystem.config.js (or .ts) file to configure PM2. This file defines settings such as the application name, entry point, and other options. For example:
 
-```js
-module.exports = {
-  apps: [
-    {
-      name: 'osmo-notify', // Name of your application
-      script: 'dist/main.js', // Path to the compiled NestJS entry file
-      instances: 1, // Use max to Automatically scale instances based on CPU cores
-      autorestart: true, // Auto-restart if the app crashes
-      watch: false, // Watch for file changes (disable for production)
-      max_memory_restart: '1G', // Restart if memory usage exceeds 1GB
-      env: {
-        NODE_ENV: 'production', // Set the environment to production
+  ```js
+  module.exports = {
+    apps: [
+      {
+        name: 'osmo-notify', // Name of your application
+        script: 'dist/main.js', // Path to the compiled NestJS entry file
+        instances: 1, // Use max to Automatically scale instances based on CPU cores
+        autorestart: true, // Auto-restart if the app crashes
+        watch: false, // Watch for file changes (disable for production)
+        max_memory_restart: '1G', // Restart if memory usage exceeds 1GB
+        env: {
+          NODE_ENV: 'production', // Set the environment to production
+        },
       },
-    },
-  ],
-};
-```
+    ],
+  };
+  ```
 
 2. **Start the Application with PM2:** Use PM2 to start your application:
 
-```sh
-pm2 start ecosystem.config.js
-```
+  ```sh
+  pm2 start ecosystem.config.js
+  ```
 
 To ensure your application starts on system boot:
 
-```sh
-pm2 startup
-```
+  ```sh
+  pm2 startup
+  ```
 
 Follow instruction given by the command if any.
 
 Save pm2 config:
 
-```sh
-pm2 save
-```
+  ```sh
+  pm2 save
+  ```
 
 For details on using the application and making API calls, refer to our [Usage Guide](usage-guide.md).

--- a/docs/production-setup.md
+++ b/docs/production-setup.md
@@ -1,0 +1,78 @@
+# Production Setup
+
+This document outlines the steps required to set up your NestJS project for production. Following these steps will ensure that your application is configured properly for a production environment.
+
+## Prerequisites
+
+Before you begin the production setup, make sure you have the following software and steps completed:
+
+### Node.js and npm
+
+Ensure that you have Node.js and npm installed on your production server. You can install them using the methods described in the [Development Setup](development-setup.md) document.
+
+### PM2 (Process Manager)
+
+Install [PM2](https://pm2.keymetrics.io/), a process manager for Node.js applications, on your production server:
+
+```sh
+npm install -g pm2
+```
+
+## Server Configuration
+
+1. **Node.js and npm:** Ensure that you have Node.js and npm installed on your production server. You can install them using the methods described in the [Development Setup](development-setup.md) document.
+
+2. **Environment Variables:** Set the necessary environment variables on your production server. These variables include database configuration, SMTP settings, and any other variables your application requires. Ensure the `.env` file is properly configured.
+
+3. **Database Configuration:** If you're using a separate production database server, update the database configuration in the `.env` file to point to the production database.
+
+## Building and Preparing
+
+1. **Build the Application:** Before starting the server, build your NestJS application by running:
+
+   ```sh
+   npm run build
+   ```
+This command compiles your TypeScript code into JavaScript and generates the necessary build files.
+
+## Starting the Server
+
+1. **PM2 Configuration:** Create an ecosystem.config.js (or .ts) file to configure PM2. This file defines settings such as the application name, entry point, and other options. For example:
+```js
+module.exports = {
+  apps: [
+    {
+      name: 'osmo-notification', // Name of your application
+      script: 'dist/main.js', // Path to the compiled NestJS entry file
+      instances: 1, // Use max to Automatically scale instances based on CPU cores
+      autorestart: true, // Auto-restart if the app crashes
+      watch: false, // Watch for file changes (disable for production)
+      max_memory_restart: '1G', // Restart if memory usage exceeds 1GB
+      env: {
+        NODE_ENV: 'production', // Set the environment to production
+      },
+    },
+  ],
+};
+```
+2. **Start the Application with PM2:** Use PM2 to start your application:
+```sh
+pm2 start ecosystem.config.js
+```
+To ensure your application starts on system boot:
+```sh
+pm2 startup
+```
+Follow instruction given by the command if any.
+
+Save pm2 config:
+```sh
+pm2 save
+```
+
+For details on using the application and making API calls, refer to our [Usage Guide](usage-guide.md).
+
+
+
+
+

--- a/docs/production-setup.md
+++ b/docs/production-setup.md
@@ -42,7 +42,7 @@ This command compiles your TypeScript code into JavaScript and generates the nec
 module.exports = {
   apps: [
     {
-      name: 'osmo-notification', // Name of your application
+      name: 'osmo-notify', // Name of your application
       script: 'dist/main.js', // Path to the compiled NestJS entry file
       instances: 1, // Use max to Automatically scale instances based on CPU cores
       autorestart: true, // Auto-restart if the app crashes

--- a/docs/production-setup.md
+++ b/docs/production-setup.md
@@ -1,43 +1,59 @@
 # Production Setup
 
-This document outlines the steps required to set up your NestJS project for production. Following these steps will ensure that your application is configured properly for a production environment.
+This document outlines the steps required to set up Osmo-Notify for production. Following these steps will ensure that your application is configured properly for a production environment.
 
 ## Prerequisites
 
-Before you begin the production setup, make sure you have the following software and steps completed:
+Before setting up Osmo-Notify for production, ensure you have the following prerequisites with the specified versions:
 
-### Node.js and npm
+- **NVM (Node Version Manager):** Use NVM to manage Node.js versions.
+- **Node.js** Node.js v18.x or higher.
+- **Git:** Git v2.x or higher.
+- **MariaDB:** MariaDB v10.x or higher.
+- **Redis:** Redis v6.x or higher
+- **PM2 (Process Manager):** PM2 v5.x or higher.
 
-Ensure that you have Node.js and npm installed on your production server. You can install them using the methods described in the [Development Setup](development-setup.md) document.
-
-### PM2 (Process Manager)
-
-Install [PM2](https://pm2.keymetrics.io/), a process manager for Node.js applications, on your production server:
-
-```sh
-npm install -g pm2
-```
+These prerequisites are essential for deploying and running Osmo-Notify in a environment.
 
 ## Server Configuration
 
-1. **Node.js and npm:** Ensure that you have Node.js and npm installed on your production server. You can install them using the methods described in the [Development Setup](development-setup.md) document.
+1. **Environment Variables:** Set the necessary environment variables on your production server. These variables include database configuration, SMTP settings, and any other variables your application requires. Ensure the `.env` file is properly configured with production values.
 
-2. **Environment Variables:** Set the necessary environment variables on your production server. These variables include database configuration, SMTP settings, and any other variables your application requires. Ensure the `.env` file is properly configured.
+```env
+# Server
+SERVER_PORT=3000
 
-3. **Database Configuration:** If you're using a separate production database server, update the database configuration in the `.env` file to point to the production database.
+# Database configuration
+DB_TYPE=mysql
+DB_HOST=localhost
+DB_PORT=3306
+DB_USERNAME=root
+DB_PASSWORD=your-password
+DB_NAME=your-database
+
+# SMTP
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USERNAME=your-smtp-username
+SMTP_PASSWORD=your-smtp-password
+```
+
+Make sure to replace `your-password`, `your-database`, `your-smtp-username`, and `your-smtp-password` with appropriate values. Server Port is `3000`, you can update it if you want to use a different port of your choice.
 
 ## Building and Preparing
 
-1. **Build the Application:** Before starting the server, build your NestJS application by running:
+1. **Build the Application:** Before starting the server, build Osmo-Notify by running:
 
    ```sh
    npm run build
    ```
-This command compiles your TypeScript code into JavaScript and generates the necessary build files.
+
+   This command compiles your TypeScript code into JavaScript and generates the necessary build files.
 
 ## Starting the Server
 
 1. **PM2 Configuration:** Create an ecosystem.config.js (or .ts) file to configure PM2. This file defines settings such as the application name, entry point, and other options. For example:
+
 ```js
 module.exports = {
   apps: [
@@ -55,24 +71,25 @@ module.exports = {
   ],
 };
 ```
+
 2. **Start the Application with PM2:** Use PM2 to start your application:
+
 ```sh
 pm2 start ecosystem.config.js
 ```
+
 To ensure your application starts on system boot:
+
 ```sh
 pm2 startup
 ```
+
 Follow instruction given by the command if any.
 
 Save pm2 config:
+
 ```sh
 pm2 save
 ```
 
 For details on using the application and making API calls, refer to our [Usage Guide](usage-guide.md).
-
-
-
-
-

--- a/docs/production-setup.md
+++ b/docs/production-setup.md
@@ -15,8 +15,10 @@ Before setting up Osmo-Notify for production, ensure you have the following prer
 
 These prerequisites are essential for deploying and running Osmo-Notify in a environment.
 
-## Server Configuration
+Make sure Redis and MariaDB server are up and running.
 
+## Server Configuration
+Make sure 
 1. **Environment Variables:** Set the necessary environment variables on your production server. These variables include database configuration, SMTP settings, and any other variables your application requires. Ensure the `.env` file is properly configured with production values.
 
   ```env

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   apps: [
     {
-      name: 'osmo-notification', // Name of your application
+      name: 'osmo-notify', // Name of your application
       script: 'dist/main.js', // Path to the compiled NestJS entry file
       instances: 1, // Use max to Automatically scale instances based on CPU cores
       autorestart: true, // Auto-restart if the app crashes

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+  apps: [
+    {
+      name: 'osmo-notification', // Name of your application
+      script: 'dist/main.js', // Path to the compiled NestJS entry file
+      instances: 1, // Use max to Automatically scale instances based on CPU cores
+      autorestart: true, // Auto-restart if the app crashes
+      watch: false, // Watch for file changes (disable for production)
+      max_memory_restart: '1G', // Restart if memory usage exceeds 1GB
+      env: {
+        NODE_ENV: 'production', // Set the environment to production
+      },
+    },
+  ],
+};


### PR DESCRIPTION
- Create a new `production-setup.md` file to provide comprehensive instructions for setting up the project in a production environment.
- Add a `ecosystem.config.js` file to be used by pm2.