### PR TITLE
docs: add mailgun channel usage guide

### DIFF
--- a/docs/channels/mailgun.md
+++ b/docs/channels/mailgun.md
@@ -1,0 +1,52 @@
+## Mailgun
+
+Mailgun is an email service provider that offers a RESTful API for sending emails from your Node.js application. Their official `npm` module, `mailgun.js`, makes it easy to integrate Mailgun into your Node.js app and send emails using API requests.
+
+### ENV Values to Update
+
+When using Mailgun to send emails via their API, you need to provide certain environment variables that hold the Mailgun configuration details. Here are the ENV values you need to update:
+
+```sh
+# Mailgun
+MAILGUN_API_KEY=your-api-key         # Your Mailgun API key
+MAILGUN_HOST=api.mailgun.net         # Mailgun host; api.mailgun.net for US, api.eu.mailgun.net for EU
+MAILGUN_DOMAIN=your.mailgun.domain   # Your Mailgun domain name
+```
+
+Make sure to replace `your-api-key`, `api.mailgun.net`, and `your.mailgun.domain` with the appropriate values as per your Mailgun account setup.
+
+### Sample Request Body
+
+Here's a sample request body:
+
+```jsonc
+{
+  "channelType": 2,
+  "data": {
+    "from": "sender@example.com",                   # Sender's email address
+    "to": "recipient@example.com",                  # Recipient's email address
+    "cc": "cc@example.com",                         # CC email address (optional)
+    "bcc": "bcc@example.com",                       # BCC email address (optional)
+    "subject": "Test subject",                      # Email subject
+    "text": "This is a test notification",          # Plain text version of the email
+    "html": "<b>This is a test notification</b>",   # HTML version of the email
+    "attachment": [                                 # Attachments (optional)
+      {
+        "filename": "names.txt",
+        "data": "John Doe\nJane Doe",
+      },
+    ],
+  }
+}
+```
+
+In addition to the provided fields, there are several other options you can include when calling the `messages.create` method:
+
+- **to:** An array or comma-separated string of email addresses to send mail.
+- **cc:** An array or comma-separated string of CC email addresses.
+- **bcc:** An array or comma-separated string of BCC email addresses.
+- **attachment:** An array of attachment objects, each containing `filename` and `data`. As of now we only support text content as mentioned in the example.
+
+These options allow you to customize the email message according to your needs. Remember to adjust the options based on your specific use case and requirements.
+
+Reference: https://documentation.mailgun.com/en/latest/api-sending.html

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -35,12 +35,12 @@ Make sure Redis and MariaDB server are up and running.
    npm install
    ```
 
-3. Create a .env file in the project root and add the required environment variables:
+3. Create a `.env` file in the project root and add the required environment variables:
 
    ```env
    # Server
    SERVER_PORT=3000
-  
+
    # Database configuration
    DB_TYPE=mysql
    DB_HOST=localhost
@@ -49,14 +49,26 @@ Make sure Redis and MariaDB server are up and running.
    DB_PASSWORD=your-password
    DB_NAME=your-database
 
+   # Redis configuration
+   REDIS_HOST=127.0.0.1
+   REDIS_PORT=6379
+
    # SMTP
    SMTP_HOST=smtp.example.com
    SMTP_PORT=587
    SMTP_USERNAME=your-smtp-username
    SMTP_PASSWORD=your-smtp-password
+
+   # Mailgun
+   MAILGUN_API_KEY=your-mailgun-api-key
+   MAILGUN_HOST=api.mailgun.net
+   MAILGUN_DOMAIN=your.mailgun.domain
+
+   # TEMP
+   APP_NAME=osmo_notify
    ```
 
-Make sure to replace `your-password`, `your-database`, `your-smtp-username`, and `your-smtp-password` with appropriate values. Server Port is `3000`, you can update it if you want to use a different port of your choice.
+Make sure to replace the above example values with appropriate values as per your setup and configuration. Server Port is `3000`, you can update it if you want to use a different port of your choice.
 
 4. Set up the database:
 

--- a/docs/production-setup.md
+++ b/docs/production-setup.md
@@ -18,7 +18,7 @@ These prerequisites are essential for deploying and running Osmo-Notify in a env
 Make sure Redis and MariaDB server are up and running.
 
 ## Server Configuration
-Make sure 
+
 1. **Environment Variables:** Set the necessary environment variables on your production server. These variables include database configuration, SMTP settings, and any other variables your application requires. Ensure the `.env` file is properly configured with production values.
 
   ```env
@@ -33,14 +33,26 @@ Make sure
   DB_PASSWORD=your-password
   DB_NAME=your-database
 
+  # Redis configuration
+  REDIS_HOST=127.0.0.1
+  REDIS_PORT=6379
+
   # SMTP
   SMTP_HOST=smtp.example.com
   SMTP_PORT=587
   SMTP_USERNAME=your-smtp-username
   SMTP_PASSWORD=your-smtp-password
+
+  # Mailgun
+  MAILGUN_API_KEY=your-mailgun-api-key
+  MAILGUN_HOST=api.mailgun.net
+  MAILGUN_DOMAIN=your.mailgun.domain
+
+  # TEMP
+  APP_NAME=osmo_notify
   ```
 
-Make sure to replace `your-password`, `your-database`, `your-smtp-username`, and `your-smtp-password` with appropriate values. Server Port is `3000`, you can update it if you want to use a different port of your choice.
+Make sure to replace the above example values with appropriate values as per your setup and configuration. Server Port is `3000`, you can update it if you want to use a different port of your choice.
 
 ## Building and Preparing
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -73,9 +73,10 @@ Osmo-Notify updates the `delivery_status` and `result` columns to provide inform
 
 Osmo-Notify supports multiple channel types, allowing you to choose the most suitable one for your notifications. Currently, the available channel types are:
 
-|           **Channel Type**           | **Value** |       **Document**       |
-|:------------------------------------:|:---------:|:------------------------:|
-| SMTP - Simple Mail Transfer Protocol |     1     | [SMTP](channels/smtp.md) |
+|           **Channel Type**           | **Value** |          **Document**          |
+|:------------------------------------:|:---------:|:------------------------------:|
+| SMTP - Simple Mail Transfer Protocol |     1     | [SMTP](channels/smtp.md)       |
+| Mailgun                              |     2     | [Mailgun](channels/mailgun.md) |
 
 ## 6. Delivery Status Information
 


### PR DESCRIPTION
This PR adds the usage documentation guide for Mailgun channel type.

Related changes:
- Update development and production setup docs with new env file config
- Update main usage-guide doc to add link to mailgun doc link