### PR TITLE
fix: add standard validation for attachments

### DIFF
--- a/src/jobs/consumers/notifications/mailgun-notifications.job.consumer.ts
+++ b/src/jobs/consumers/notifications/mailgun-notifications.job.consumer.ts
@@ -28,7 +28,12 @@ export class MailgunNotificationConsumer {
 
     try {
       this.logger.log(`Sending notification with id: ${id}`);
-      const result = await this.mailgunService.sendEmail(notification.data as MailgunMessageData);
+      const formattedNotificationData = this.mailgunService.formatNotificationData(
+        notification.data,
+      );
+      const result = await this.mailgunService.sendEmail(
+        formattedNotificationData as MailgunMessageData,
+      );
       notification.deliveryStatus = DeliveryStatus.SUCCESS;
       notification.result = { result };
     } catch (error) {

--- a/src/modules/notifications/dtos/create-notification-attachment.dto.ts
+++ b/src/modules/notifications/dtos/create-notification-attachment.dto.ts
@@ -1,0 +1,10 @@
+import { IsNotEmpty } from 'class-validator';
+import { Stream } from 'stream';
+
+export class CreateNotificationAttachmentDto {
+  @IsNotEmpty()
+  filename: string;
+
+  @IsNotEmpty()
+  content: string | Buffer | Stream;
+}

--- a/src/modules/notifications/dtos/create-notification-data.dto.ts
+++ b/src/modules/notifications/dtos/create-notification-data.dto.ts
@@ -1,4 +1,6 @@
-import { IsString, IsNotEmpty, IsOptional } from 'class-validator';
+import { Type } from 'class-transformer';
+import { IsString, IsNotEmpty, IsOptional, ValidateNested } from 'class-validator';
+import { CreateNotificationAttachmentDto } from './create-notification-attachment.dto';
 
 export class CreateNotificationDataDto {
   @IsNotEmpty()
@@ -24,4 +26,9 @@ export class CreateNotificationDataDto {
   @IsNotEmpty()
   @IsString()
   html: string;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => CreateNotificationAttachmentDto)
+  attachments: CreateNotificationAttachmentDto[];
 }

--- a/src/services/email/mailgun/mailgun.service.ts
+++ b/src/services/email/mailgun/mailgun.service.ts
@@ -2,6 +2,8 @@ import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import * as FormData from 'form-data';
 import Mailgun, { MailgunClientOptions, MailgunMessageData, MessagesSendResult } from 'mailgun.js';
+import { CreateNotificationAttachmentDto } from 'src/modules/notifications/dtos/create-notification-attachment.dto';
+import { CreateNotificationDataDto } from 'src/modules/notifications/dtos/create-notification-data.dto';
 
 @Injectable()
 export class MailgunService {
@@ -21,5 +23,26 @@ export class MailgunService {
 
   sendEmail(mailgunNotificationData: MailgunMessageData): Promise<MessagesSendResult> {
     return this.mailgunClient.messages.create(this.mailgunDomain, mailgunNotificationData);
+  }
+
+  formatNotificationData(notificationData: CreateNotificationDataDto): unknown {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const formattedNotificationData: any = notificationData;
+    formattedNotificationData.attachment = this.formatAttachments(notificationData.attachments);
+    delete formattedNotificationData.attachments;
+    return formattedNotificationData;
+  }
+
+  formatAttachments(attachments: CreateNotificationAttachmentDto[]): unknown[] {
+    const formattedAttachments = [];
+
+    for (const attachment of attachments) {
+      formattedAttachments.push({
+        filename: attachment.filename,
+        data: attachment.content,
+      });
+    }
+
+    return formattedAttachments;
   }
 }


### PR DESCRIPTION
This PR adds validations for attachments that are to be sent via SMTP or Mailgun. The format for adding attachments is standardised and internal conversion/formatting is handled in Mailgun for making it work.

Related changes:
- Add a notification attachment dto
- Update notification data dto to add attachments validation
- Update mailgun service to add new methods for formatting notification data and attachments as per required format
- Update mailgun consumer to use the above methods for correctly formatting data

Sample request (with attachment):
```json
{
  "channelType": 2,
  "data": {
    "from": "sender@email.com",
    "to": "receiver@email.com",
    "subject": "Test Notification",
    "text": "This is a test notification",
    "html": "<b>This is a test notification</b>",
    "attachments": [
      {
        "filename": "sample.txt",
        "content": "John Doe\nJane Doe"
      }
    ]
  }
}
```