### PR TITLE
feat: add login page with auth guard

### DIFF
--- a/apps/portal/package-lock.json
+++ b/apps/portal/package-lock.json
@@ -19,6 +19,7 @@
         "@apollo/client": "^3.8.8",
         "apollo-angular": "^5.0.2",
         "graphql": "^16.8.1",
+        "primeflex": "^3.3.1",
         "primeng": "^16.9.1",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
@@ -3550,12 +3551,6 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/@gar/promisify": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
-      "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
-      "dev": true
-    },
     "node_modules/@graphql-typed-document-node/core": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
@@ -5802,30 +5797,6 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/apollo-angular/-/apollo-angular-5.0.2.tgz",
       "integrity": "sha512-U+ApPHhmdDirO95kovNJKt0Zd8kthOWALWY1t22zCI4LrT7tLZDDs0LJAzFXcvILN3FDkXWOE9R6Sa29jNOCIQ==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "@angular/core": "^14.0.0 || ^15.0.0 || ^16.0.0",
-        "@apollo/client": "^3.0.0",
-        "graphql": "^15.0.0 || ^16.0.0",
-        "rxjs": "^6.0.0 || ^7.0.0"
-      }
-    },
-    "node_modules/aproba": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
-      "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
-      "dev": true
-    },
-    "node_modules/are-we-there-yet": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
-      "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -13684,6 +13655,11 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/primeflex": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/primeflex/-/primeflex-3.3.1.tgz",
+      "integrity": "sha512-zaOq3YvcOYytbAmKv3zYc+0VNS9Wg5d37dfxZnveKBFPr7vEIwfV5ydrpiouTft8MVW6qNjfkaQphHSnvgQbpQ=="
+    },
     "node_modules/primeng": {
       "version": "16.9.1",
       "resolved": "https://registry.npmjs.org/primeng/-/primeng-16.9.1.tgz",
@@ -19166,12 +19142,6 @@
       "integrity": "sha512-ut5V+D+fOoWPgGGNj83GGjnntO39xDy6DWxO0wb7Jp3DcMX0TfIqdzHF85VTQkerdyGmuuMD9AKAo5KiNlf/AQ==",
       "dev": true
     },
-    "@gar/promisify": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
-      "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
-      "dev": true
-    },
     "@graphql-typed-document-node/core": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
@@ -20806,21 +20776,6 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/apollo-angular/-/apollo-angular-5.0.2.tgz",
       "integrity": "sha512-U+ApPHhmdDirO95kovNJKt0Zd8kthOWALWY1t22zCI4LrT7tLZDDs0LJAzFXcvILN3FDkXWOE9R6Sa29jNOCIQ==",
-      "requires": {
-        "tslib": "^2.6.2"
-      }
-    },
-    "aproba": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
-      "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
-      "dev": true
-    },
-    "are-we-there-yet": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
-      "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
-      "dev": true,
       "requires": {
         "tslib": "^2.6.2"
       }
@@ -26613,6 +26568,11 @@
           "dev": true
         }
       }
