### PR TITLE
fix: change migrations table name to notify_migrations

### DIFF
--- a/src/config/typeorm/configuration.ts
+++ b/src/config/typeorm/configuration.ts
@@ -15,5 +15,6 @@ export default new DataSource({
   database: configService.getOrThrow<string>('DB_NAME'),
   entities: [],
   migrations: ['src/database/migrations/**'],
+  migrationsTableName: 'notify_migrations',
   synchronize: false,
 } as DataSourceOptions);


### PR DESCRIPTION
This PR updates the TypeORM DataSource configuration to specify migrations table name to be `notify_migrations` instead of default `migrations`.