### PR TITLE
fix: graphql core service left join conditions

### DIFF
--- a/apps/api/src/common/graphql/services/core.service.ts
+++ b/apps/api/src/common/graphql/services/core.service.ts
@@ -32,22 +32,15 @@ export abstract class CoreService<TEntity> {
 
     const queryBuilder = this.repository.createQueryBuilder(alias);
 
-    // Perform a Left Join to fetch and display related applicationDetails & providerDetails
-    // For 'notification' or 'archivedNotification' findAll
+    // Perform a Left Join to fetch and display related entityDetails
     if (alias === 'notification' || alias === 'archivedNotification') {
       queryBuilder.leftJoinAndSelect(`${alias}.applicationDetails`, 'application');
       queryBuilder.leftJoinAndSelect(`${alias}.providerDetails`, 'provider');
-    }
-
-    if (alias === 'serverApiKeys') {
+    } else if (alias === 'serverApiKeys') {
       queryBuilder.leftJoinAndSelect(`${alias}.applicationDetails`, 'application');
-    }
-
-    if (alias === 'providerChain') {
+    } else if (alias === 'providerChain') {
       queryBuilder.leftJoinAndSelect(`${alias}.applicationDetails`, 'application');
-    }
-
-    if (alias === 'providerChainMember') {
+    } else if (alias === 'providerChainMember') {
       queryBuilder.leftJoinAndSelect(`${alias}.providerDetails`, 'provider');
       queryBuilder.leftJoinAndSelect(`${alias}.providerChainDetails`, 'provider-chain');
     }


### PR DESCRIPTION
## API PR Checklist

### Task Link

Osmosys Developers must include the Pinestem task link in the PR.

[OSXT-359](https://pinestem.com/dashboard.html#/tasks/OSXT-359/details/?companyId=453&isPrevNext=1)

### Pre-requisites

- [x] I have gone through the Contributing guidelines for [Submitting a Pull Request (PR)](https://github.com/OsmosysSoftware/osmo-x/blob/main/CONTRIBUTING.md#-submitting-a-pull-request-pr) and ensured that this is not a duplicate PR.
- [x] I have performed unit testing for the new feature added or updated to ensure the new features added are working as expected.
- [x] I have added/updated test cases to the [test suite](https://github.com/OsmosysSoftware/osmo-x/blob/main/apps/api/OsmoX.postman_collection.json) as applicable.
- [x] I have performed preliminary testing using the [test suite](https://github.com/OsmosysSoftware/osmo-x/blob/main/apps/api/OsmoX.postman_collection.json) to ensure that any existing features are not impacted and any new features are working as expected as a whole.
- [x] I have added/updated the required [api docs](https://github.com/OsmosysSoftware/osmo-x/tree/main/apps/api/docs) as applicable.
- [ ] I have added/updated the `.env.example` file with the required values as applicable.

### PR Details

PR details have been updated as per the given format (see below)

- [x] PR title adheres to the format specified in guidelines (e.g., `feat: add admin login endpoint`)
- [x] Description has been added
- [x] Related changes have been added (optional)
- [ ] Screenshots have been added (optional)
- [ ] Query request and response examples have been added (as applicable, in case added or updated)
- [x] Documentation changes have been listed (as applicable)
- [ ] Test suite/unit testing output is added (as applicable)
- [ ] Pending actions have been added (optional)
- [ ] Any other additional notes have been added (optional)

### Additional Information

- [x] Appropriate label(s) have been added (`ready for review` should be added if the PR is ready to be reviewed)
- [x] Assignee(s) and reviewer(s) have been added (optional)

_Note: Reviewer should ensure that the checklist and description have been populated and followed correctly, and the PR should be merged only after resolving all conversations and verifying that CI checks pass._

---

**Description:**

Fix the if-else ladder used in `core.service` for performing a left join in GraphQL `findAll` API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved the logic for handling related entity joins to ensure only one relevant join is executed per request. No changes to user-facing features or functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->