### PR TITLE
fix: dynamically fetch year for portal footer

### DIFF
--- a/apps/portal/src/app/layout/component/app.footer.ts
+++ b/apps/portal/src/app/layout/component/app.footer.ts
@@ -1,19 +1,20 @@
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
 
 @Component({
   standalone: true,
   selector: 'app-footer',
+  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `<div class="layout-footer">
     <a
       href="https://osmosys.co/"
       target="_blank"
       rel="noopener noreferrer"
       class="text-primary font-bold hover:underline"
-      >Copyright &copy; {{ currentYear }} Osmosys Software Solutions</a
+      >Copyright &copy; {{ currentYear() }} Osmosys Software Solutions</a
     >
     | All Rights Reserved
   </div>`,
 })
 export class AppFooter {
-  readonly currentYear = new Date().getFullYear();
+  readonly currentYear = signal(new Date().getFullYear());
 }


### PR DESCRIPTION
## Portal PR Checklist

### Task Link

[#498](https://github.com/OsmosysSoftware/osmo-x/issues/498)

### Pre-requisites

- [x] I have gone through the Contributing guidelines for [Submitting a Pull Request (PR)](https://github.com/OsmosysSoftware/osmo-x/blob/main/CONTRIBUTING.md#-submitting-a-pull-request-pr) and ensured that this is not a duplicate PR.
- [x] I have performed unit testing for the new feature added or updated to ensure the new features added are working as expected.
- [x] I have performed preliminary testing to ensure that any existing features are not impacted and any new features are working as expected as a whole.

### PR Details

- [x] PR title adheres to the format specified in guidelines
- [x] Description has been added
- [x] Related changes have been added
- [x] Screenshots have been added

### Additional Information

- [x] Appropriate label(s) have been added

---

**Description:**

Replace hardcoded "2025" in the portal footer with a dynamically computed year using `new Date().getFullYear()`. This ensures the copyright year stays current without manual updates.

**Related changes:**

- Added `currentYear` readonly property to `AppFooter` component
- Updated template to interpolate `{{ currentYear }}` instead of hardcoded "2025"

**Screenshots:**

<img width="2033" height="1500" alt="Footer showing dynamic year 2026" src="https://github.com/user-attachments/assets/1d433291-7b9f-4d9e-9b11-8daae5ca5ba5" />

Closes #498