### PR TITLE
fix: change json columns to text type

### DIFF
--- a/src/database/migrations/1692870736644-migration.ts
+++ b/src/database/migrations/1692870736644-migration.ts
@@ -21,7 +21,7 @@ export class Migration1692870736644 implements MigrationInterface {
           },
           {
             name: 'data',
-            type: 'json',
+            type: 'text',
           },
           {
             name: 'delivery_status',
@@ -30,7 +30,7 @@ export class Migration1692870736644 implements MigrationInterface {
           },
           {
             name: 'result',
-            type: 'json',
+            type: 'text',
             isNullable: true,
           },
           {


### PR DESCRIPTION
This PR updates the json data type columns `data` and `result` to text type to allow migrations to run with MariaDB versions 10.x or higher.