### PR TITLE
feat: add mailgun service for sending mails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,5 +19,10 @@ SMTP_PORT=
 SMTP_USERNAME=
 SMTP_PASSWORD=
 
+# Mailgun
+MAILGUN_API_KEY=
+MAILGUN_HOST=  # api.mailgun.net for US, api.eu.mailgun.net for EU
+MAILGUN_DOMAIN=
+
 # TEMP
 APP_NAME=  # Add your app name here.

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "bull": "^4.11.3",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.0",
+        "mailgun.js": "^9.2.1",
         "mysql2": "^3.6.0",
         "nest-winston": "^1.9.4",
         "nodemailer": "^6.9.4",
@@ -2831,8 +2832,17 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/axios": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.0.tgz",
+      "integrity": "sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
     },
     "node_modules/babel-jest": {
       "version": "29.6.3",
@@ -2954,6 +2964,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "node_modules/base-64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
+      "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg=="
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -3621,7 +3636,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -4033,7 +4047,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -4859,6 +4872,25 @@
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fork-ts-checker-webpack-plugin": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-8.0.0.tgz",
@@ -4891,7 +4923,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -6495,6 +6526,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/mailgun.js": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/mailgun.js/-/mailgun.js-9.2.1.tgz",
+      "integrity": "sha512-ra95/QyaI3E6u+xeQlMvjP0ORz+8/50qqtwq7s6c8piqhRjNFk+cp0hxjJe8KtJjF65P68JfLxiQh+DeV6euig==",
+      "dependencies": {
+        "axios": "^1.3.3",
+        "base-64": "^1.0.0",
+        "url-join": "^4.0.1"
+      }
+    },
     "node_modules/make-dir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
@@ -7430,6 +7471,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/pump": {
       "version": "3.0.0",
@@ -9080,6 +9126,11 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "bull": "^4.11.3",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
+    "mailgun.js": "^9.2.1",
     "mysql2": "^3.6.0",
     "nest-winston": "^1.9.4",
     "nodemailer": "^6.9.4",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,6 +7,7 @@ import { NotificationsModule } from './modules/notifications/notifications.modul
 import { SmtpService } from './services/email/smtp/smtp.service';
 import { BullModule } from '@nestjs/bull';
 import { DatabaseModule } from './database/database.module';
+import { MailgunService } from './services/email/mailgun/mailgun.service';
 
 @Module({
   imports: [
@@ -26,6 +27,6 @@ import { DatabaseModule } from './database/database.module';
     NotificationsModule,
   ],
   controllers: [AppController],
-  providers: [AppService, SmtpService],
+  providers: [AppService, SmtpService, MailgunService],
 })
 export class AppModule {}

