### PR TITLE
fix: behaviour of paginator pages

### DIFF
--- a/apps/portal/src/app/views/notifications/notifications.component.html
+++ b/apps/portal/src/app/views/notifications/notifications.component.html
@@ -23,11 +23,14 @@
   <div class="p-grid table-container">
     <div class="p-col-12">
       <p-table
-        [value]="displayedNotifications"
+        [value]="filteredNotifications"
         [rows]="pageSize"
         [paginator]="true"
         [totalRecords]="totalRecords"
         (onPage)="onPageChange($event)"
+        [showCurrentPageReport]="true"
+        currentPageReportTemplate="Showing {first} to {last} of {totalRecords} entries"
+        [rowsPerPageOptions]="pageSizeOptions"
       >
         <ng-template pTemplate="header">
           <tr>

--- a/apps/portal/src/app/views/notifications/notifications.component.ts
+++ b/apps/portal/src/app/views/notifications/notifications.component.ts
@@ -26,7 +26,7 @@ export class NotificationsComponent implements OnInit {
 
   pageSizeOptions: number[] = [5, 10, 25, 50];
 
-  pageSize = 20;
+  pageSize = 10;
 
   currentPage = 1;
 


### PR DESCRIPTION
**Description:**
This PR fixes the behaviour of clicking on a paginator page, and allow showing all the notifications in proper pages.
Additionally, added information regarding total records and what are currently being viewed along with allowing user to select the visible number of rows.

**Related changes:**
- Update the table to show values from the filteredNotifications array instead of displayedNotifications
- Additionally add current page report for showing current range and total records, also show the rows per page options from pageSizeOptions
- Update the default pageSize value to be 10, a value from pageSizeOptions

**Screenshots:**

https://github.com/OsmosysSoftware/osmo-notify/assets/108812833/30c84f23-02a9-4177-9c85-d77e90345942



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the notifications view with options to customize the number of notifications per page.
	- Added a current page report to the notifications table.

- **Refactor**
	- Improved the notifications filtering logic for better user experience.

- **Style**
	- Adjusted the default number of notifications displayed per page from 20 to 10 for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->