### PR TITLE
fix: add check for empty message object for push sns data dto

### DIFF
--- a/apps/api/src/modules/notifications/dtos/providers/pushSns-data.dto.ts
+++ b/apps/api/src/modules/notifications/dtos/providers/pushSns-data.dto.ts
@@ -14,11 +14,19 @@ import { Type } from 'class-transformer';
 class AllowedPropertiesConstraint implements ValidatorConstraintInterface {
   validate(message: unknown) {
     const allowedKeys = ['GCM', 'APNS_SANDBOX', 'APNS', 'default'];
+    const inputKeys = Object.keys(message);
+
+    // Check if the object is empty
+    if (inputKeys.length === 0) {
+      return false;
+    }
+
+    // Check if ALL present keys are within the allowed list
     return Object.keys(message).every((key) => allowedKeys.includes(key));
   }
 
   defaultMessage() {
-    return 'Invalid properties found in the message payload. Allowed properties are GCM, APNS_SANDBOX, APNS, and default.';
+    return 'Invalid properties found in the message payload. Input object must contain at least one of the allowed properties. Allowed properties are GCM, APNS_SANDBOX, APNS, and default.';
   }
 }
 


### PR DESCRIPTION
## API PR Checklist

### Task Link

Osmosys Developers must include the Pinestem task link in the PR.

[OSXT-301](https://pinestem.com/dashboard.html#/tasks/OSXT-301/details/?companyId=453&isPrevNext=1)

### Pre-requisites

- [x] I have gone through the Contributing guidelines for [Submitting a Pull Request (PR)](https://github.com/OsmosysSoftware/osmo-x/blob/main/CONTRIBUTING.md#-submitting-a-pull-request-pr) and ensured that this is not a duplicate PR.
- [x] I have performed unit testing for the new feature added or updated to ensure the new features added are working as expected.
- [ ] I have added/updated test cases to the [test suite](https://github.com/OsmosysSoftware/osmo-x/blob/main/apps/api/OsmoX.postman_collection.json) as applicable.
- [ ] I have performed preliminary testing using the [test suite](https://github.com/OsmosysSoftware/osmo-x/blob/main/apps/api/OsmoX.postman_collection.json) to ensure that any existing features are not impacted and any new features are working as expected as a whole.
- [ ] I have added/updated the required [api docs](https://github.com/OsmosysSoftware/osmo-x/tree/main/apps/api/docs) as applicable.
- [ ] I have added/updated the `.env.example` file with the required values as applicable.

### PR Details

PR details have been updated as per the given format (see below)

- [x] PR title adheres to the format specified in guidelines (e.g., `feat: add admin login endpoint`)
- [x] Description has been added
- [ ] Related changes have been added (optional)
- [ ] Screenshots have been added (optional)
- [ ] Query request and response examples have been added (as applicable, in case added or updated)
- [ ] Documentation changes have been listed (as applicable)
- [ ] Test suite/unit testing output is added (as applicable)
- [ ] Pending actions have been added (optional)
- [x] Any other additional notes have been added (optional)

### Additional Information

- [x] Appropriate label(s) have been added (`ready for review` should be added if the PR is ready to be reviewed)
- [x] Assignee(s) and reviewer(s) have been added (optional)

_Note: Reviewer should ensure that the checklist and description have been populated and followed correctly, and the PR should be merged only after resolving all conversations and verifying that CI checks pass._

---

**Description:**

- Add check for empty message object for push sns notification
- This will prevent osmox from processing notifications that send empty message objects in request body

**Screenshots:**

400 Bad Request
![image](https://github.com/user-attachments/assets/d3dfbbb0-da6f-4cc0-bc42-d18c1483b541)

201 Created
![image](https://github.com/user-attachments/assets/9d1ce1e3-186f-404d-9602-cbf42b3a0f92)

**Additional notes:**

References: https://docs.aws.amazon.com/sns/latest/dg/sns-send-custom-platform-specific-payloads-mobile-devices.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for push notification settings to ensure at least one allowed property is provided and empty objects are not accepted.
  - Updated error messages for clearer guidance when required properties are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->