### PR TITLE
docs: update api response formats, content fixes

### DIFF
--- a/docs/channels/mailgun.md
+++ b/docs/channels/mailgun.md
@@ -23,14 +23,14 @@ Here's a sample request body:
 {
   "channelType": 2,
   "data": {
-    "from": "sender@example.com",                   # Sender's email address
-    "to": "recipient@example.com",                  # Recipient's email address
-    "cc": "cc@example.com",                         # CC email address (optional)
-    "bcc": "bcc@example.com",                       # BCC email address (optional)
-    "subject": "Test subject",                      # Email subject
-    "text": "This is a test notification",          # Plain text version of the email
-    "html": "<b>This is a test notification</b>",   # HTML version of the email
-    "attachment": [                                 # Attachments (optional)
+    "from": "sender@example.com",                   // Sender's email address
+    "to": "recipient@example.com",                  // Recipient's email address
+    "cc": "cc@example.com",                         // CC email address (optional)
+    "bcc": "bcc@example.com",                       // BCC email address (optional)
+    "subject": "Test subject",                      // Email subject
+    "text": "This is a test notification",          // Plain text version of the email
+    "html": "<b>This is a test notification</b>",   // HTML version of the email
+    "attachment": [                                 // Attachments (optional)
       {
         "filename": "names.txt",
         "data": "John Doe\nJane Doe",

--- a/docs/channels/smtp.md
+++ b/docs/channels/smtp.md
@@ -20,24 +20,24 @@ Make sure to replace `smtp.example.com`, `your-smtp-username`, and `your-smtp-pa
 
 Here's a sample request body:
 
-```json
+```jsonc
 {
   "channelType": 1,
   "data": {
-    "from": "sender@example.com",            # Sender's email address
-    "to": "recipient@example.com",           # Recipient's email address
-    "cc": "cc@example.com",                 # CC email address (optional)
-    "bcc": "bcc@example.com",               # BCC email address (optional)
-    "subject": "Test subject",              # Email subject
-    "text": "This is a test notification",  # Plain text version of the email
-    "html": "<b>This is a test notification</b>",  # HTML version of the email
-    "attachments": [                        # Attachments (optional)
+    "from": "sender@example.com",                  // Sender's email address
+    "to": "recipient@example.com",                 // Recipient's email address
+    "cc": "cc@example.com",                        // CC email address (optional)
+    "bcc": "bcc@example.com",                      // BCC email address (optional)
+    "subject": "Test subject",                     // Email subject
+    "text": "This is a test notification",         // Plain text version of the email
+    "html": "<b>This is a test notification</b>",  // HTML version of the email
+    "attachments": [                               // Attachments (optional)
       {
           "filename": "names.txt",
           "content": "John Doe\nJane Doe",
       },
     ],
-    "headers": {                            # Custom headers (optional)
+    "headers": {                                   // Custom headers (optional)
       "X-Custom-Header": "Custom Value"
     }
   }
@@ -49,7 +49,7 @@ In addition to the provided fields, there are several other options you can incl
 - **to:** An array or comma-separated string of email addresses to send mail.
 - **cc:** An array or comma-separated string of CC email addresses.
 - **bcc:** An array or comma-separated string of BCC email addresses.
-- **attachments:** An array of attachment objects, each containing `filename` and `path`. As of now we only support text content as mentioned in the example.
+- **attachments:** An array of attachment objects, each containing `filename` and `content`/`path`. As of now we only support text content as mentioned in the example.
 - **headers:** Additional headers to include in the email.
 
 These options allow you to customize the email message according to your needs. Remember to adjust the options based on your specific use case and requirements.

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -45,22 +45,26 @@ To use the Osmo-Notify API, follow these steps:
 **Response:**
 ```json
 {
-  "notification": {
-    "channelType": "smtp-server",
-    "data": {
-      "from": "sender@example.com",
-      "to": "recipient@example.com",
-      "subject": "Test subject",
-      "text": "This is a test notification",
-      "html": "<b>This is a test notification</b>"
-    },
-    "deliveryStatus": 1,
-    "createdBy": "osmo-notify",
-    "createdOn": "2023-08-25T10:55:36.794Z",
-    "result": null,
-    "modifiedBy": null,
-    "modifiedOn": null,
-    "id": 1
+  "status": "success",
+  "data": {
+    "notification": {
+      "channelType": 1,
+      "data": {
+        "from": "sender@example.com",
+        "to": "recipient@example.com",
+        "subject": "Test subject",
+        "text": "This is a test notification",
+        "html": "<b>This is a test notification</b>"
+      },
+      "createdBy": "osmo_notify",
+      "updatedBy": "osmo_notify",
+      "result": null,
+      "id": 36,
+      "deliveryStatus": 1,
+      "createdOn": "2023-09-08T13:11:52.000Z",
+      "updatedOn": "2023-09-08T13:11:52.000Z",
+      "status": 1
+    }
   }
 }
 ```
@@ -80,7 +84,7 @@ Osmo-Notify supports multiple channel types, allowing you to choose the most sui
 
 ## 6. Delivery Status Information
 
-Osmo-Notify provides different delivery status options to reflect the state of your notifications:**
+Osmo-Notify provides different delivery status options to reflect the state of your notifications:
 
 |  **Status** |                **Description**               | **Value** |
 |:-----------:|:--------------------------------------------:|:---------:|


### PR DESCRIPTION
This PR updates some outdated API responses and fixes their formatting (for comments). 

Related changes:
- Update sample API response in `usage-guide.md` as per jsend format (see #43)
- Fix comments in smtp and mailgun docs
- Other minor formatting and content fixes