### PR TITLE
fix: view data and result modals cannot be re-opened

### DIFF
--- a/apps/portal/src/app/views/notifications/json-dialog/json-dialog.component.html
+++ b/apps/portal/src/app/views/notifications/json-dialog/json-dialog.component.html
@@ -1,4 +1,10 @@
-<p-dialog header="JSON Data" [(visible)]="visible" [draggable]="false" [style]="{ width: '50vw' }">
+<p-dialog
+  header="JSON Data"
+  [(visible)]="visible"
+  [draggable]="false"
+  [style]="{ width: '50vw' }"
+  (onHide)="hideDialog()"
+>
   <pre>{{ jsonData | json }}</pre>
   <button pButton label="Close" (click)="hideDialog()" class="p-button-text"></button>
 </p-dialog>


### PR DESCRIPTION
**Description**
This PR fixes an issue with not being able to open View Data and View Result modals after clicking on X to close them. 

**Related changes:**
- Add (onHide) to call hideDialog() when closing the dialog on pressing X to allow correct behaviour

**Screenshots:**

https://github.com/OsmosysSoftware/osmo-notify/assets/108812833/0455209a-7649-47a6-940e-6bdbfea049cf



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Implemented an automatic trigger to handle dialog closure events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->