### PR TITLE
chore: add 127.0.0.1 to api docker-compose ports

### DIFF
--- a/apps/api/docker-compose.yml
+++ b/apps/api/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - '${SERVER_PORT}:${SERVER_PORT}'
+      - '127.0.0.1:${SERVER_PORT}:${SERVER_PORT}'
     depends_on:
       - mariadb
       - redis
@@ -23,7 +23,7 @@ services:
       MYSQL_PASSWORD: ${DB_PASSWORD}
       MYSQL_DATABASE: ${DB_NAME}
     ports:
-      - '${MARIADB_DOCKER_PORT}:3306'
+      - '127.0.0.1:${MARIADB_DOCKER_PORT}:3306'
     volumes:
       - osmo-notify-db:/var/lib/mysql
 
@@ -32,7 +32,7 @@ services:
     image: redis:latest
     restart: always
     ports:
-      - '${REDIS_DOCKER_PORT}:6379'
+      - '127.0.0.1:${REDIS_DOCKER_PORT}:6379'
 
 volumes:
   osmo-notify-db: ~

--- a/apps/portal/docker-compose.yml
+++ b/apps/portal/docker-compose.yml
@@ -7,4 +7,4 @@ services:
       dockerfile: Dockerfile
     image: osmo-notify-portal
     ports:
-      - "${SERVER_PORT}:80"
+      - '127.0.0.1:${SERVER_PORT}:80'


### PR DESCRIPTION
**Description:**
This PR updates the `docker-compose.yml` file for `apps/api` to add `127.0.0.1` before port bindings for server, mariadb docker and redis docker ports.