### PR TITLE
feat: add display mappings for delivery status and channel type

### DIFF
--- a/apps/portal/src/app/views/notifications/notifications.component.html
+++ b/apps/portal/src/app/views/notifications/notifications.component.html
@@ -43,12 +43,12 @@
         <ng-template pTemplate="body" let-notification>
           <tr>
             <td>{{ notification.id }}</td>
-            <td>{{ notification.channelType }}</td>
+            <td>{{ channelTypeMap[notification.channelType] }}</td>
             <td>{{ notification.createdBy }}</td>
             <td>{{ notification.createdOn | date: 'yyyy-MM-dd HH:mm:ss' }}</td>
             <td>{{ notification.updatedBy }}</td>
             <td>{{ notification.updatedOn | date: 'yyyy-MM-dd HH:mm:ss' }}</td>
-            <td>{{ notification.deliveryStatus }}</td>
+            <td>{{ deliveryStatusMap[notification.deliveryStatus] }}</td>
             <td>
               <button class="view-button" (click)="showJsonObject(notification.data)">
                 View Data

--- a/apps/portal/src/app/views/notifications/notifications.component.html
+++ b/apps/portal/src/app/views/notifications/notifications.component.html
@@ -48,7 +48,13 @@
             <td>{{ notification.createdOn | date: 'yyyy-MM-dd HH:mm:ss' }}</td>
             <td>{{ notification.updatedBy }}</td>
             <td>{{ notification.updatedOn | date: 'yyyy-MM-dd HH:mm:ss' }}</td>
-            <td>{{ deliveryStatusMap[notification.deliveryStatus] }}</td>
+            <td>
+              <span
+                [class]="'badge status-' + deliveryStatusMap[notification.deliveryStatus].style"
+              >
+                {{ deliveryStatusMap[notification.deliveryStatus].value }}
+              </span>
+            </td>
             <td>
               <button class="view-button" (click)="showJsonObject(notification.data)">
                 View Data

--- a/apps/portal/src/app/views/notifications/notifications.component.scss
+++ b/apps/portal/src/app/views/notifications/notifications.component.scss
@@ -83,3 +83,32 @@ tr:hover {
 .no-result {
   color: #757575; /* Gray text for no result */
 }
+
+.badge {
+  border-radius: 4px;
+  padding: 0.25em 0.5rem;
+  text-transform: uppercase;
+  font-weight: 700;
+  font-size: 0.75em;
+  letter-spacing: 0.3px;
+}
+
+.badge.status-success {
+  background: #c8e6c9;
+  color: #256029;
+}
+
+.badge.status-failed {
+  background: #ffcdd2;
+  color: #c63737;
+}
+
+.badge.status-pending {
+  background: #dadada;
+  color: #424242;
+}
+
+.badge.status-in-progress {
+  background: #abcdef;
+  color: #1558be;
+}

--- a/apps/portal/src/app/views/notifications/notifications.component.ts
+++ b/apps/portal/src/app/views/notifications/notifications.component.ts
@@ -39,10 +39,10 @@ export class NotificationsComponent implements OnInit {
   jsonDialogVisible: Boolean = false;
 
   deliveryStatusMap = {
-    [DeliveryStatus.PENDING]: 'Pending',
-    [DeliveryStatus.IN_PROGRESS]: 'In Progress',
-    [DeliveryStatus.SUCCESS]: 'Success',
-    [DeliveryStatus.FAILED]: 'Failed',
+    [DeliveryStatus.PENDING]: { value: 'Pending', style: 'pending' },
+    [DeliveryStatus.IN_PROGRESS]: { value: 'In Progress', style: 'in-progress' },
+    [DeliveryStatus.SUCCESS]: { value: 'Success', style: 'success' },
+    [DeliveryStatus.FAILED]: { value: 'Failed', style: 'failed' },
   };
 
   channelTypeMap = {

--- a/apps/portal/src/app/views/notifications/notifications.component.ts
+++ b/apps/portal/src/app/views/notifications/notifications.component.ts
@@ -38,6 +38,19 @@ export class NotificationsComponent implements OnInit {
 
   jsonDialogVisible: Boolean = false;
 
+  deliveryStatusMap = {
+    [DeliveryStatus.PENDING]: 'Pending',
+    [DeliveryStatus.IN_PROGRESS]: 'In Progress',
+    [DeliveryStatus.SUCCESS]: 'Success',
+    [DeliveryStatus.FAILED]: 'Failed',
+  };
+
+  channelTypeMap = {
+    [ChannelType.SMTP]: 'SMTP',
+    [ChannelType.MAILGUN]: 'Mailgun',
+    [ChannelType.WA_360_DAILOG]: 'WhatsApp 360 Dialog',
+  };
+
   constructor(private notificationService: NotificationsService) {}
 
   ngOnInit(): void {


### PR DESCRIPTION
**Description:**
This PR adds display string mappings for showing easily readable strings for Channel Type and Delivery Status in the portal instead of numeric values.

**Related changes:**
- Add deliveryStatusMap and channelTypeMap for mapping display strings for corresponding values
- Update notifications.component html to use these maps when displaying delivery status and channel type values, along with proper styles

**Screenshots:**
![image](https://github.com/OsmosysSoftware/osmo-notify/assets/108812833/d7434f68-b579-4e11-ab5d-c95a1cd48588)
