### PR TITLE
feat: add api to get notifications by ids

### DIFF
--- a/src/common/jsend-formatter.ts
+++ b/src/common/jsend-formatter.ts
@@ -1,8 +1,7 @@
 import { HttpExceptionBodyMessage } from '@nestjs/common';
-import { Notification } from 'src/modules/notifications/entities/notification.entity';
 
 export class JsendFormatter {
-  public success(data: { notification: Notification }): Record<string, unknown> {
+  public success(data: unknown): Record<string, unknown> {
     return {
       status: 'success',
       data: data,

--- a/src/modules/notifications/notifications.controller.ts
+++ b/src/modules/notifications/notifications.controller.ts
@@ -1,4 +1,13 @@
-import { Controller, Post, Body, Logger, HttpException, UseGuards } from '@nestjs/common';
+import {
+  Controller,
+  Post,
+  Body,
+  Logger,
+  HttpException,
+  UseGuards,
+  Get,
+  Param,
+} from '@nestjs/common';
 import { NotificationsService } from './notifications.service';
 import { CreateNotificationDto } from './dtos/create-notification.dto';
 import { JsendFormatter } from 'src/common/jsend-formatter';
@@ -28,6 +37,20 @@ export class NotificationsController {
       }
 
       this.logger.error('Error while creating notification');
+      this.logger.error(JSON.stringify(error, ['message', 'stack'], 2));
+      return this.jsend.error(error.message);
+    }
+  }
+
+  @Get(':ids')
+  @UseGuards(ApiKeyGuard)
+  async getNotificationsByIds(@Param('ids') ids: string): Promise<Record<string, unknown>> {
+    try {
+      const idArray = ids.split(',').map((id) => +id);
+      const notifications = await this.notificationService.getNotificationsByIds(idArray);
+      return this.jsend.success(notifications);
+    } catch (error) {
+      this.logger.error(`Error while retrieving notification with IDs ${ids}`);
       this.logger.error(JSON.stringify(error, ['message', 'stack'], 2));
       return this.jsend.error(error.message);
     }

--- a/src/modules/notifications/notifications.service.ts
+++ b/src/modules/notifications/notifications.service.ts
@@ -1,6 +1,6 @@
 import { BadRequestException, Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
 import { Notification } from './entities/notification.entity';
 import { DeliveryStatus, generateEnabledChannelEnum } from 'src/common/constants/notifications';
 import { NotificationQueueProducer } from 'src/jobs/producers/notifications/notifications.job.producer';
@@ -93,6 +93,16 @@ export class NotificationsService {
     return this.notificationRepository.find({
       where: {
         id: id,
+        status: Status.ACTIVE,
+      },
+    });
+  }
+
+  getNotificationsByIds(ids: number[]): Promise<Notification[]> {
+    this.logger.log(`Getting notifications with ids: ${ids.join(', ')}`);
+    return this.notificationRepository.find({
+      where: {
+        id: In(ids),
         status: Status.ACTIVE,
       },
     });

--- a/src/modules/notifications/notifications.service.ts
+++ b/src/modules/notifications/notifications.service.ts
@@ -1,6 +1,6 @@
 import { BadRequestException, Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { In, Repository } from 'typeorm';
+import { Repository } from 'typeorm';
 import { Notification } from './entities/notification.entity';
 import { DeliveryStatus, generateEnabledChannelEnum } from 'src/common/constants/notifications';
 import { NotificationQueueProducer } from 'src/jobs/producers/notifications/notifications.job.producer';
@@ -93,16 +93,6 @@ export class NotificationsService {
     return this.notificationRepository.find({
       where: {
         id: id,
-        status: Status.ACTIVE,
-      },
-    });
-  }
-
-  getNotificationsByIds(ids: number[]): Promise<Notification[]> {
-    this.logger.log(`Getting notifications with ids: ${ids.join(', ')}`);
-    return this.notificationRepository.find({
-      where: {
-        id: In(ids),
         status: Status.ACTIVE,
       },
     });


### PR DESCRIPTION
## Description

### Added API Endpoint to Retrieve Notification by ID

This pull request introduces a new API endpoint allowing the retrieval of a notification using a single ID. The endpoint provides detailed information about the specified notification, or returns an error message if the notification is not found.

### Example: Successful Request

#### Request:
```bash
curl --location 'localhost:3000/notifications/58' \
--header 'Authorization: Bearer osmo-notify-test-key'
```

#### Response:
```json
{
    "status": "success",
    "data": {
        "notification": {
            "id": 58,
            "channelType": 1,
            "data": {
                "from": "vikaskyatannawar@gmail.com",
                "to": "vikas.k@osmosys.co",
                "subject": "Test subject",
                "text": "This is a test notification",
                "html": "<b>This is a test notification</b>"
            },
            "deliveryStatus": 4,
            "result": {
                "result": {
                    "code": "EMESSAGE",
                    "response": "554 5.2.0 STOREDRV.Submission.Exception:OutboundSpamException; Failed to process message due to a permanent exception with message [BeginDiagnosticData]WASCL UserAction verdict is not None. Actual verdict is RefuseQuota, ShowTierUpgrade. OutboundSpamException: WASCL UserAction verdict is not None. Actual verdict is RefuseQuota, ShowTierUpgrade.[EndDiagnosticData] [Hostname=CH2PR17MB3527.namprd17.prod.outlook.com]",
                    "responseCode": 554,
                    "command": "DATA"
                }
            },
            "createdOn": "2023-11-03T12:50:59.000Z",
            "updatedOn": "2023-11-03T12:50:59.000Z",
            "createdBy": "admin",
            "updatedBy": "admin",
            "status": 1
        }
    }
}
```

### Example: Not Found Response

#### Request:
```bash
curl --location 'localhost:3000/notifications/1' \
--header 'Authorization: Bearer osmo-notify-test-key'
```

#### Response:
```json
{
    "status": "error",
    "message": "Notification with id 1 not found"
}
```

---

This pull request enhances the API functionality by providing a dedicated endpoint to retrieve a notification using a single ID, delivering detailed information for existing notifications, and an appropriate error response for non-existent ones.