### PR TITLE
fix: graphql query for getting notifications

### DIFF
--- a/apps/portal/src/app/graphql/graphql.queries.ts
+++ b/apps/portal/src/app/graphql/graphql.queries.ts
@@ -3,16 +3,18 @@ import { gql } from 'apollo-angular';
 export const GetNotifcations = gql`
   query {
     notifications {
-      channelType
-      createdBy
-      createdOn
-      data
-      deliveryStatus
-      id
-      result
-      status
-      updatedBy
-      updatedOn
+      notifications {
+        channelType
+        createdBy
+        createdOn
+        data
+        deliveryStatus
+        id
+        result
+        status
+        updatedBy
+        updatedOn
+      }
     }
   }
 `;

--- a/apps/portal/src/app/views/notifications/notifications.service.ts
+++ b/apps/portal/src/app/views/notifications/notifications.service.ts
@@ -5,8 +5,10 @@ import { GetNotifcations } from 'src/app/graphql/graphql.queries';
 import { ApolloQueryResult } from '@apollo/client/core';
 import { Notification } from './notification.model';
 
-interface GetNoticationsResponse {
-  notifications?: Notification[];
+interface GetNotificationsResponse {
+  notifications: {
+    notifications?: Notification[];
+  };
 }
 @Injectable({
   providedIn: 'root',
@@ -16,13 +18,13 @@ export class NotificationsService {
 
   getNotifications(): Observable<Notification[]> {
     return this.graphqlService.query(GetNotifcations).pipe(
-      map((response: ApolloQueryResult<GetNoticationsResponse>) => {
+      map((response: ApolloQueryResult<GetNotificationsResponse>) => {
         if (response.error) {
           const errorMessage: string = response.error.message;
           throw new Error(errorMessage);
         } else {
-          const notifcations = response.data?.notifications;
-          return JSON.parse(JSON.stringify(notifcations));
+          const notifications = response.data?.notifications.notifications;
+          return JSON.parse(JSON.stringify(notifications));
         }
       }),
     );


### PR DESCRIPTION
**Description:**
This PR fixes https://github.com/OsmosysSoftware/osmo-notify/issues/133, the issue with no notifications showing in the portal due to error with graphql query.

**Related changes:**
- Update the GetNotifications query to have correct structure
- Update the notifications.service file to update the GetNotificationsResponse interface with proper response structure, get values from response.data accordingly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the structure of the notifications data retrieval to enhance app performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->