### PR TITLE
fix(api): restore postgres volume name and mount path

### DIFF
--- a/apps/api/docker-compose.yml
+++ b/apps/api/docker-compose.yml
@@ -11,9 +11,8 @@ services:
       POSTGRES_USER: '${DB_USERNAME}'
       POSTGRES_PASSWORD: '${DB_PASSWORD}'
       POSTGRES_DB: '${DB_NAME}'
-      PGDATA: /var/lib/postgresql/data
     volumes:
-      - osmox-postgres-data:/var/lib/postgresql/data
+      - osmox-postgres-data-saas:/var/lib/postgresql
     healthcheck:
       test: ['CMD-SHELL', 'pg_isready -U ${DB_USERNAME} -d ${DB_NAME}']
       interval: 10s
@@ -119,7 +118,7 @@ services:
       - osmox-network
 
 volumes:
-  osmox-postgres-data:
+  osmox-postgres-data-saas:
     driver: local
   osmox-redis-data:
     driver: local


### PR DESCRIPTION
## API PR Checklist

### Task Link

N/A — Hotfix for production database connectivity issue.

### Pre-requisites

- [x] I have gone through the Contributing guidelines for [Submitting a Pull Request (PR)](https://github.com/OsmosysSoftware/osmo-x/blob/main/CONTRIBUTING.md#-submitting-a-pull-request-pr) and ensured that this is not a duplicate PR.
- [x] I have performed unit testing for the new feature added or updated to ensure the new features added are working as expected.
- [ ] I have added/updated test cases to the [test suite](https://github.com/OsmosysSoftware/osmo-x/blob/main/apps/api/OsmoX.postman_collection.json) as applicable.
- [ ] I have performed preliminary testing using the [test suite](https://github.com/OsmosysSoftware/osmo-x/blob/main/apps/api/OsmoX.postman_collection.json) to ensure that any existing features are not impacted and any new features are working as expected as a whole.
- [ ] I have added/updated the required [api docs](https://github.com/OsmosysSoftware/osmo-x/tree/main/apps/api/docs) as applicable.
- [x] I have added/updated the `.env.example` file with the required values as applicable.

### PR Details

- [x] PR title adheres to the format specified in guidelines
- [x] Description has been added
- [x] Related changes have been added
- [ ] Screenshots have been added (optional)
- [ ] Query request and response examples have been added
- [ ] Documentation changes have been listed
- [ ] Test suite/unit testing output is added
- [ ] Pending actions have been added
- [x] Any other additional notes have been added

### Additional Information

- [ ] Appropriate label(s) have been added
- [ ] Assignee(s) and reviewer(s) have been added

---

**Description:**

Restores the original postgres volume configuration that was inadvertently changed in the SaaS transformation PR (#488). The volume name and mount path must match the existing production volume to prevent data loss.

Production postgres was failing to start because:
1. Volume name changed from `osmox-postgres-data-saas` to `osmox-postgres-data` — creating a new empty volume instead of using the existing one with data
2. Mount path changed from `/var/lib/postgresql` to `/var/lib/postgresql/data` — incompatible with how the existing volume stores data
3. Explicit `PGDATA` env var was added — not present in the original config

**Related changes:**

- Restored volume name to `osmox-postgres-data-saas` (matching existing production volume)
- Restored mount path to `/var/lib/postgresql` (matching original config)
- Removed explicit `PGDATA` environment variable (was not in original config)

**Additional notes:**

- Production also needs `postgres:17-alpine` image (not 18) since the existing data was initialized with Postgres 17. The image version change from the pin docker images PR (#486) is a separate issue — upgrading Postgres major versions requires `pg_dump`/`pg_restore`.
- After deploying this fix, migrations need to be run: `docker exec -it $(docker compose ps -q osmox-api) npm run typeorm:run-migration`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database storage configuration for the API service to support multi-environment deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->