+    },
+    "primeflex": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/primeflex/-/primeflex-3.3.1.tgz",
+      "integrity": "sha512-zaOq3YvcOYytbAmKv3zYc+0VNS9Wg5d37dfxZnveKBFPr7vEIwfV5ydrpiouTft8MVW6qNjfkaQphHSnvgQbpQ=="
     },
     "primeng": {
       "version": "16.9.1",

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -26,6 +26,7 @@
     "@apollo/client": "^3.8.8",
     "apollo-angular": "^5.0.2",
     "graphql": "^16.8.1",
+    "primeflex": "^3.3.1",
     "primeng": "^16.9.1",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",

--- a/apps/portal/src/app/app-routing.module.ts
+++ b/apps/portal/src/app/app-routing.module.ts
@@ -2,8 +2,14 @@ import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { NotificationsComponent } from './views/notifications/notifications.component';
 import { GraphQLModule } from './graphql/graphql.module';
+import { LoginComponent } from './auth/login/login.component';
+import { AuthGuard } from './auth/auth.guard';
 
-const routes: Routes = [{ path: 'notifications', component: NotificationsComponent }];
+const routes: Routes = [
+  { path: 'notifications', component: NotificationsComponent, canActivate: [AuthGuard] },
+  { path: 'login', component: LoginComponent, canActivate: [AuthGuard] },
+  { path: '**', redirectTo: '/login', pathMatch: 'full' },
+];
 
 @NgModule({
   imports: [RouterModule.forRoot(routes), GraphQLModule],

--- a/apps/portal/src/app/app.component.html
+++ b/apps/portal/src/app/app.component.html
@@ -1,4 +1,4 @@
 <div class="container">
-  <h1>Osmo Notify Portal</h1>
+  <h1 class="text-center">Osmo Notify Portal</h1>
   <router-outlet></router-outlet>
 </div>

--- a/apps/portal/src/app/app.module.ts
+++ b/apps/portal/src/app/app.module.ts
@@ -3,17 +3,19 @@ import { BrowserModule } from '@angular/platform-browser';
 import { HttpClientModule } from '@angular/common/http';
 
 import { FormsModule } from '@angular/forms';
+import { MessageService } from 'primeng/api';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { NotificationsComponent } from './views/notifications/notifications.component';
 import { NotificationsService } from './views/notifications/notifications.service';
 import { JsonDialogComponent } from './views/notifications/json-dialog/json-dialog.component';
 import { PrimeNgModule } from './primeng.module';
+import { LoginComponent } from './auth/login/login.component';
 
 @NgModule({
-  declarations: [AppComponent, NotificationsComponent, JsonDialogComponent],
+  declarations: [AppComponent, NotificationsComponent, JsonDialogComponent, LoginComponent],
   imports: [BrowserModule, AppRoutingModule, FormsModule, PrimeNgModule, HttpClientModule],
-  providers: [NotificationsService],
+  providers: [NotificationsService, MessageService],
   bootstrap: [AppComponent],
 })
 export class AppModule {}

--- a/apps/portal/src/app/auth/auth.guard.spec.ts
+++ b/apps/portal/src/app/auth/auth.guard.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { AuthGuard } from './auth.guard';
+
+describe('AuthGuard', () => {
+  let guard: AuthGuard;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    guard = TestBed.inject(AuthGuard);
+  });
+
+  it('should be created', () => {
+    expect(guard).toBeTruthy();
+  });
+});

--- a/apps/portal/src/app/auth/auth.guard.ts
+++ b/apps/portal/src/app/auth/auth.guard.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@angular/core';
+import {
+  ActivatedRouteSnapshot,
+  CanActivate,
+  Router,
+  RouterStateSnapshot,
+  UrlTree,
+} from '@angular/router';
+import { Observable } from 'rxjs';
+import { AuthService } from './auth.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class AuthGuard implements CanActivate {
+  constructor(
+    private router: Router,
+    private authService: AuthService,
+  ) {}
+
+  canActivate(
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot,
+  ): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
+    const isLoggedIn = this.authService.isLoggedIn();
+
+    if (!isLoggedIn) {
+      if (state.url !== '/login') {
+        this.router.navigate(['login']);
+      }
+    } else if (state.url === '/login') {
+      this.router.navigate(['notifications']);
+    }
+
+    return true;
+  }
+}

--- a/apps/portal/src/app/auth/auth.interface.ts
+++ b/apps/portal/src/app/auth/auth.interface.ts
@@ -1,0 +1,13 @@
+export interface LoginRequestBody {
+  username: string;
+  password: string;
+}
+
+export interface ErrorResponse {
+  extensions?: {
+    originalError?: {
+      message?: string;
+    };
+  };
+  message?: string;
+}

