### PR TITLE
fix: api response to follow jsend format

### DIFF
--- a/src/common/http-exception.filter.ts
+++ b/src/common/http-exception.filter.ts
@@ -1,0 +1,22 @@
+import {
+  ExceptionFilter,
+  Catch,
+  ArgumentsHost,
+  HttpException,
+  HttpExceptionBody,
+} from '@nestjs/common';
+import { Response } from 'express';
+import { JsendFormatter } from './jsend-formatter';
+
+@Catch(HttpException)
+export class HttpExceptionFilter implements ExceptionFilter {
+  constructor(private jsend: JsendFormatter) {}
+
+  catch(exception: HttpException, host: ArgumentsHost): void {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+    const status = exception.getStatus();
+    const data = exception.getResponse() as HttpExceptionBody;
+    response.status(status).json(this.jsend.fail(data.message));
+  }
+}

--- a/src/common/jsend-formatter.ts
+++ b/src/common/jsend-formatter.ts
@@ -1,0 +1,25 @@
+import { HttpExceptionBodyMessage } from '@nestjs/common';
+import { Notification } from 'src/modules/notifications/entities/notification.entity';
+
+export class JsendFormatter {
+  public success(data: { notification: Notification }): Record<string, unknown> {
+    return {
+      status: 'success',
+      data: data,
+    };
+  }
+
+  public fail(data: HttpExceptionBodyMessage): Record<string, unknown> {
+    return {
+      status: 'fail',
+      data: data,
+    };
+  }
+
+  public error(message: string): Record<string, unknown> {
+    return {
+      status: 'error',
+      message: message,
+    };
+  }
+}

--- a/src/modules/notifications/notifications.controller.ts
+++ b/src/modules/notifications/notifications.controller.ts
@@ -1,19 +1,30 @@
-import { Controller, Post, Body } from '@nestjs/common';
+import { Controller, Post, Body, Logger, UseFilters } from '@nestjs/common';
 import { NotificationsService } from './notifications.service';
-import { Notification } from './entities/notification.entity';
 import { CreateNotificationDto } from './dtos/create-notification.dto';
+import { JsendFormatter } from 'src/common/jsend-formatter';
+import { HttpExceptionFilter } from 'src/common/http-exception.filter';
 
 @Controller('notifications')
 export class NotificationsController {
-  constructor(private readonly notificationService: NotificationsService) {}
+  constructor(
+    private readonly notificationService: NotificationsService,
+    private readonly jsend: JsendFormatter,
+    private logger: Logger,
+  ) {}
 
   @Post()
+  @UseFilters(HttpExceptionFilter)
   async addNotification(
     @Body() notificationData: CreateNotificationDto,
-  ): Promise<{ notification: Notification }> {
-    const createdNotification = await this.notificationService.createNotification(notificationData);
-    return {
-      notification: createdNotification,
-    };
+  ): Promise<Record<string, unknown>> {
+    try {
+      const createdNotification =
+        await this.notificationService.createNotification(notificationData);
+      return this.jsend.success({ notification: createdNotification });
+    } catch (error) {
+      this.logger.error('Error while creating notification');
+      this.logger.error(JSON.stringify(error, ['message', 'stack'], 2));
+      return this.jsend.error(error.message);
+    }
   }
 }

--- a/src/modules/notifications/notifications.module.ts
+++ b/src/modules/notifications/notifications.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, Logger } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { BullModule } from '@nestjs/bull';
 import { Notification } from './entities/notification.entity';
@@ -12,6 +12,7 @@ import { smtpQueueConfig } from './queues/smtp.queue';
 import { MailgunService } from 'src/services/email/mailgun/mailgun.service';
 import { mailgunQueueConfig } from './queues/mailgun.queue';
 import { MailgunNotificationConsumer } from 'src/jobs/consumers/notifications/mailgun-notifications.job.consumer';
+import { JsendFormatter } from 'src/common/jsend-formatter';
 
 @Module({
   imports: [
@@ -26,6 +27,8 @@ import { MailgunNotificationConsumer } from 'src/jobs/consumers/notifications/ma
     SmtpService,
     MailgunService,
     ConfigService,
+    JsendFormatter,
+    Logger,
   ],
   exports: [NotificationsService],
   controllers: [NotificationsController],


### PR DESCRIPTION
This PR fixes the responses sent to follow jsend formatting when making API call to create a notification.

Related changes:
- Add a JsendFormatter class to declare methods for formatting messages for success, fail, error
- Add an exception filter for formatting response for failed dto validations
- Update controller to add try catch block for success and error jsend response, log error when creating notification

Sample response for successful notification creation:
```json
{
  "status": "success",
  "data": {
    "notification": {
      "channelType": 1,
      "data": {
        "from": "sender@email.com",
        "to": "receiver@email.com",
        "subject": "Test Notification",
        "text": "This is a test notification",
        "html": "<b>This is a test notification</b>"
      },
      "createdBy": "LocalDev",
      "updatedBy": "LocalDev",
      "result": null,
      "id": 36,
      "deliveryStatus": 1,
      "createdOn": "2023-09-08T13:11:52.000Z",
      "updatedOn": "2023-09-08T13:11:52.000Z",
      "status": 1
    }
  }
}
```

Sample response when using incorrect channelType value:
```json
{
  "status": "fail",
  "data": [
    "channelType must be one of the following values: 1, 2"
  ]
}
```