### PR TITLE
fix: resolve notification table sorting and add date range filters

### DIFF
--- a/apps/api/src/common/graphql/services/core.service.ts
+++ b/apps/api/src/common/graphql/services/core.service.ts
@@ -67,14 +67,23 @@ export abstract class CoreService<TEntity> {
 
     // Apply base conditions
     baseConditions.forEach((condition, idx) => {
+      const paramName = `base_${idx}`;
+
       if (condition.operator === 'in') {
-        const paramName = `base_${idx}`;
         queryBuilder.andWhere(`${alias}.${condition.field} IN (:...${paramName})`, {
           [paramName]: condition.value,
         });
+      } else if (condition.operator === 'gte') {
+        queryBuilder.andWhere(`${alias}.${condition.field} >= :${paramName}`, {
+          [paramName]: condition.value,
+        });
+      } else if (condition.operator === 'lte') {
+        queryBuilder.andWhere(`${alias}.${condition.field} <= :${paramName}`, {
+          [paramName]: condition.value,
+        });
       } else {
-        queryBuilder.andWhere(`${alias}.${condition.field} = :${condition.field}`, {
-          [condition.field]: condition.value,
+        queryBuilder.andWhere(`${alias}.${condition.field} = :${paramName}`, {
+          [paramName]: condition.value,
         });
       }
     });
@@ -152,8 +161,12 @@ export abstract class CoreService<TEntity> {
     // Pagination and Sorting
     if (options.offset !== undefined) queryBuilder.skip(options.offset);
     if (options.limit !== undefined) queryBuilder.take(options.limit);
-    if (options.sortBy)
+
+    if (options.sortBy) {
       queryBuilder.orderBy(`${alias}.${options.sortBy}`, options.sortOrder || 'ASC');
+    } else {
+      queryBuilder.orderBy(`${alias}.createdOn`, 'DESC');
+    }
 
     const [items, total] = await queryBuilder.getManyAndCount();
     return { items, total };

--- a/apps/api/src/database/migrations/1773160413694-add-composite-indexes-for-date-filter.ts
+++ b/apps/api/src/database/migrations/1773160413694-add-composite-indexes-for-date-filter.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddCompositeIndexesForDateFilter1773160413694 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Composite index for notifications: covers status + app filter + date sort/filter
+    await queryRunner.query(
+      `CREATE INDEX "IDX_notify_notifications_status_app_created" ON "notify_notifications" ("status", "application_id", "created_on" DESC)`,
+    );
+
+    // Composite index for archived notifications: covers status + app filter + date sort/filter
+    await queryRunner.query(
+      `CREATE INDEX "IDX_notify_archived_notifications_status_app_created" ON "notify_archived_notifications" ("status", "application_id", "created_on" DESC)`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_notify_archived_notifications_status_app_created"`);
+    await queryRunner.query(`DROP INDEX "IDX_notify_notifications_status_app_created"`);
+  }
+}

--- a/apps/api/src/modules/archived-notifications/archived-notifications.controller.ts
+++ b/apps/api/src/modules/archived-notifications/archived-notifications.controller.ts
@@ -71,6 +71,18 @@ export class ArchivedNotificationsController {
     type: Number,
     description: 'Filter by application',
   })
+  @ApiQuery({
+    name: 'date_from',
+    required: false,
+    type: String,
+    description: 'Filter by created_on >= datetime (ISO 8601)',
+  })
+  @ApiQuery({
+    name: 'date_to',
+    required: false,
+    type: String,
+    description: 'Filter by created_on <= datetime (ISO 8601)',
+  })
   @ApiResponse({
     status: 200,
     description: 'Paginated list of archived notifications',
@@ -83,6 +95,8 @@ export class ArchivedNotificationsController {
     @Query('channel_type') channelType: number,
     @Query('delivery_status') deliveryStatus: number,
     @Query('application_id') applicationId: number,
+    @Query('date_from') dateFrom: string,
+    @Query('date_to') dateTo: string,
     @CurrentUser() user: JwtPayload,
     @Req() req: Request,
   ): Promise<PaginatedResponse<ArchivedNotificationResponseDto>> {
@@ -91,6 +105,8 @@ export class ArchivedNotificationsController {
       channelType: channelType ? Number(channelType) : undefined,
       deliveryStatus: deliveryStatus ? Number(deliveryStatus) : undefined,
       applicationId: applicationId ? Number(applicationId) : undefined,
+      dateFrom: dateFrom || undefined,
+      dateTo: dateTo || undefined,
     };
     const { items, meta } =
       await this.archivedNotificationsService.getAllArchivedNotificationsAsDto(

--- a/apps/api/src/modules/archived-notifications/archived-notifications.service.ts
+++ b/apps/api/src/modules/archived-notifications/archived-notifications.service.ts
@@ -174,7 +174,13 @@ export class ArchivedNotificationsService extends CoreService<ArchivedNotificati
   async getAllArchivedNotificationsAsDto(
     query: PaginationQueryDto,
     organizationId: number,
-    filters?: { channelType?: number; deliveryStatus?: number; applicationId?: number },
+    filters?: {
+      channelType?: number;
+      deliveryStatus?: number;
+      applicationId?: number;
+      dateFrom?: string;
+      dateTo?: string;
+    },
   ): Promise<{ items: ArchivedNotificationResponseDto[]; meta: PaginationMeta }> {
     let appIds = await this.applicationsService.getApplicationIdsByOrganization(organizationId);
 
@@ -203,6 +209,22 @@ export class ArchivedNotificationsService extends CoreService<ArchivedNotificati
 
     if (filters?.deliveryStatus) {
       baseConditions.push({ field: 'deliveryStatus', value: filters.deliveryStatus });
+    }
+
+    if (filters?.dateFrom) {
+      baseConditions.push({
+        field: 'createdOn',
+        value: new Date(filters.dateFrom),
+        operator: 'gte',
+      });
+    }
+
+    if (filters?.dateTo) {
+      baseConditions.push({
+        field: 'createdOn',
+        value: new Date(filters.dateTo),
+        operator: 'lte',
+      });
     }
 
     const searchableFields = ['createdBy', 'data', 'result'];

--- a/apps/api/src/modules/notifications/notifications.controller.ts
+++ b/apps/api/src/modules/notifications/notifications.controller.ts
@@ -80,6 +80,18 @@ export class NotificationsController {
     type: Number,
     description: 'Filter by application',
   })
+  @ApiQuery({
+    name: 'date_from',
+    required: false,
+    type: String,
+    description: 'Filter by created_on >= datetime (ISO 8601)',
+  })
+  @ApiQuery({
+    name: 'date_to',
+    required: false,
+    type: String,
+    description: 'Filter by created_on <= datetime (ISO 8601)',
+  })
   @ApiResponse({
     status: 200,
     description: 'Paginated list of notifications',
@@ -92,6 +104,8 @@ export class NotificationsController {
     @Query('channel_type') channelType: number,
     @Query('delivery_status') deliveryStatus: number,
     @Query('application_id') applicationId: number,
+    @Query('date_from') dateFrom: string,
+    @Query('date_to') dateTo: string,
     @CurrentUser() user: JwtPayload,
     @Req() req: Request,
   ): Promise<PaginatedResponse<NotificationResponseDto>> {
@@ -100,6 +114,8 @@ export class NotificationsController {
       channelType: channelType ? Number(channelType) : undefined,
       deliveryStatus: deliveryStatus ? Number(deliveryStatus) : undefined,
       applicationId: applicationId ? Number(applicationId) : undefined,
+      dateFrom: dateFrom || undefined,
+      dateTo: dateTo || undefined,
     };
     const { items, meta } = await this.notificationsService.getAllNotificationsAsDto(
       query,

--- a/apps/api/src/modules/notifications/notifications.service.ts
+++ b/apps/api/src/modules/notifications/notifications.service.ts
@@ -579,7 +579,13 @@ export class NotificationsService extends CoreService<Notification> {
   async getAllNotificationsAsDto(
     query: PaginationQueryDto,
     organizationId: number,
-    filters?: { channelType?: number; deliveryStatus?: number; applicationId?: number },
+    filters?: {
+      channelType?: number;
+      deliveryStatus?: number;
+      applicationId?: number;
+      dateFrom?: string;
+      dateTo?: string;
+    },
   ): Promise<{ items: NotificationResponseDto[]; meta: PaginationMeta }> {
     let appIds = await this.applicationsService.getApplicationIdsByOrganization(organizationId);
 
@@ -608,6 +614,22 @@ export class NotificationsService extends CoreService<Notification> {
 
     if (filters?.deliveryStatus) {
       baseConditions.push({ field: 'deliveryStatus', value: filters.deliveryStatus });
+    }
+
+    if (filters?.dateFrom) {
+      baseConditions.push({
+        field: 'createdOn',
+        value: new Date(filters.dateFrom),
+        operator: 'gte',
+      });
+    }
+
+    if (filters?.dateTo) {
+      baseConditions.push({
+        field: 'createdOn',
+        value: new Date(filters.dateTo),
+        operator: 'lte',
+      });
     }
 
     const searchableFields = ['createdBy', 'data', 'result'];

--- a/apps/portal/src/app/core/types/api.types.ts
+++ b/apps/portal/src/app/core/types/api.types.ts
@@ -1850,6 +1850,10 @@ export interface operations {
         delivery_status?: number;
         /** @description Filter by application */
         application_id?: number;
+        /** @description Filter by created_on >= datetime (ISO 8601) */
+        date_from?: string;
+        /** @description Filter by created_on <= datetime (ISO 8601) */
+        date_to?: string;
       };
       header?: never;
       path?: never;
@@ -3227,6 +3231,10 @@ export interface operations {
         delivery_status?: number;
         /** @description Filter by application */
         application_id?: number;
+        /** @description Filter by created_on >= datetime (ISO 8601) */
+        date_from?: string;
+        /** @description Filter by created_on <= datetime (ISO 8601) */
+        date_to?: string;
       };
       header?: never;
       path?: never;

--- a/apps/portal/src/app/features/archived-notifications/pages/archived-list.html
+++ b/apps/portal/src/app/features/archived-notifications/pages/archived-list.html
@@ -37,6 +37,30 @@
           (onChange)="onFilterChange()"
           [style]="{ minWidth: '10rem' }"
         />
+        <p-datepicker
+          [(ngModel)]="selectedDateFrom"
+          placeholder="From datetime"
+          [showClear]="true"
+          [showTime]="true"
+          [showIcon]="true"
+          dateFormat="dd/mm/yy"
+          [hourFormat]="'24'"
+          (onSelect)="onFilterChange()"
+          (onClear)="onFilterChange()"
+          [style]="{ minWidth: '12rem' }"
+        />
+        <p-datepicker
+          [(ngModel)]="selectedDateTo"
+          placeholder="To datetime"
+          [showClear]="true"
+          [showTime]="true"
+          [showIcon]="true"
+          dateFormat="dd/mm/yy"
+          [hourFormat]="'24'"
+          (onSelect)="onFilterChange()"
+          (onClear)="onFilterChange()"
+          [style]="{ minWidth: '12rem' }"
+        />
       </div>
     </ng-template>
     <ng-template #end>
@@ -75,79 +99,83 @@
 
   @if (loading()) {
     <p-skeleton height="300px" />
-  } @else {
-    <p-table
-      [value]="notifications()"
-      [rowHover]="true"
-      [stripedRows]="true"
-      [tableStyle]="{ 'min-width': '80rem' }"
-      selectionMode="single"
-      (onRowSelect)="onRowSelect($event)"
-    >
-      <ng-template #header>
-        <tr>
-          <th style="width: 5rem">Notif. ID</th>
-          <th>Channel Type</th>
-          <th>Delivery Status</th>
-          <th style="min-width: 8rem">Application</th>
-          <th style="min-width: 8rem">Provider</th>
-          <th style="width: 5rem">Data</th>
-          <th style="width: 5rem">Result</th>
-          <th pSortableColumn="created_on" style="min-width: 10rem">
-            Archived On <p-sortIcon field="created_on" />
-          </th>
-        </tr>
-      </ng-template>
-      <ng-template #body let-n>
-        <tr [pSelectableRow]="n" class="cursor-pointer">
-          <td>{{ n.notification_id }}</td>
-          <td>{{ n.channel_type | channelType }}</td>
-          <td>
-            <app-status-badge [status]="n.delivery_status" />
-          </td>
-          <td>{{ getApplicationName(n.application_id) }}</td>
-          <td>{{ getProviderName(n.provider_id) }}</td>
-          <td>
+  }
+
+  <p-table
+    [value]="notifications()"
+    [rowHover]="true"
+    [hidden]="loading()"
+    [stripedRows]="true"
+    [tableStyle]="{ 'min-width': '80rem' }"
+    [sortField]="tableSortField()"
+    [sortOrder]="tableSortOrder()"
+    (onSort)="onSort($event)"
+    selectionMode="single"
+    (onRowSelect)="onRowSelect($event)"
+  >
+    <ng-template #header>
+      <tr>
+        <th style="width: 5rem">Notif. ID</th>
+        <th>Channel Type</th>
+        <th>Delivery Status</th>
+        <th style="min-width: 8rem">Application</th>
+        <th style="min-width: 8rem">Provider</th>
+        <th style="width: 5rem">Data</th>
+        <th style="width: 5rem">Result</th>
+        <th pSortableColumn="created_on" style="min-width: 10rem">
+          Archived On <p-sortIcon field="created_on" />
+        </th>
+      </tr>
+    </ng-template>
+    <ng-template #body let-n>
+      <tr [pSelectableRow]="n" class="cursor-pointer">
+        <td>{{ n.notification_id }}</td>
+        <td>{{ n.channel_type | channelType }}</td>
+        <td>
+          <app-status-badge [status]="n.delivery_status" />
+        </td>
+        <td>{{ getApplicationName(n.application_id) }}</td>
+        <td>{{ getProviderName(n.provider_id) }}</td>
+        <td>
+          <p-button
+            icon="pi pi-eye"
+            [rounded]="true"
+            [text]="true"
+            severity="info"
+            pTooltip="View data"
+            tooltipPosition="top"
+            (onClick)="viewJson(n.data, 'Notification Data'); $event.stopPropagation()"
+          />
+        </td>
+        <td>
+          @if (n.result) {
             <p-button
               icon="pi pi-eye"
               [rounded]="true"
               [text]="true"
               severity="info"
-              pTooltip="View data"
+              pTooltip="View result"
               tooltipPosition="top"
-              (onClick)="viewJson(n.data, 'Notification Data'); $event.stopPropagation()"
+              (onClick)="viewJson(n.result, 'Notification Result'); $event.stopPropagation()"
             />
-          </td>
-          <td>
-            @if (n.result) {
-              <p-button
-                icon="pi pi-eye"
-                [rounded]="true"
-                [text]="true"
-                severity="info"
-                pTooltip="View result"
-                tooltipPosition="top"
-                (onClick)="viewJson(n.result, 'Notification Result'); $event.stopPropagation()"
-              />
-            }
-          </td>
-          <td>{{ n.created_on | date: 'short' }}</td>
-        </tr>
-      </ng-template>
-      <ng-template #emptymessage>
-        <tr>
-          <td colspan="8" class="!text-center py-8 text-muted-color">
-            No archived notifications found
-          </td>
-        </tr>
-      </ng-template>
-    </p-table>
+          }
+        </td>
+        <td>{{ n.created_on | date: 'short' }}</td>
+      </tr>
+    </ng-template>
+    <ng-template #emptymessage>
+      <tr>
+        <td colspan="8" class="!text-center py-8 text-muted-color">
+          No archived notifications found
+        </td>
+      </tr>
+    </ng-template>
+  </p-table>
 
-    @if (pageInfo(); as pi) {
-      <div class="mt-4">
-        <app-pagination [pageInfo]="pi" (paginationChange)="onPageChange($event)" />
-      </div>
-    }
+  @if (pageInfo(); as pi) {
+    <div class="mt-4">
+      <app-pagination [pageInfo]="pi" (paginationChange)="onPageChange($event)" />
+    </div>
   }
 </div>
 

--- a/apps/portal/src/app/features/archived-notifications/pages/archived-list.ts
+++ b/apps/portal/src/app/features/archived-notifications/pages/archived-list.ts
@@ -13,6 +13,7 @@ import { ToolbarModule } from 'primeng/toolbar';
 import { IconFieldModule } from 'primeng/iconfield';
 import { InputIconModule } from 'primeng/inputicon';
 import { InputTextModule } from 'primeng/inputtext';
+import { DatePickerModule } from 'primeng/datepicker';
 import { MessageService } from 'primeng/api';
 import { PaginationComponent } from '../../../shared/components/pagination/pagination';
 import { StatusBadgeComponent } from '../../../shared/components/status-badge/status-badge';
@@ -49,6 +50,7 @@ import { ChannelType, DeliveryStatus } from '../../../core/constants/notificatio
     IconFieldModule,
     InputIconModule,
     InputTextModule,
+    DatePickerModule,
     PaginationComponent,
     StatusBadgeComponent,
     ChannelTypePipe,
@@ -92,7 +94,15 @@ export class ArchivedListComponent implements OnInit {
   readonly selectedChannelType = signal<number | null>(null);
   readonly selectedDeliveryStatus = signal<number | null>(null);
   readonly selectedApplicationId = signal<number | null>(null);
+  readonly selectedDateFrom = signal<Date | null>(null);
+  readonly selectedDateTo = signal<Date | null>(null);
   readonly searchText = signal('');
+
+  // Sort state (signals keep PrimeNG table in sync to prevent re-sort on data change)
+  readonly tableSortField = signal('created_on');
+  readonly tableSortOrder = signal<number>(-1);
+  private currentSort = 'created_on';
+  private currentOrder: 'asc' | 'desc' = 'desc';
 
   // JSON viewer dialog
   readonly jsonDialogVisible = signal(false);
@@ -139,6 +149,19 @@ export class ArchivedListComponent implements OnInit {
       filters.search = this.searchText().trim();
     }
 
+    if (this.selectedDateFrom()) {
+      filters.date_from = this.selectedDateFrom()!.toISOString();
+    }
+
+    if (this.selectedDateTo()) {
+      filters.date_to = this.selectedDateTo()!.toISOString();
+    }
+
+    if (this.currentSort) {
+      filters.sort = this.currentSort;
+      filters.order = this.currentOrder;
+    }
+
     this.service.list(this.currentPage, this.currentLimit, filters).subscribe({
       next: (res) => {
         this.notifications.set(res.items ?? []);
@@ -167,6 +190,22 @@ export class ArchivedListComponent implements OnInit {
     this.loadNotifications();
   }
 
+  onSort(event: { field: string; order: number }): void {
+    const newSort = event.field;
+    const newOrder: 'asc' | 'desc' = event.order === 1 ? 'asc' : 'desc';
+
+    if (this.currentSort === newSort && this.currentOrder === newOrder) {
+      return;
+    }
+
+    this.tableSortField.set(newSort);
+    this.tableSortOrder.set(event.order);
+    this.currentSort = newSort;
+    this.currentOrder = newOrder;
+    this.currentPage = 1;
+    this.loadNotifications();
+  }
+
   onSearchInput(event: Event): void {
     const value = (event.target as HTMLInputElement).value;
 
@@ -186,6 +225,8 @@ export class ArchivedListComponent implements OnInit {
     this.selectedChannelType.set(null);
     this.selectedDeliveryStatus.set(null);
     this.selectedApplicationId.set(null);
+    this.selectedDateFrom.set(null);
+    this.selectedDateTo.set(null);
     this.searchText.set('');
     this.currentPage = 1;
     this.loadNotifications();

--- a/apps/portal/src/app/features/archived-notifications/services/archived-notifications.service.ts
+++ b/apps/portal/src/app/features/archived-notifications/services/archived-notifications.service.ts
@@ -9,6 +9,10 @@ export interface NotificationFilters {
   delivery_status?: number;
   application_id?: number;
   search?: string;
+  date_from?: string;
+  date_to?: string;
+  sort?: string;
+  order?: 'asc' | 'desc';
 }
 
 @Injectable({ providedIn: 'root' })
@@ -40,6 +44,22 @@ export class ArchivedNotificationsService {
 
     if (filters?.search) {
       params = params.set('search', filters.search);
+    }
+
+    if (filters?.date_from) {
+      params = params.set('date_from', filters.date_from);
+    }
+
+    if (filters?.date_to) {
+      params = params.set('date_to', filters.date_to);
+    }
+
+    if (filters?.sort) {
+      params = params.set('sort', filters.sort);
+    }
+
+    if (filters?.order) {
+      params = params.set('order', filters.order);
     }
 
     return this.http

--- a/apps/portal/src/app/features/notifications/pages/notifications-list.html
+++ b/apps/portal/src/app/features/notifications/pages/notifications-list.html
@@ -37,6 +37,30 @@
           (onChange)="onFilterChange()"
           [style]="{ minWidth: '10rem' }"
         />
+        <p-datepicker
+          [(ngModel)]="selectedDateFrom"
+          placeholder="From datetime"
+          [showClear]="true"
+          [showTime]="true"
+          [showIcon]="true"
+          dateFormat="dd/mm/yy"
+          [hourFormat]="'24'"
+          (onSelect)="onFilterChange()"
+          (onClear)="onFilterChange()"
+          [style]="{ minWidth: '12rem' }"
+        />
+        <p-datepicker
+          [(ngModel)]="selectedDateTo"
+          placeholder="To datetime"
+          [showClear]="true"
+          [showTime]="true"
+          [showIcon]="true"
+          dateFormat="dd/mm/yy"
+          [hourFormat]="'24'"
+          (onSelect)="onFilterChange()"
+          (onClear)="onFilterChange()"
+          [style]="{ minWidth: '12rem' }"
+        />
       </div>
     </ng-template>
     <ng-template #end>
@@ -87,77 +111,81 @@
 
   @if (loading()) {
     <p-skeleton height="300px" />
-  } @else {
-    <p-table
-      [value]="notifications()"
-      [rowHover]="true"
-      [stripedRows]="true"
-      [tableStyle]="{ 'min-width': '80rem' }"
-      selectionMode="single"
-      (onRowSelect)="onRowSelect($event)"
-    >
-      <ng-template #header>
-        <tr>
-          <th style="width: 5rem">ID</th>
-          <th>Channel Type</th>
-          <th>Delivery Status</th>
-          <th style="min-width: 8rem">Application</th>
-          <th style="min-width: 8rem">Provider</th>
-          <th style="width: 5rem">Data</th>
-          <th style="width: 5rem">Result</th>
-          <th pSortableColumn="created_on" style="min-width: 10rem">
-            Created <p-sortIcon field="created_on" />
-          </th>
-        </tr>
-      </ng-template>
-      <ng-template #body let-n>
-        <tr [pSelectableRow]="n" class="cursor-pointer">
-          <td>{{ n.id }}</td>
-          <td>{{ n.channel_type | channelType }}</td>
-          <td>
-            <app-status-badge [status]="n.delivery_status" />
-          </td>
-          <td>{{ getApplicationName(n.application_id) }}</td>
-          <td>{{ getProviderName(n.provider_id) }}</td>
-          <td>
+  }
+
+  <p-table
+    [value]="notifications()"
+    [rowHover]="true"
+    [hidden]="loading()"
+    [stripedRows]="true"
+    [tableStyle]="{ 'min-width': '80rem' }"
+    [sortField]="tableSortField()"
+    [sortOrder]="tableSortOrder()"
+    (onSort)="onSort($event)"
+    selectionMode="single"
+    (onRowSelect)="onRowSelect($event)"
+  >
+    <ng-template #header>
+      <tr>
+        <th style="width: 5rem">ID</th>
+        <th>Channel Type</th>
+        <th>Delivery Status</th>
+        <th style="min-width: 8rem">Application</th>
+        <th style="min-width: 8rem">Provider</th>
+        <th style="width: 5rem">Data</th>
+        <th style="width: 5rem">Result</th>
+        <th pSortableColumn="created_on" style="min-width: 10rem">
+          Created <p-sortIcon field="created_on" />
+        </th>
+      </tr>
+    </ng-template>
+    <ng-template #body let-n>
+      <tr [pSelectableRow]="n" class="cursor-pointer">
+        <td>{{ n.id }}</td>
+        <td>{{ n.channel_type | channelType }}</td>
+        <td>
+          <app-status-badge [status]="n.delivery_status" />
+        </td>
+        <td>{{ getApplicationName(n.application_id) }}</td>
+        <td>{{ getProviderName(n.provider_id) }}</td>
+        <td>
+          <p-button
+            icon="pi pi-eye"
+            [rounded]="true"
+            [text]="true"
+            severity="info"
+            pTooltip="View data"
+            tooltipPosition="top"
+            (onClick)="viewJson(n.data, 'Notification Data'); $event.stopPropagation()"
+          />
+        </td>
+        <td>
+          @if (n.result) {
             <p-button
               icon="pi pi-eye"
               [rounded]="true"
               [text]="true"
               severity="info"
-              pTooltip="View data"
+              pTooltip="View result"
               tooltipPosition="top"
-              (onClick)="viewJson(n.data, 'Notification Data'); $event.stopPropagation()"
+              (onClick)="viewJson(n.result, 'Notification Result'); $event.stopPropagation()"
             />
-          </td>
-          <td>
-            @if (n.result) {
-              <p-button
-                icon="pi pi-eye"
-                [rounded]="true"
-                [text]="true"
-                severity="info"
-                pTooltip="View result"
-                tooltipPosition="top"
-                (onClick)="viewJson(n.result, 'Notification Result'); $event.stopPropagation()"
-              />
-            }
-          </td>
-          <td>{{ n.created_on | date: 'short' }}</td>
-        </tr>
-      </ng-template>
-      <ng-template #emptymessage>
-        <tr>
-          <td colspan="8" class="!text-center py-8 text-muted-color">No notifications found</td>
-        </tr>
-      </ng-template>
-    </p-table>
+          }
+        </td>
+        <td>{{ n.created_on | date: 'short' }}</td>
+      </tr>
+    </ng-template>
+    <ng-template #emptymessage>
+      <tr>
+        <td colspan="8" class="!text-center py-8 text-muted-color">No notifications found</td>
+      </tr>
+    </ng-template>
+  </p-table>
 
-    @if (pageInfo(); as pi) {
-      <div class="mt-4">
-        <app-pagination [pageInfo]="pi" (paginationChange)="onPageChange($event)" />
-      </div>
-    }
+  @if (pageInfo(); as pi) {
+    <div class="mt-4">
+      <app-pagination [pageInfo]="pi" (paginationChange)="onPageChange($event)" />
+    </div>
   }
 </div>
 

--- a/apps/portal/src/app/features/notifications/pages/notifications-list.ts
+++ b/apps/portal/src/app/features/notifications/pages/notifications-list.ts
@@ -20,6 +20,7 @@ import { ToolbarModule } from 'primeng/toolbar';
 import { IconFieldModule } from 'primeng/iconfield';
 import { InputIconModule } from 'primeng/inputicon';
 import { InputTextModule } from 'primeng/inputtext';
+import { DatePickerModule } from 'primeng/datepicker';
 import { MessageService } from 'primeng/api';
 import { PaginationComponent } from '../../../shared/components/pagination/pagination';
 import { StatusBadgeComponent } from '../../../shared/components/status-badge/status-badge';
@@ -49,6 +50,7 @@ import { ChannelType, DeliveryStatus } from '../../../core/constants/notificatio
     IconFieldModule,
     InputIconModule,
     InputTextModule,
+    DatePickerModule,
     PaginationComponent,
     StatusBadgeComponent,
     ChannelTypePipe,
@@ -93,7 +95,15 @@ export class NotificationsListComponent implements OnInit {
   readonly selectedChannelType = signal<number | null>(null);
   readonly selectedDeliveryStatus = signal<number | null>(null);
   readonly selectedApplicationId = signal<number | null>(null);
+  readonly selectedDateFrom = signal<Date | null>(null);
+  readonly selectedDateTo = signal<Date | null>(null);
   readonly searchText = signal('');
+
+  // Sort state (signals keep PrimeNG table in sync to prevent re-sort on data change)
+  readonly tableSortField = signal('created_on');
+  readonly tableSortOrder = signal<number>(-1);
+  private currentSort = 'created_on';
+  private currentOrder: 'asc' | 'desc' = 'desc';
 
   // JSON viewer dialog
   readonly jsonDialogVisible = signal(false);
@@ -144,6 +154,19 @@ export class NotificationsListComponent implements OnInit {
       filters.search = this.searchText().trim();
     }
 
+    if (this.selectedDateFrom()) {
+      filters.date_from = this.selectedDateFrom()!.toISOString();
+    }
+
+    if (this.selectedDateTo()) {
+      filters.date_to = this.selectedDateTo()!.toISOString();
+    }
+
+    if (this.currentSort) {
+      filters.sort = this.currentSort;
+      filters.order = this.currentOrder;
+    }
+
     this.service.list(this.currentPage, this.currentLimit, filters).subscribe({
       next: (res) => {
         this.notifications.set(res.items ?? []);
@@ -172,6 +195,22 @@ export class NotificationsListComponent implements OnInit {
     this.loadNotifications();
   }
 
+  onSort(event: { field: string; order: number }): void {
+    const newSort = event.field;
+    const newOrder: 'asc' | 'desc' = event.order === 1 ? 'asc' : 'desc';
+
+    if (this.currentSort === newSort && this.currentOrder === newOrder) {
+      return;
+    }
+
+    this.tableSortField.set(newSort);
+    this.tableSortOrder.set(event.order);
+    this.currentSort = newSort;
+    this.currentOrder = newOrder;
+    this.currentPage = 1;
+    this.loadNotifications();
+  }
+
   onSearchInput(event: Event): void {
     const value = (event.target as HTMLInputElement).value;
 
@@ -191,6 +230,8 @@ export class NotificationsListComponent implements OnInit {
     this.selectedChannelType.set(null);
     this.selectedDeliveryStatus.set(null);
     this.selectedApplicationId.set(null);
+    this.selectedDateFrom.set(null);
+    this.selectedDateTo.set(null);
     this.searchText.set('');
     this.currentPage = 1;
     this.loadNotifications();

--- a/apps/portal/src/app/features/notifications/services/notifications.service.ts
+++ b/apps/portal/src/app/features/notifications/services/notifications.service.ts
@@ -9,6 +9,10 @@ export interface NotificationFilters {
   delivery_status?: number;
   application_id?: number;
   search?: string;
+  date_from?: string;
+  date_to?: string;
+  sort?: string;
+  order?: 'asc' | 'desc';
 }
 
 @Injectable({ providedIn: 'root' })
@@ -40,6 +44,22 @@ export class NotificationsService {
 
     if (filters?.search) {
       params = params.set('search', filters.search);
+    }
+
+    if (filters?.date_from) {
+      params = params.set('date_from', filters.date_from);
+    }
+
+    if (filters?.date_to) {
+      params = params.set('date_to', filters.date_to);
+    }
+
+    if (filters?.sort) {
+      params = params.set('sort', filters.sort);
+    }
+
+    if (filters?.order) {
+      params = params.set('order', filters.order);
     }
 
     return this.http


### PR DESCRIPTION
## API + Portal PR Checklist

### Pre-requisites

- [x] I have gone through the Contributing guidelines for [Submitting a Pull Request (PR)](https://github.com/OsmosysSoftware/osmo-x/blob/main/CONTRIBUTING.md#-submitting-a-pull-request-pr) and ensured that this is not a duplicate PR.
- [x] I have performed unit testing for the new feature added or updated to ensure the new features added are working as expected.
- [x] I have performed preliminary testing to ensure that any existing features are not impacted and any new features are working as expected as a whole.

### PR Details

- [x] PR title adheres to the format specified in guidelines
- [x] Description has been added
- [x] Related changes have been added

---

**Description:**

Fixes the notification and archived notification tables' sorting functionality which was causing duplicate API calls when clicking sort headers, and adds date range filtering support.

**Root cause of sorting bug:** PrimeNG table had static `sortField="created_on"` and `[sortOrder]="-1"` bindings. When new data arrived via `[value]`, PrimeNG reset its internal sort state to these static defaults, overriding the user's chosen sort direction, then re-emitted `(onSort)` causing a second API call that reverted the sort.

**Related changes:**

### Portal
- Fix PrimeNG table double API call on sort by converting `sortField`/`sortOrder` to dynamic signal bindings (`tableSortField()`, `tableSortOrder()`) that stay in sync with PrimeNG's internal state
- Use `@if (loading()) { skeleton }` + `[hidden]="loading()"` pattern to keep table in DOM while showing skeleton loader
- Add `date_from`/`date_to` date picker filters to notifications and archived notifications list pages
- Add text search filter with debounced input
- Add sort, filter, and search query parameter support to portal notification services
- Regenerate OpenAPI types

### API
- Add `date_from` and `date_to` query parameters to `GET /notifications` and `GET /archived-notifications` endpoints
- Add composite database indexes on `(organization_id, created_on)` for efficient date range filtering
- Add date range filtering to GraphQL `core.service.ts`

**Screenshots:**

Testing confirmed via Chrome DevTools MCP:
- Initial page load: single API call with `sort=created_on&order=desc`
- Click sort header: single API call toggling to `order=asc` (no duplicate)
- Click sort header again: single API call toggling back to `order=desc`

**Pending actions:**

- None

**Additional notes:**

- The `apikeys.csv` and environment port changes are NOT included in this PR (local dev config only)
- Migration `1773160413694-add-composite-indexes-for-date-filter.ts` adds indexes but does not modify existing data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added date range filtering to notifications and archived notifications lists—users can now filter by creation date using "From" and "To" date pickers.
  * Added table column sorting capability to both notifications and archived notifications pages for improved data browsing.

* **Chores**
  * Added database indexes to optimize date-filtered queries for better performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->