### PR TITLE
feat: add validation for notification data

### DIFF
--- a/src/modules/notifications/dtos/create-notification-data.dto.ts
+++ b/src/modules/notifications/dtos/create-notification-data.dto.ts
@@ -1,0 +1,27 @@
+import { IsString, IsNotEmpty, IsOptional } from 'class-validator';
+
+export class CreateNotificationDataDto {
+  @IsNotEmpty()
+  from: string | string[];
+
+  @IsNotEmpty()
+  to: string | string[];
+
+  @IsOptional()
+  cc?: string | string[];
+
+  @IsOptional()
+  bcc?: string | string[];
+
+  @IsNotEmpty()
+  @IsString()
+  subject: string;
+
+  @IsNotEmpty()
+  @IsString()
+  text: string;
+
+  @IsNotEmpty()
+  @IsString()
+  html: string;
+}

--- a/src/modules/notifications/dtos/create-notification.dto.ts
+++ b/src/modules/notifications/dtos/create-notification.dto.ts
@@ -1,10 +1,14 @@
-import { IsEnum, IsObject } from 'class-validator';
+import { Type } from 'class-transformer';
+import { IsEnum, IsObject, ValidateNested } from 'class-validator';
 import { ChannelType } from 'src/common/constants/notifications';
+import { CreateNotificationDataDto } from './create-notification-data.dto';
 
 export class CreateNotificationDto {
   @IsEnum(ChannelType)
   channelType: number;
 
   @IsObject()
-  data: Record<string, unknown>;
+  @ValidateNested()
+  @Type(() => CreateNotificationDataDto)
+  data: CreateNotificationDataDto;
 }

--- a/src/modules/notifications/entities/notification.entity.ts
+++ b/src/modules/notifications/entities/notification.entity.ts
@@ -8,6 +8,7 @@ import {
 import { IsEnum, IsOptional, IsObject } from 'class-validator';
 import { Status } from 'src/common/constants/database';
 import { ChannelType, DeliveryStatus } from 'src/common/constants/notifications';
+import { CreateNotificationDataDto } from '../dtos/create-notification-data.dto';
 
 @Entity({ name: 'notify_notifications' })
 export class Notification {
@@ -20,7 +21,7 @@ export class Notification {
 
   @Column({ type: 'json' })
   @IsObject()
-  data: Record<string, unknown>;
+  data: CreateNotificationDataDto;
 
   @Column({
     name: 'delivery_status',

--- a/src/modules/notifications/notifications.service.ts
+++ b/src/modules/notifications/notifications.service.ts
@@ -8,6 +8,9 @@ import { NotificationQueueProducer } from 'src/jobs/producers/notifications/noti
 import { Status } from 'src/common/constants/database';
 import { CreateNotificationDto } from './dtos/create-notification.dto';
 import { ConfigService } from '@nestjs/config';
+import { validateOrReject } from 'class-validator';
+import { plainToClass } from 'class-transformer';
+import { CreateNotificationDataDto } from './dtos/create-notification-data.dto';
 
 @Injectable()
 export class NotificationsService {
@@ -46,11 +49,15 @@ export class NotificationsService {
     for (const notification of pendingNotifications) {
       try {
         notification.deliveryStatus = DeliveryStatus.IN_PROGRESS;
+        await validateOrReject(plainToClass(CreateNotificationDataDto, notification.data), {
+          validationError: { target: false },
+        });
         await this.notificationQueueService.addNotificationToQueue(notification);
       } catch (error) {
         notification.deliveryStatus = DeliveryStatus.PENDING;
+        notification.result = { result: error };
         this.logger.error(`Error adding notification with id: ${notification.id} to queue`);
-        this.logger.error(JSON.stringify(error, ['message', 'stack'], 2));
+        this.logger.error(JSON.stringify(error, null, 2));
       } finally {
         await this.notificationRepository.save(notification);
       }


### PR DESCRIPTION
This PR adds validation to the notification data, when sent via API call and also before adding the notification ID into queue.

Related changes:
- Create a DTO for notification data, add rules
- Update notification dto, entity to change type of data to CreateNotificationDataDto Update notification service to validate notification data from database via the new DTO before adding to queue

Sample Erroneous Request:
```json
{
  "channelType": 1,
  "data": {
    "to": "receiver@email.com",
    "subject": "Test Notification",
    "text": "This is a test notification",
    "html": "<b>This is a test notification</b>"
  }
}
```

Sample Response:
```json
{
  "message": [
    "data.from should not be empty"
  ],
  "error": "Bad Request",
  "statusCode": 400
}
```

Error Logging in Console:
```bash
[OsmoNotify] Error      9/7/2023, 6:45:00 PM [NotificationsService] Error adding notification with id: 9 to queue - {"stack":[null]} +9ms
[OsmoNotify] Error      9/7/2023, 6:45:00 PM [NotificationsService] [
  {
    "property": "from",
    "children": [],
    "constraints": {
      "isNotEmpty": "from should not be empty"
    }
  }
] - {"stack":[null]} +1ms
```