### PR TITLE
feat: add check for enabled channels

### DIFF
--- a/src/common/constants/notifications.ts
+++ b/src/common/constants/notifications.ts
@@ -1,3 +1,23 @@
+import { ConfigService } from '@nestjs/config';
+
+export function generateEnabledChannelEnum(configService: ConfigService): Record<string, number> {
+  const enabledChannels: Record<string, number> = {};
+
+  if (configService.get('ENABLE_SMTP') === 'true') {
+    enabledChannels['SMTP'] = ChannelType.SMTP;
+  }
+
+  if (configService.get('ENABLE_MAILGUN') === 'true') {
+    enabledChannels['MAILGUN'] = ChannelType.MAILGUN;
+  }
+
+  if (configService.get('ENABLE_WA_360_DAILOG') === 'true') {
+    enabledChannels['WA_360_DAILOG'] = ChannelType.WA_360_DAILOG;
+  }
+
+  return enabledChannels as Record<string, number>;
+}
+
 export const DeliveryStatus = {
   PENDING: 1,
   IN_PROGRESS: 2,

--- a/src/modules/notifications/notifications.controller.ts
+++ b/src/modules/notifications/notifications.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Body, Logger } from '@nestjs/common';
+import { Controller, Post, Body, Logger, HttpException } from '@nestjs/common';
 import { NotificationsService } from './notifications.service';
 import { CreateNotificationDto } from './dtos/create-notification.dto';
 import { JsendFormatter } from 'src/common/jsend-formatter';
@@ -21,6 +21,10 @@ export class NotificationsController {
       this.logger.log('Notification created successfully.');
       return this.jsend.success({ notification: createdNotification });
     } catch (error) {
+      if (error instanceof HttpException) {
+        throw error;
+      }
+
       this.logger.error('Error while creating notification');
       this.logger.error(JSON.stringify(error, ['message', 'stack'], 2));
       return this.jsend.error(error.message);

--- a/src/modules/notifications/notifications.service.ts
+++ b/src/modules/notifications/notifications.service.ts
@@ -1,9 +1,9 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { BadRequestException, Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { Notification } from './entities/notification.entity';
-import { DeliveryStatus } from 'src/common/constants/notifications';
+import { DeliveryStatus, generateEnabledChannelEnum } from 'src/common/constants/notifications';
 import { NotificationQueueProducer } from 'src/jobs/producers/notifications/notifications.job.producer';
 import { Status } from 'src/common/constants/database';
 import { CreateNotificationDto } from './dtos/create-notification.dto';
@@ -24,6 +24,13 @@ export class NotificationsService {
   async createNotification(notificationData: CreateNotificationDto): Promise<Notification> {
     this.logger.log('Creating notification...');
     const notification = new Notification(notificationData);
+    const enabledChannels = generateEnabledChannelEnum(this.configService);
+    const channelEnabled = Object.values(enabledChannels).includes(notification.channelType);
+
+    if (!channelEnabled) {
+      throw new BadRequestException(`Channel ${notification.channelType} is not enabled`);
+    }
+
     notification.createdBy = this.configService.getOrThrow<string>('APP_NAME') || 'osmo_notify';
     notification.updatedBy = this.configService.getOrThrow<string>('APP_NAME') || 'osmo_notify';
     return this.notificationRepository.save(notification);
@@ -40,7 +47,11 @@ export class NotificationsService {
     }
 
     this.isProcessingQueue = true;
-    const pendingNotifications = await this.getPendingNotifications();
+    const allPendingNotifications = await this.getPendingNotifications();
+    const enabledChannels = generateEnabledChannelEnum(this.configService);
+    const pendingNotifications = allPendingNotifications.filter((notification) =>
+      Object.values(enabledChannels).includes(notification.channelType),
+    );
     this.logger.log(`Adding ${pendingNotifications.length} pending notifications to queue`);
 
     for (const notification of pendingNotifications) {


### PR DESCRIPTION
- filter out disbaled channels when adding to queue.
- throw error when channel is not enabled before creating notification.


Sample Response
```json
{
    "status": "fail",
    "data": "Channel 2 is not enabled"
}
```