### PR TITLE
fix: fetch only active pending notifications

### DIFF
--- a/src/models/notifications/notifications.service.ts
+++ b/src/models/notifications/notifications.service.ts
@@ -51,6 +51,7 @@ export class NotificationsService {
     return this.notificationRepository.find({
       where: {
         deliveryStatus: DeliveryStatus.PENDING,
+        status: Status.ACTIVE,
       },
     });
   }


### PR DESCRIPTION
This PR updates the `getPendingNotifications()` to fetch only notifications that are in `status` `1` (active), along with the `delivery_status check` of `1` (pending).