--- a/src/common/constants/notifications.ts
+++ b/src/common/constants/notifications.ts
@@ -7,4 +7,5 @@ export const DeliveryStatus = {
 
 export const ChannelType = {
   SMTP: 1,
+  MAILGUN: 2,
 };

--- a/src/jobs/consumers/notifications/mailgun-notifications.job.consumer.ts
+++ b/src/jobs/consumers/notifications/mailgun-notifications.job.consumer.ts
@@ -22,7 +22,7 @@ export class MailgunNotificationConsumer {
   ) {}
 
   @Process()
-  async processMailgunNotificationQueue(job: Job): Promise<void> {
+  async processMailgunNotificationQueue(job: Job<number>): Promise<void> {
     const id = job.data;
     const notification = (await this.notificationsService.getNotificationById(id))[0];
 

--- a/src/jobs/consumers/notifications/mailgun-notifications.job.consumer.ts
+++ b/src/jobs/consumers/notifications/mailgun-notifications.job.consumer.ts
@@ -1,0 +1,43 @@
+import { Logger } from '@nestjs/common';
+import { Processor, Process } from '@nestjs/bull';
+import { Job } from 'bull';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Notification } from 'src/modules/notifications/entities/notification.entity';
+import { DeliveryStatus } from 'src/common/constants/notifications';
+import { MailgunService } from 'src/services/email/mailgun/mailgun.service';
+import { MailgunMessageData } from 'mailgun.js';
+import { NotificationsService } from 'src/modules/notifications/notifications.service';
+import { MAILGUN_QUEUE } from 'src/modules/notifications/queues/mailgun.queue';
+
+@Processor(MAILGUN_QUEUE)
+export class MailgunNotificationConsumer {
+  private readonly logger = new Logger(MailgunNotificationConsumer.name);
+
+  constructor(
+    @InjectRepository(Notification)
+    private readonly notificationRepository: Repository<Notification>,
+    private readonly mailgunService: MailgunService,
+    private readonly notificationsService: NotificationsService,
+  ) {}
+
+  @Process()
+  async processMailgunNotificationQueue(job: Job): Promise<void> {
+    const id = job.data;
+    const notification = (await this.notificationsService.getNotificationById(id))[0];
+
+    try {
+      this.logger.log(`Sending notification with id: ${id}`);
+      const result = await this.mailgunService.sendEmail(notification.data as MailgunMessageData);
+      notification.deliveryStatus = DeliveryStatus.SUCCESS;
+      notification.result = { result };
+    } catch (error) {
+      notification.deliveryStatus = DeliveryStatus.FAILED;
+      notification.result = { result: error };
+      this.logger.error(`Error sending notification with id: ${id}`);
+      this.logger.error(JSON.stringify(error, ['message', 'stack'], 2));
+    } finally {
+      await this.notificationRepository.save(notification);
+    }
+  }
+}

--- a/src/jobs/producers/notifications/notifications.job.producer.ts
+++ b/src/jobs/producers/notifications/notifications.job.producer.ts
@@ -18,10 +18,6 @@ export class NotificationQueueProducer {
       this.logger.error('Redis connection error:');
       this.logger.error(JSON.stringify(error, ['message', 'stack', 2]));
     });
-    this.mailgunQueue.client.on('error', (error) => {
-      this.logger.error('Redis connection error:');
-      this.logger.error(JSON.stringify(error, ['message', 'stack', 2]));
-    });
   }
   async addNotificationToQueue(notification: Notification): Promise<void> {
     switch (notification.channelType) {

--- a/src/jobs/producers/notifications/notifications.job.producer.ts
+++ b/src/jobs/producers/notifications/notifications.job.producer.ts
@@ -3,18 +3,34 @@ import { InjectQueue } from '@nestjs/bull';
 import { Queue } from 'bull';
 import { Notification } from 'src/modules/notifications/entities/notification.entity';
 import { SMTP_QUEUE } from 'src/modules/notifications/queues/smtp.queue';
+import { MAILGUN_QUEUE } from 'src/modules/notifications/queues/mailgun.queue';
+import { ChannelType } from 'src/common/constants/notifications';
 
 @Injectable()
 export class NotificationQueueProducer {
-  constructor(@InjectQueue(SMTP_QUEUE) private readonly smtpQueue: Queue) {}
+  constructor(
+    @InjectQueue(SMTP_QUEUE) private readonly smtpQueue: Queue,
+    @InjectQueue(MAILGUN_QUEUE) private readonly mailgunQueue: Queue,
+  ) {}
   private readonly logger = new Logger(NotificationQueueProducer.name);
   async onModuleInit(): Promise<void> {
     this.smtpQueue.client.on('error', (error) => {
       this.logger.error('Redis connection error:');
       this.logger.error(JSON.stringify(error, ['message', 'stack', 2]));
     });
+    this.mailgunQueue.client.on('error', (error) => {
+      this.logger.error('Redis connection error:');
+      this.logger.error(JSON.stringify(error, ['message', 'stack', 2]));
+    });
   }
   async addNotificationToQueue(notification: Notification): Promise<void> {
-    await this.smtpQueue.add(notification.id);
+    switch (notification.channelType) {
+      case ChannelType.SMTP:
+        await this.smtpQueue.add(notification.id);
+        break;
+      case ChannelType.MAILGUN:
+        await this.mailgunQueue.add(notification.id);
+        break;
+    }
   }
 }

--- a/src/modules/notifications/notifications.module.ts
+++ b/src/modules/notifications/notifications.module.ts
@@ -9,14 +9,22 @@ import { SmtpNotificationConsumer } from 'src/jobs/consumers/notifications/smtp-
 import { SmtpService } from 'src/services/email/smtp/smtp.service';
 import { ConfigService } from '@nestjs/config';
 import { smtpQueueConfig } from './queues/smtp.queue';
+import { MailgunService } from 'src/services/email/mailgun/mailgun.service';
+import { mailgunQueueConfig } from './queues/mailgun.queue';
+import { MailgunNotificationConsumer } from 'src/jobs/consumers/notifications/mailgun-notifications.job.consumer';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Notification]), BullModule.registerQueue(smtpQueueConfig)],
+  imports: [
+    TypeOrmModule.forFeature([Notification]),
+    BullModule.registerQueue(smtpQueueConfig, mailgunQueueConfig),
+  ],
   providers: [
     NotificationQueueProducer,
     SmtpNotificationConsumer,
+    MailgunNotificationConsumer,
     NotificationsService,
     SmtpService,
+    MailgunService,
     ConfigService,
   ],
   exports: [NotificationsService],

