### PR TITLE
fix: table name to notify_notifications for revert migration

### DIFF
--- a/src/database/migrations/1692870736644-migration.ts
+++ b/src/database/migrations/1692870736644-migration.ts
@@ -63,6 +63,6 @@ export class Migration1692870736644 implements MigrationInterface {
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`DROP TABLE \`notifications\``);
+    await queryRunner.query(`DROP TABLE \`notify_notifications\``);
   }
 }


### PR DESCRIPTION
This PR updates the query in migration file when running revert migration to use correct table name `notify_notifications` instead of `notifications`.