--- a/apps/portal/src/app/auth/auth.service.spec.ts
+++ b/apps/portal/src/app/auth/auth.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { AuthService } from './auth.service';
+
+describe('AuthService', () => {
+  let service: AuthService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(AuthService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/apps/portal/src/app/auth/auth.service.ts
+++ b/apps/portal/src/app/auth/auth.service.ts
@@ -1,0 +1,41 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { MutationResult } from 'apollo-angular';
+import { GraphqlService } from '../graphql/graphql.service';
+import { LoginUser } from '../graphql/graphql.queries';
+import { LoginRequestBody } from './auth.interface';
+
+const SESSION_EXPIRATION_DAYS = 30;
+
+@Injectable({
+  providedIn: 'root',
+})
+export class AuthService {
+  userData = null;
+
+  constructor(private graphqlService: GraphqlService) {}
+
+  isLoggedIn(): boolean {
+    this.userData = JSON.parse(localStorage.getItem('osmoNotifyUserData'));
+
+    if (!this.userData) {
+      return false;
+    }
+
+    const loggedAt = localStorage.getItem('osmoNotifyLoggedAt');
+
+    if (loggedAt) {
+      const expirationDate = new Date(loggedAt);
+      expirationDate.setDate(expirationDate.getDate() + SESSION_EXPIRATION_DAYS);
+      const currentTime = new Date();
+      return currentTime.getTime() < expirationDate.getTime();
+    }
+
+    return true;
+  }
+
+  loginUser(data: LoginRequestBody): Observable<MutationResult> {
+    const variables = { username: data.username, password: data.password };
+    return this.graphqlService.mutate(LoginUser, variables);
+  }
+}

--- a/apps/portal/src/app/auth/login/login.component.html
+++ b/apps/portal/src/app/auth/login/login.component.html
@@ -1,6 +1,6 @@
 <div class="flex align-items-center justify-content-center overflow-hidden">
   <div class="flex flex-column align-items-center justify-content-center">
-    <div style="border-radius: 56px">
+    <div style="border-radius: 56px" class="bg-primary my-5 p-1">
       <div class="w-full surface-card py-8 px-5 sm:px-8" style="border-radius: 53px">
         <div class="text-center mb-5">
           <div class="text-900 text-3xl font-medium mb-3">Welcome!</div>

--- a/apps/portal/src/app/auth/login/login.component.html
+++ b/apps/portal/src/app/auth/login/login.component.html
@@ -1,0 +1,52 @@
+<div class="flex align-items-center justify-content-center overflow-hidden">
+  <div class="flex flex-column align-items-center justify-content-center">
+    <div style="border-radius: 56px">
+      <div class="w-full surface-card py-8 px-5 sm:px-8" style="border-radius: 53px">
+        <div class="text-center mb-5">
+          <div class="text-900 text-3xl font-medium mb-3">Welcome!</div>
+          <span class="text-600 font-medium">Sign in to continue</span>
+        </div>
+        <p-toast key="tst"></p-toast>
+        <form id="login-form" class="form" [formGroup]="loginForm" (ngSubmit)="loginWithUsername()">
+          <label for="username" class="block text-900 text-xl font-medium mb-2">Username</label>
+          <input
+            id="username"
+            formControlName="selectedUsername"
+            type="text"
+            pInputText
+            class="w-full md:w-30rem"
+            style="padding: 1rem"
+          />
+          <div class="mt-1" *ngIf="selectedUsername?.invalid && selectedUsername?.touched">
+            <small id="username-help" class="p-error">Username cannot be empty</small>
+          </div>
+
+          <label for="password" class="block text-900 font-medium text-xl mt-5 mb-2"
+            >Password</label
+          >
+          <p-password
+            id="password"
+            formControlName="selectedPassword"
+            [toggleMask]="true"
+            inputStyleClass="w-full p-3 md:w-30rem"
+            [feedback]="false"
+          ></p-password>
+          <div class="mt-1" *ngIf="selectedPassword?.invalid && selectedPassword?.touched">
+            <small id="password-help" class="p-error">Password cannot be empty</small>
+          </div>
+
+          <div class="flex align-items-center justify-content-between mt-5 mb-5 gap-5"></div>
+          <button
+            pButton
+            pRipple
+            [disabled]="loginForm.invalid"
+            label="Sign In"
+            class="w-full p-3 text-xl"
+            [routerLink]="['/notifications']"
+            [loading]="loading"
+          ></button>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>

--- a/apps/portal/src/app/auth/login/login.component.spec.ts
+++ b/apps/portal/src/app/auth/login/login.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LoginComponent } from './login.component';
+
+describe('LoginComponent', () => {
+  let component: LoginComponent;
+  let fixture: ComponentFixture<LoginComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [LoginComponent],
+    });
+    fixture = TestBed.createComponent(LoginComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/apps/portal/src/app/auth/login/login.component.ts
+++ b/apps/portal/src/app/auth/login/login.component.ts
@@ -77,6 +77,7 @@ export class LoginComponent implements OnInit {
             this.router.navigate(['notifications']);
           }
         }
+
         this.loading = false;
       },
       error: (error) => {

--- a/apps/portal/src/app/auth/login/login.component.ts
+++ b/apps/portal/src/app/auth/login/login.component.ts
@@ -1,0 +1,93 @@
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { Router } from '@angular/router';
+import { MessageService } from 'primeng/api';
+import { ErrorResponse, LoginRequestBody } from '../auth.interface';
+import { AuthService } from '../auth.service';
+
+@Component({
+  selector: 'app-login',
+  templateUrl: './login.component.html',
+  styleUrls: ['./login.component.scss'],
+})
+export class LoginComponent implements OnInit {
+  loginForm: FormGroup;
+
+  loading = false;
+
+  private fb: FormBuilder = new FormBuilder();
+
+  constructor(
+    private router: Router,
+    private authService: AuthService,
+    private messageService: MessageService,
+  ) {}
+
+  ngOnInit(): void {
+    this.loginForm = this.fb.group({
+      selectedUsername: ['', [Validators.required]],
+      selectedPassword: ['', [Validators.required]],
+    });
+  }
+
+  get selectedUsername() {
+    return this.loginForm.get('selectedUsername');
+  }
+
+  get selectedPassword() {
+    return this.loginForm.get('selectedPassword');
+  }
+
+  loginWithUsername() {
+    this.loading = true;
+    const body: LoginRequestBody = {
+      username: this.selectedUsername.value,
+      password: this.selectedPassword.value,
+    };
+    this.authService.loginUser(body).subscribe({
+      next: (resp) => {
+        if (resp.errors) {
+          let errorMessage: string;
+
+          if (resp.errors && resp.errors.length > 0) {
+            const error = resp.errors[0] as ErrorResponse;
+            errorMessage =
+              error.extensions?.originalError?.message ||
+              error.message ||
+              'An error occurred while logging in';
+          } else {
+            errorMessage = 'An error occurred while logging in';
+          }
+
+          if (Array.isArray(errorMessage)) {
+            [errorMessage] = errorMessage;
+          }
+
+          this.messageService.add({
+            key: 'tst',
+            severity: 'error',
+            summary: 'Error',
+            detail: errorMessage,
+          });
+        } else {
+          localStorage.setItem('osmoNotifyUserData', JSON.stringify(resp.data.login));
+          localStorage.setItem('osmoNotifyLoggedAt', new Date().toISOString());
+
+          if (this.router.url !== '/notifications') {
+            this.router.navigate(['notifications']);
+          }
+        }
+        this.loading = false;
+      },
+      error: (error) => {
+        this.messageService.add({
+          key: 'tst',
+          severity: 'error',
+          summary: 'Error',
+          detail: error,
+        });
+        this.loading = false;
+      },
+    });
+  }
+}

--- a/apps/portal/src/app/graphql/graphql.queries.ts
+++ b/apps/portal/src/app/graphql/graphql.queries.ts
@@ -16,3 +16,12 @@ export const GetNotifcations = gql`
     }
   }
 `;
+
+export const LoginUser = gql`
+  mutation LoginUser($username: String!, $password: String!) {
+    login(loginUserInput: { username: $username, password: $password }) {
+      token
+      user
+    }
+  }
+`;

--- a/apps/portal/src/app/graphql/graphql.service.ts
+++ b/apps/portal/src/app/graphql/graphql.service.ts
@@ -14,7 +14,7 @@ export class GraphqlService {
   constructor(private apollo: Apollo) {}
 
   query<T>(query: DocumentNode, variables?: unknown): Observable<ApolloQueryResult<T>> {
-    const token = serverApiKey;
+    const token = JSON.parse(localStorage.getItem('osmoNotifyUserData'))?.token;
     let headers;
 
     if (token) {

--- a/apps/portal/src/app/primeng.module.ts
+++ b/apps/portal/src/app/primeng.module.ts
@@ -3,8 +3,23 @@ import { ButtonModule } from 'primeng/button';
 import { TableModule } from 'primeng/table';
 import { DropdownModule } from 'primeng/dropdown';
 import { DialogModule } from 'primeng/dialog';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { ToastModule } from 'primeng/toast';
+import { ReactiveFormsModule } from '@angular/forms';
+import { PasswordModule } from 'primeng/password';
+import { InputTextModule } from 'primeng/inputtext';
 
-const modules = [ButtonModule, TableModule, DropdownModule, DialogModule];
+const modules = [
+  ButtonModule,
+  TableModule,
+  DropdownModule,
+  DialogModule,
+  ToastModule,
+  ReactiveFormsModule,
+  PasswordModule,
+  InputTextModule,
+  BrowserAnimationsModule,
+];
 
 @NgModule({
   imports: [...modules],

--- a/apps/portal/src/styles.scss
+++ b/apps/portal/src/styles.scss
@@ -1,2 +1,4 @@
-@import "primeng/resources/primeng.css";
-@import "primeng/resources/themes/lara-light-blue/theme.css";
+@import 'primeng/resources/primeng.css';
+@import 'primeng/resources/themes/lara-light-blue/theme.css';
+
+@import '../node_modules/primeflex/primeflex.scss';


### PR DESCRIPTION
**Description:**
This PR adds a login page for allowing admin users to login in and access the notifications page. Required guards have also been added and the token fetched on logging in is used for fetching the notifications further on.

**Related changes:**
- Create a new login component, add the required logic in login.component ts file for methods and making required method calls for logging in, creating error toasts
- Add the required html code and styles for creating a login form with basic validations on username and password, showing any login errors that occur
- Create a new auth.guard ts file for checking is user is logged in before accessing notifications page, redirect accordingly
- Add an auth.interface file for specifying the LoginRequestBody and ErrorResponse
- Create an auth.service file for checking if isUserLogged in and call graphql methods for loginUser
- Update graphql.queries to add new LoginUser query
- Update graphql.service to use the token obtained after logging in for graphql query
- Update app-routing module to add the login path, navigate and activate auth guard accordingly
- Update app.module and primeng.module to import and add required modules and services
- Add the primeflex package in package.json and update styles.scss to import the primeflex sheet for properly showing login page

**Screenshots:**
![image](https://github.com/OsmosysSoftware/osmo-notify/assets/108812833/f2b98dec-79be-4ddb-ac3a-e9c62e8e5c75)
![image](https://github.com/OsmosysSoftware/osmo-notify/assets/108812833/6f777219-78ce-436b-930c-bd6980b84fa5)

**Notes:**
- Will require https://github.com/OsmosysSoftware/osmo-notify/pull/112 to be merged first