--- a/src/modules/notifications/queues/mailgun.queue.ts
+++ b/src/modules/notifications/queues/mailgun.queue.ts
@@ -1,0 +1,5 @@
+export const MAILGUN_QUEUE = 'mailgun';
+
+export const mailgunQueueConfig = {
+  name: MAILGUN_QUEUE,
+};

--- a/src/services/email/mailgun/mailgun.service.spec.ts
+++ b/src/services/email/mailgun/mailgun.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MailgunService } from './mailgun.service';
+
+describe('MailgunService', () => {
+  let service: MailgunService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [MailgunService],
+    }).compile();
+
+    service = module.get<MailgunService>(MailgunService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/services/email/mailgun/mailgun.service.ts
+++ b/src/services/email/mailgun/mailgun.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import * as FormData from 'form-data';
+import Mailgun, { MailgunClientOptions, MailgunMessageData, MessagesSendResult } from 'mailgun.js';
+
+@Injectable()
+export class MailgunService {
+  private configService: ConfigService = new ConfigService();
+  private mailgun: Mailgun = new Mailgun(FormData);
+  private mailgunClient;
+
+  constructor() {
+    this.mailgunClient = this.mailgun.client({
+      username: 'api',
+      key: this.configService.getOrThrow<string>('MAILGUN_API_KEY'),
+      host: this.configService.getOrThrow<string>('MAILGUN_HOST'),
+    } as MailgunClientOptions);
+  }
+
+  sendEmail(mailgunNotificationData: MailgunMessageData): Promise<MessagesSendResult> {
+    return this.mailgunClient.messages.create(
+      this.configService.getOrThrow<string>('MAILGUN_DOMAIN'),
+      mailgunNotificationData,
+    );
+  }
+}

--- a/src/services/email/mailgun/mailgun.service.ts
+++ b/src/services/email/mailgun/mailgun.service.ts
@@ -8,6 +8,7 @@ export class MailgunService {
   private configService: ConfigService = new ConfigService();
   private mailgun: Mailgun = new Mailgun(FormData);
   private mailgunClient;
+  private mailgunDomain: string;
 
   constructor() {
     this.mailgunClient = this.mailgun.client({
@@ -15,12 +16,10 @@ export class MailgunService {
       key: this.configService.getOrThrow<string>('MAILGUN_API_KEY'),
       host: this.configService.getOrThrow<string>('MAILGUN_HOST'),
     } as MailgunClientOptions);
+    this.mailgunDomain = this.configService.getOrThrow<string>('MAILGUN_DOMAIN');
   }
 
   sendEmail(mailgunNotificationData: MailgunMessageData): Promise<MessagesSendResult> {
-    return this.mailgunClient.messages.create(
-      this.configService.getOrThrow<string>('MAILGUN_DOMAIN'),
-      mailgunNotificationData,
-    );
+    return this.mailgunClient.messages.create(this.mailgunDomain, mailgunNotificationData);
   }
 }


### PR DESCRIPTION
This PR adds and implements the mailgun service functionality for sending emails. Required code changes, updates and additions have been made.

Related changes:
- Add mailgun.js npm package
- Update .env.example to store mailgun related env variables Update notifications constant file to add MAILGUN type Add mailgun service files for sending mail
- Add mailgun queue file to store its config
- Add mailgun consumer for processing its queue
- Update notifications producer to add notifications to correct queue based on channelType Update notifications module to register queue, add mailgun providers

Sample request body:
```json
{
  "channelType": 2,
  "data": {
    "from": "sender@email.com",
    "to": "recepient1@email.com, recepient2@email.com",
    "subject": "Test subject",
    "text": "This is a test notification",
    "html": "<b>This is a test notification</b>"
  }
}
```

Sample response:
```json
{
  "notification": {
    "channelType": 2,
    "data": {
      "from": "sender@email.com",
      "to": "recepient1@email.com, recepient2@email.com",
      "subject": "Test subject",
      "text": "This is a test notification",
      "html": "<b>This is a test notification</b>"
    },
    "createdBy": "testuser",
    "updatedBy": "testuser",
    "result": null,
    "id": 21,
    "deliveryStatus": 1,
    "createdOn": "2023-09-04T12:31:21.000Z",
    "updatedOn": "2023-09-04T12:31:21.000Z",
    "status": 1
  }
}
```