### PR TITLE
fix: allow user to clear dropdown selection

### DIFF
--- a/apps/portal/src/app/views/notifications/notifications.component.html
+++ b/apps/portal/src/app/views/notifications/notifications.component.html
@@ -8,12 +8,14 @@
         [(ngModel)]="selectedChannelType"
         placeholder="Select a channel Type"
         class="grid-dropdown"
+        [showClear]="true"
       ></p-dropdown>
       <p-dropdown
         [options]="deliveryStatuses"
         [(ngModel)]="selectedDeliveryStatus"
         placeholder="Select a Delivery Status Type"
         class="grid-dropdown"
+        [showClear]="true"
       ></p-dropdown>
     </div>
   </div>

--- a/apps/portal/src/app/views/notifications/notifications.component.ts
+++ b/apps/portal/src/app/views/notifications/notifications.component.ts
@@ -20,9 +20,9 @@ export class NotificationsComponent implements OnInit {
     value,
   }));
 
-  selectedChannelType = 'All';
+  selectedChannelType = null;
 
-  selectedDeliveryStatus = 'All';
+  selectedDeliveryStatus = null;
 
   pageSizeOptions: number[] = [5, 10, 25, 50];
 


### PR DESCRIPTION
**Description:**
This PR adds an option to allow the user to clear selection from the channel type and delivery status dropdown.

**Related changes:**
- Add the [showClear] property to p-dropdown
- Change default value of selectedChannelType and selectedDeliveryStatus from 'Any' to null to prevent clear icon from showing when nothing is selected initially

**Screenshots:**

https://github.com/OsmosysSoftware/osmo-notify/assets/108812833/c1fcb0e8-35d7-4675-93a7-f9e97caabc6e


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a clear icon in notification dropdowns to easily reset selections.

- **Improvements**
	- Modified default dropdown values to enhance selection clarity for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->