### PR TITLE
feat: add property-specific filters for notification data JSON

### DIFF
--- a/.claude/skills/crud-page/SKILL.md
+++ b/.claude/skills/crud-page/SKILL.md
@@ -266,6 +266,27 @@ onImportUpload(event: { files: File[] }): void {
 
 ### Service patterns
 
+> **CRITICAL — snake_case end-to-end for filter interfaces:**
+> Filter/query-param interfaces in portal services MUST use snake_case property names that match the API query param names verbatim. **Never** use camelCase and translate at the HTTP boundary.
+>
+> ```typescript
+> // CORRECT — snake_case end-to-end, no translation step
+> export interface MyFilters {
+>   channel_type?: number;
+>   date_from?: string;
+>   application_id?: number;
+> }
+> if (filters?.channel_type) { params = params.set('channel_type', filters.channel_type); }
+>
+> // WRONG — camelCase with translation introduces drift and reviewer drag
+> export interface MyFilters {
+>   channelType?: number;   // ← wrong
+> }
+> if (filters?.channelType) { params = params.set('channel_type', filters.channelType); }
+> ```
+>
+> This applies to all filter/request DTO interfaces defined inside `services/*.service.ts` files. Response entity types from `core/models/api.model.ts` (generated from OpenAPI) are already snake_case — use them directly.
+
 **List with sort params** (all v1 APIs support this):
 ```typescript
 list(page = 1, limit = 20, sort?: string, order?: string): Observable<PaginatedResponse<T>> {

--- a/.claude/skills/crud-page/SKILL.md
+++ b/.claude/skills/crud-page/SKILL.md
@@ -367,6 +367,36 @@ export type UpdateMyEntityInput = components['schemas']['UpdateMyEntityInput'];
 ```
 NEVER create manual interfaces for API entities — always derive from the generated types.
 
+### snake_case for filter / query-param interfaces (MANDATORY)
+
+When the generated service contains a `Filters` interface for the list endpoint's query params (e.g. `MyEntityFilters` with `channel_type`, `application_id`, `date_from`), **every field must be snake_case** — exactly matching the backend query-param names. This is the same rule that applies to API response entities, applied to request shapes.
+
+```typescript
+// CORRECT - snake_case end-to-end, no translation step
+export interface MyEntityFilters {
+  channel_type?: number;
+  application_id?: number;
+  date_from?: string;
+  status?: number;
+}
+
+if (filters?.channel_type) {
+  params = params.set('channel_type', filters.channel_type);
+}
+
+// WRONG - camelCase in TS with inline translation
+// export interface MyEntityFilters {
+//   channelType?: number;        // adds a translation step on every set()
+//   applicationId?: number;
+//   dateFrom?: string;
+// }
+// if (filters?.channelType) {
+//   params = params.set('channel_type', filters.channelType);
+// }
+```
+
+Why: filter interfaces are part of the API contract just like response DTOs. Keeping `filters.field_name` ↔ `params.set('field_name', ...)` ↔ `?field_name=...` aligned end-to-end means renames stay consistent and there's no place for typo-driven silent drops. Generic TypeScript camelCase advice does not apply here — see `apps/portal/CLAUDE.md` § "snake_case applies to request shapes too".
+
 ## Step 6: Verify
 
 1. Run `cd apps/portal && npx ng build` — must succeed with zero errors

--- a/.claude/skills/generate-api-types/SKILL.md
+++ b/.claude/skills/generate-api-types/SKILL.md
@@ -40,6 +40,6 @@ This runs `openapi-typescript http://localhost:3000/api/docs-json -o src/app/cor
    export type CreateApplicationInput = components['schemas']['CreateApplicationInput'];
    ```
 3. All services and components import from `api.model.ts` — NOT directly from `api.types.ts`
-4. Use snake_case field names directly — NO conversion to camelCase
+4. Use snake_case field names directly — NO conversion to camelCase. **This applies equally to handwritten interfaces in services for filter / query-param shapes** (e.g. `MyEntityFilters`) — they must use snake_case to stay aligned with the wire format and the auto-generated response types. See `apps/portal/CLAUDE.md` § "snake_case applies to request shapes too".
 5. Run `npx ng build` to verify no type errors
 6. If new fields were added, check if any components need updating (e.g., new columns in tables)

--- a/apps/api/src/common/dto/pagination-query.dto.ts
+++ b/apps/api/src/common/dto/pagination-query.dto.ts
@@ -4,8 +4,9 @@
  */
 
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { Type } from 'class-transformer';
-import { IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+import { Transform, Type } from 'class-transformer';
+import { IsInt, IsObject, IsOptional, IsString, MaxLength, Min, Max, Validate } from 'class-validator';
+import { IsDataFilterMap } from '../validators/is-data-filter-map.validator';
 
 export class PaginationQueryDto {
   @ApiPropertyOptional({
@@ -59,4 +60,71 @@ export class PaginationQueryDto {
   @IsOptional()
   @IsString()
   search?: string;
+
+  @ApiPropertyOptional({
+    name: 'recipient',
+    description:
+      'Match against notification recipients. Searches data.to, data.cc, data.bcc, ' +
+      'and data.target (push). Supports both string and array values.',
+    example: 'jane@example.com',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(254)
+  recipient?: string;
+
+  @ApiPropertyOptional({
+    name: 'sender',
+    description: 'Match against email From address (data.from).',
+    example: 'noreply@example.com',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(254)
+  sender?: string;
+
+  @ApiPropertyOptional({
+    name: 'subject',
+    description: 'Match against email subject (data.subject).',
+    example: 'Invoice',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  subject?: string;
+
+  @ApiPropertyOptional({
+    name: 'message_body',
+    description:
+      'Match against message body. Searches data.text, data.html, data.message, ' +
+      'data.text.body (WhatsApp), and data.message.default (push). HTML markup is ' +
+      'included in the search.',
+    example: 'password reset',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  @Transform(({ value, obj }: { value: string; obj: Record<string, unknown> }) => {
+    return value ?? (obj.message_body as string | undefined);
+  })
+  messageBody?: string;
+
+  @ApiPropertyOptional({
+    name: 'data_filter',
+    description:
+      'Top-level key/value pairs to match against the notification data JSON. ' +
+      'Repeat as data_filter[key]=value. Keys must match ^[a-zA-Z0-9_]{1,64}$ and ' +
+      'are AND-combined. Swagger UI: rendered with style: deepObject via @ApiQuery ' +
+      'on the controller.',
+    type: 'object',
+    additionalProperties: { type: 'string' },
+    example: { template: 'otp_v2', locale: 'en' },
+  })
+  @IsOptional()
+  @IsObject()
+  @Validate(IsDataFilterMap)
+  @Transform(({ value, obj }: { value: unknown; obj: Record<string, unknown> }) => {
+    return value ?? obj.data_filter;
+  })
+  dataFilter?: Record<string, string>;
 }

--- a/apps/api/src/common/dto/pagination-query.dto.ts
+++ b/apps/api/src/common/dto/pagination-query.dto.ts
@@ -5,7 +5,16 @@
 
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Transform, Type } from 'class-transformer';
-import { IsInt, IsObject, IsOptional, IsString, MaxLength, Min, Max, Validate } from 'class-validator';
+import {
+  IsInt,
+  IsObject,
+  IsOptional,
+  IsString,
+  MaxLength,
+  Min,
+  Max,
+  Validate,
+} from 'class-validator';
 import { IsDataFilterMap } from '../validators/is-data-filter-map.validator';
 
 export class PaginationQueryDto {

--- a/apps/api/src/common/dto/pagination-query.dto.ts
+++ b/apps/api/src/common/dto/pagination-query.dto.ts
@@ -4,7 +4,7 @@
  */
 
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { Transform, Type } from 'class-transformer';
+import { Type } from 'class-transformer';
 import {
   IsInt,
   IsObject,
@@ -113,10 +113,19 @@ export class PaginationQueryDto {
   @IsOptional()
   @IsString()
   @MaxLength(255)
-  @Transform(({ value, obj }: { value: string; obj: Record<string, unknown> }) => {
-    return value ?? (obj.message_body as string | undefined);
+  message_body?: string;
+
+  @ApiPropertyOptional({
+    name: 'template_name',
+    description:
+      'Match against WhatsApp template name (data.template.name). ' +
+      'Applies to 360Dialog and Twilio WhatsApp Business providers.',
+    example: 'ir_incident_resolution',
   })
-  messageBody?: string;
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  template_name?: string;
 
   @ApiPropertyOptional({
     name: 'data_filter',
@@ -132,8 +141,5 @@ export class PaginationQueryDto {
   @IsOptional()
   @IsObject()
   @Validate(IsDataFilterMap)
-  @Transform(({ value, obj }: { value: unknown; obj: Record<string, unknown> }) => {
-    return value ?? obj.data_filter;
-  })
-  dataFilter?: Record<string, string>;
+  data_filter?: Record<string, string>;
 }

--- a/apps/api/src/common/graphql/services/core.service.ts
+++ b/apps/api/src/common/graphql/services/core.service.ts
@@ -1,9 +1,17 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { Repository, Brackets } from 'typeorm';
+import { Repository, Brackets, SelectQueryBuilder } from 'typeorm';
 import { QueryOptionsDto, SortOrder } from '../dtos/query-options.dto';
 import { PaginationQueryDto } from '../../dto/pagination-query.dto';
 import { PaginationHelper, PaginationMeta } from '../../utils/pagination.helper';
 import { Status } from '../../constants/database';
+
+/**
+ * Optional callback that lets domain services append additional WHERE clauses
+ * to a query builder. Runs after base conditions and the bracketed free-text
+ * search are applied, before sort/paging — so its andWhere() composes safely
+ * with the parenthesized search expression.
+ */
+export type ExtraFiltersFn<T> = (qb: SelectQueryBuilder<T>, alias: string) => void;
 
 @Injectable()
 export abstract class CoreService<TEntity> {
@@ -30,6 +38,7 @@ export abstract class CoreService<TEntity> {
     alias: string,
     searchableFields: string[] = [],
     baseConditions: Array<{ field: string; value: unknown; operator?: string }> = [],
+    applyExtraFilters?: ExtraFiltersFn<TEntity>,
   ): Promise<{ items: TEntity[]; total: number }> {
     this.logger.log(`Getting all ${alias} with options`);
 
@@ -101,6 +110,13 @@ export abstract class CoreService<TEntity> {
           });
         }),
       );
+    }
+
+    // Domain-specific extra filters (e.g. notification data JSON predicates).
+    // The previous andWhere(new Brackets(...)) ensures the OR group is parenthesized,
+    // so subsequent andWhere() calls compose safely.
+    if (applyExtraFilters) {
+      applyExtraFilters(queryBuilder, alias);
     }
 
     // Dynamic filters with special handling for date fields
@@ -182,6 +198,7 @@ export abstract class CoreService<TEntity> {
     alias: string,
     searchableFields: string[] = [],
     baseConditions: Array<{ field: string; value: unknown; operator?: string }> = [],
+    applyExtraFilters?: ExtraFiltersFn<TEntity>,
   ): Promise<{ items: TEntity[]; total: number; meta: PaginationMeta }> {
     const { page, limit, offset, sort } = PaginationHelper.normalizePaginationParams(query);
 
@@ -193,7 +210,13 @@ export abstract class CoreService<TEntity> {
       search: query.search,
     };
 
-    const { items, total } = await this.findAll(options, alias, searchableFields, baseConditions);
+    const { items, total } = await this.findAll(
+      options,
+      alias,
+      searchableFields,
+      baseConditions,
+      applyExtraFilters,
+    );
     const meta = PaginationHelper.buildPaginationMeta(page, limit, total);
 
     return { items, total, meta };

--- a/apps/api/src/common/validators/is-data-filter-map.validator.spec.ts
+++ b/apps/api/src/common/validators/is-data-filter-map.validator.spec.ts
@@ -1,0 +1,67 @@
+import { IsDataFilterMap } from './is-data-filter-map.validator';
+
+describe('IsDataFilterMap', () => {
+  let validator: IsDataFilterMap;
+
+  beforeEach(() => {
+    validator = new IsDataFilterMap();
+  });
+
+  it('accepts undefined and null', () => {
+    expect(validator.validate(undefined)).toBe(true);
+    expect(validator.validate(null)).toBe(true);
+  });
+
+  it('accepts a flat object of string values with valid keys', () => {
+    expect(validator.validate({ template: 'otp_v2', locale: 'en' })).toBe(true);
+    expect(validator.validate({ a: 'x', _b: 'y', c1: 'z' })).toBe(true);
+  });
+
+  it('rejects arrays', () => {
+    expect(validator.validate([])).toBe(false);
+    expect(validator.validate(['template', 'otp_v2'])).toBe(false);
+  });
+
+  it('rejects non-object primitives', () => {
+    expect(validator.validate('string')).toBe(false);
+    expect(validator.validate(42)).toBe(false);
+    expect(validator.validate(true)).toBe(false);
+  });
+
+  it('rejects prototype-pollution keys directly invoked', () => {
+    // Express qs typically strips these before class-validator sees them, but the
+    // validator must still reject them as defense in depth.
+    // Object.fromEntries is required because a literal { __proto__: 'x' } sets the
+    // prototype slot, not an own property — Object.entries returns [] and the
+    // validator never sees the key.
+    expect(validator.validate(Object.fromEntries([['__proto__', 'x']]))).toBe(false);
+    expect(validator.validate(Object.fromEntries([['constructor', 'x']]))).toBe(false);
+    expect(validator.validate(Object.fromEntries([['prototype', 'x']]))).toBe(false);
+  });
+
+  it('rejects keys outside [a-zA-Z0-9_] or longer than 64 chars', () => {
+    expect(validator.validate({ 'bad-key': 'x' })).toBe(false);
+    expect(validator.validate({ 'bad key': 'x' })).toBe(false);
+    expect(validator.validate({ 'bad.key': 'x' })).toBe(false);
+    expect(validator.validate({ ['a'.repeat(65)]: 'x' })).toBe(false);
+    expect(validator.validate({ '': 'x' })).toBe(false);
+  });
+
+  it('rejects non-string values', () => {
+    expect(validator.validate({ k: 1 } as Record<string, unknown>)).toBe(false);
+    expect(validator.validate({ k: true } as Record<string, unknown>)).toBe(false);
+    expect(validator.validate({ k: null } as Record<string, unknown>)).toBe(false);
+    expect(validator.validate({ k: { nested: 'object' } } as Record<string, unknown>)).toBe(false);
+    expect(validator.validate({ k: ['a', 'b'] } as Record<string, unknown>)).toBe(false);
+  });
+
+  it('rejects empty string values and oversized values', () => {
+    expect(validator.validate({ k: '' })).toBe(false);
+    expect(validator.validate({ k: 'a'.repeat(256) })).toBe(false);
+    expect(validator.validate({ k: 'a'.repeat(255) })).toBe(true);
+  });
+
+  it('exposes a default message', () => {
+    expect(validator.defaultMessage()).toContain('data_filter');
+  });
+});

--- a/apps/api/src/common/validators/is-data-filter-map.validator.ts
+++ b/apps/api/src/common/validators/is-data-filter-map.validator.ts
@@ -1,8 +1,4 @@
-import {
-  ValidatorConstraint,
-  ValidatorConstraintInterface,
-  ValidationArguments,
-} from 'class-validator';
+import { ValidatorConstraint, ValidatorConstraintInterface } from 'class-validator';
 
 const KEY_RE = /^[a-zA-Z0-9_]{1,64}$/;
 const RESERVED_PROTO = new Set(['__proto__', 'constructor', 'prototype']);
@@ -10,7 +6,7 @@ const MAX_VALUE_LEN = 255;
 
 @ValidatorConstraint({ name: 'IsDataFilterMap', async: false })
 export class IsDataFilterMap implements ValidatorConstraintInterface {
-  validate(value: unknown, _args?: ValidationArguments): boolean {
+  validate(value: unknown): boolean {
     if (value === undefined || value === null) {
       return true;
     }
@@ -36,7 +32,7 @@ export class IsDataFilterMap implements ValidatorConstraintInterface {
     return true;
   }
 
-  defaultMessage(_args?: ValidationArguments): string {
+  defaultMessage(): string {
     return (
       'data_filter must be an object whose keys match ^[a-zA-Z0-9_]{1,64}$ and ' +
       `values are non-empty strings up to ${MAX_VALUE_LEN} chars`

--- a/apps/api/src/common/validators/is-data-filter-map.validator.ts
+++ b/apps/api/src/common/validators/is-data-filter-map.validator.ts
@@ -1,0 +1,45 @@
+import {
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+  ValidationArguments,
+} from 'class-validator';
+
+const KEY_RE = /^[a-zA-Z0-9_]{1,64}$/;
+const RESERVED_PROTO = new Set(['__proto__', 'constructor', 'prototype']);
+const MAX_VALUE_LEN = 255;
+
+@ValidatorConstraint({ name: 'IsDataFilterMap', async: false })
+export class IsDataFilterMap implements ValidatorConstraintInterface {
+  validate(value: unknown, _args?: ValidationArguments): boolean {
+    if (value === undefined || value === null) {
+      return true;
+    }
+
+    if (typeof value !== 'object' || Array.isArray(value)) {
+      return false;
+    }
+
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      if (RESERVED_PROTO.has(k)) {
+        return false;
+      }
+
+      if (!KEY_RE.test(k)) {
+        return false;
+      }
+
+      if (typeof v !== 'string' || v.length === 0 || v.length > MAX_VALUE_LEN) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  defaultMessage(_args?: ValidationArguments): string {
+    return (
+      'data_filter must be an object whose keys match ^[a-zA-Z0-9_]{1,64}$ and ' +
+      `values are non-empty strings up to ${MAX_VALUE_LEN} chars`
+    );
+  }
+}

--- a/apps/api/src/config/typeorm/configuration.ts
+++ b/apps/api/src/config/typeorm/configuration.ts
@@ -25,5 +25,6 @@ export default new DataSource({
   entities: [],
   migrations: ['src/database/migrations/**'],
   migrationsTableName: 'notify_migrations',
+  migrationsTransactionMode: 'each',
   synchronize: false,
 } as DataSourceOptions);

--- a/apps/api/src/database/migrations/1774000000000-jsonb-data-and-pg-trgm.ts
+++ b/apps/api/src/database/migrations/1774000000000-jsonb-data-and-pg-trgm.ts
@@ -1,0 +1,67 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Migrate notify_notifications.data, .result and notify_archived_notifications.data,
+ * .result columns from `json` to `jsonb` so they support GIN indexes and richer
+ * JSON predicates.
+ *
+ * Also installs the pg_trgm extension and adds whole-jsonb GIN indexes on the
+ * data columns. The pg_trgm trigram indexes on (data->>'subject'/'from'/'to')
+ * are added by the follow-up migration JsonbTrigramIndexes1774000000100, which
+ * uses CREATE INDEX CONCURRENTLY (and therefore must run outside a transaction).
+ *
+ * Caveats:
+ *   - ALTER COLUMN ... TYPE jsonb takes ACCESS EXCLUSIVE on the table and rewrites
+ *     all rows. Run during a maintenance window for large tables.
+ *   - jsonb deduplicates duplicate keys silently. The cast cannot fail on existing
+ *     duplicates, but any code that produced duplicate-key JSON in `data` or
+ *     `result` will now lose one of the duplicates after the migration.
+ *
+ * The default jsonb GIN opclass accelerates @> and ? operators (containment).
+ * It does NOT accelerate `->>` `ILIKE`; the pg_trgm trigram indexes do.
+ */
+export class JsonbDataAndPgTrgm1774000000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`CREATE EXTENSION IF NOT EXISTS pg_trgm`);
+
+    await queryRunner.query(
+      `ALTER TABLE "notify_notifications" ALTER COLUMN "data" TYPE jsonb USING "data"::jsonb`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "notify_notifications" ALTER COLUMN "result" TYPE jsonb USING "result"::jsonb`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "notify_archived_notifications" ALTER COLUMN "data" TYPE jsonb USING "data"::jsonb`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "notify_archived_notifications" ALTER COLUMN "result" TYPE jsonb USING "result"::jsonb`,
+    );
+
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_notify_notifications_data_gin" ON "notify_notifications" USING GIN ("data")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_notify_archived_notifications_data_gin" ON "notify_archived_notifications" USING GIN ("data")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_notify_archived_notifications_data_gin"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_notify_notifications_data_gin"`);
+
+    await queryRunner.query(
+      `ALTER TABLE "notify_archived_notifications" ALTER COLUMN "result" TYPE json USING "result"::json`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "notify_archived_notifications" ALTER COLUMN "data" TYPE json USING "data"::json`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "notify_notifications" ALTER COLUMN "result" TYPE json USING "result"::json`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "notify_notifications" ALTER COLUMN "data" TYPE json USING "data"::json`,
+    );
+
+    // The pg_trgm extension is left installed; harmless and may be used elsewhere.
+  }
+}

--- a/apps/api/src/database/migrations/1774000000000-jsonb-data-and-pg-trgm.ts
+++ b/apps/api/src/database/migrations/1774000000000-jsonb-data-and-pg-trgm.ts
@@ -16,9 +16,26 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
  *   - jsonb deduplicates duplicate keys silently. The cast cannot fail on existing
  *     duplicates, but any code that produced duplicate-key JSON in `data` or
  *     `result` will now lose one of the duplicates after the migration.
+ *   - Free-text search (CAST(data AS text) ILIKE :search) behaviour changes subtly:
+ *     json preserves original whitespace, key order, and duplicate keys; jsonb strips
+ *     whitespace, reorders keys, and deduplicates. Substring searches on values
+ *     (the common case) are unaffected. Searches that relied on specific key ordering
+ *     or whitespace in the serialized text will silently change results.
  *
  * The default jsonb GIN opclass accelerates @> and ? operators (containment).
  * It does NOT accelerate `->>` `ILIKE`; the pg_trgm trigram indexes do.
+ *
+ * Prerequisites / privileges:
+ *   - pg_trgm is a trusted extension (PostgreSQL 13+). Any role with CREATE on the
+ *     database can install it. On PG 12 and earlier, or on RDS without the
+ *     rds_superuser grant, the migration role must have superuser or explicit
+ *     CREATE EXTENSION privilege. Verify before running on staging/production.
+ *
+ * Rollback order:
+ *   If JsonbTrigramIndexes1774000000100 has already been applied, revert it first
+ *   (npm run typeorm:revert-migration) before reverting this migration. The trigram
+ *   expression indexes reference (data->>'...') which becomes invalid once the column
+ *   reverts to the json type.
  */
 export class JsonbDataAndPgTrgm1774000000000 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {

--- a/apps/api/src/database/migrations/1774000000100-jsonb-trigram-indexes.ts
+++ b/apps/api/src/database/migrations/1774000000100-jsonb-trigram-indexes.ts
@@ -1,0 +1,77 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Add pg_trgm GIN trigram expression indexes on the hot named-filter keys
+ * (data->>'subject', data->>'from', data->>'to') for both notify_notifications
+ * and notify_archived_notifications.
+ *
+ * These indexes accelerate `ILIKE '%v%'` (substring, case-insensitive) — exactly
+ * what NotificationDataFilterHelper emits. A plain B-tree on (data->>'k') cannot
+ * accelerate ILIKE; text_pattern_ops only helps case-sensitive prefix LIKE.
+ * Trigram indexes require ≥ 3 character search patterns to be useful; shorter
+ * patterns seq-scan regardless.
+ *
+ * CRITICAL: CREATE INDEX CONCURRENTLY cannot run inside a transaction. TypeORM
+ * wraps migrations transactionally by default, so we set `transaction = false`.
+ * This keeps the lock window minimal — these indexes can be large on production
+ * data and CONCURRENTLY avoids blocking writes during the build.
+ */
+export class JsonbTrigramIndexes1774000000100 implements MigrationInterface {
+  public readonly transaction = false;
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const indexes: Array<{ name: string; table: string; key: string }> = [
+      {
+        name: 'IDX_notify_notifications_data_subject_trgm',
+        table: 'notify_notifications',
+        key: 'subject',
+      },
+      {
+        name: 'IDX_notify_notifications_data_from_trgm',
+        table: 'notify_notifications',
+        key: 'from',
+      },
+      {
+        name: 'IDX_notify_notifications_data_to_trgm',
+        table: 'notify_notifications',
+        key: 'to',
+      },
+      {
+        name: 'IDX_notify_archived_notifications_data_subject_trgm',
+        table: 'notify_archived_notifications',
+        key: 'subject',
+      },
+      {
+        name: 'IDX_notify_archived_notifications_data_from_trgm',
+        table: 'notify_archived_notifications',
+        key: 'from',
+      },
+      {
+        name: 'IDX_notify_archived_notifications_data_to_trgm',
+        table: 'notify_archived_notifications',
+        key: 'to',
+      },
+    ];
+
+    for (const { name, table, key } of indexes) {
+      await queryRunner.query(
+        `CREATE INDEX CONCURRENTLY IF NOT EXISTS "${name}" ON "${table}" USING GIN (("data"->>'${key}') gin_trgm_ops)`,
+      );
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    const names = [
+      'IDX_notify_archived_notifications_data_to_trgm',
+      'IDX_notify_archived_notifications_data_from_trgm',
+      'IDX_notify_archived_notifications_data_subject_trgm',
+      'IDX_notify_notifications_data_to_trgm',
+      'IDX_notify_notifications_data_from_trgm',
+      'IDX_notify_notifications_data_subject_trgm',
+    ];
+
+    for (const name of names) {
+      await queryRunner.query(`DROP INDEX CONCURRENTLY IF EXISTS "${name}"`);
+    }
+  }
+}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -9,6 +9,7 @@ import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import * as packageJson from '../package.json';
 import { useContainer } from 'class-validator';
 import { urlencoded, json } from 'express';
+import { NestExpressApplication } from '@nestjs/platform-express';
 import { transformSwaggerToSnakeCase } from './common/utils/swagger-snake-case.transformer';
 
 const logDir = 'logs';
@@ -21,9 +22,12 @@ const configService = new ConfigService();
 const globalPrefix = configService.get('GLOBAL_API_PREFIX', '');
 
 async function bootstrap(): Promise<void> {
-  const app = await NestFactory.create(AppModule, {
+  const app = await NestFactory.create<NestExpressApplication>(AppModule, {
     logger: loggerConfig,
   });
+  // Enable qs-style deep-object query parsing so `?data_filter[key]=value` is parsed
+  // into req.query.data_filter = { key: 'value' }. Express 5 defaults to 'simple'.
+  app.set('query parser', 'extended');
   // used to inject services in validator decorators
   useContainer(app.select(AppModule), { fallbackOnErrors: true });
   const config = new DocumentBuilder()

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -59,7 +59,7 @@ async function bootstrap(): Promise<void> {
       { path: '/health', method: RequestMethod.GET },
     ],
   });
-  app.useGlobalPipes(new ValidationPipe());
+  app.useGlobalPipes(new ValidationPipe({ transform: true }));
   app.useGlobalFilters(new ProblemJsonFilter());
   app.use(json({ limit: configService.get('REQUEST_MAX_SIZE', '50mb') }));
   app.use(urlencoded({ extended: true, limit: configService.get('REQUEST_MAX_SIZE', '50mb') }));

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -59,7 +59,7 @@ async function bootstrap(): Promise<void> {
       { path: '/health', method: RequestMethod.GET },
     ],
   });
-  app.useGlobalPipes(new ValidationPipe({ transform: true }));
+  app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
   app.useGlobalFilters(new ProblemJsonFilter());
   app.use(json({ limit: configService.get('REQUEST_MAX_SIZE', '50mb') }));
   app.use(urlencoded({ extended: true, limit: configService.get('REQUEST_MAX_SIZE', '50mb') }));

--- a/apps/api/src/modules/archived-notifications/archived-notifications.controller.ts
+++ b/apps/api/src/modules/archived-notifications/archived-notifications.controller.ts
@@ -115,6 +115,13 @@ export class ArchivedNotificationsController {
       'Match data.text/html/message and nested template/push body fields. Type ≥ 3 chars for fast results.',
   })
   @ApiQuery({
+    name: 'template_name',
+    required: false,
+    type: String,
+    description:
+      'Match WhatsApp template name (data.template.name). Applies to 360Dialog and Twilio Business providers.',
+  })
+  @ApiQuery({
     name: 'data_filter',
     required: false,
     style: 'deepObject',
@@ -153,8 +160,9 @@ export class ArchivedNotificationsController {
       recipient: query.recipient,
       sender: query.sender,
       subject: query.subject,
-      messageBody: query.messageBody,
-      dataFilter: query.dataFilter,
+      messageBody: query.message_body,
+      templateName: query.template_name,
+      dataFilter: query.data_filter,
     };
     const { items, meta } =
       await this.archivedNotificationsService.getAllArchivedNotificationsAsDto(

--- a/apps/api/src/modules/archived-notifications/archived-notifications.controller.ts
+++ b/apps/api/src/modules/archived-notifications/archived-notifications.controller.ts
@@ -89,6 +89,41 @@ export class ArchivedNotificationsController {
     type: Number,
     description: 'Filter by provider',
   })
+  @ApiQuery({
+    name: 'recipient',
+    required: false,
+    type: String,
+    description: 'Match data.to/cc/bcc/target (string or array). Type ≥ 3 chars for fast results.',
+  })
+  @ApiQuery({
+    name: 'sender',
+    required: false,
+    type: String,
+    description: 'Match data.from. Type ≥ 3 chars for fast results.',
+  })
+  @ApiQuery({
+    name: 'subject',
+    required: false,
+    type: String,
+    description: 'Match data.subject. Type ≥ 3 chars for fast results.',
+  })
+  @ApiQuery({
+    name: 'message_body',
+    required: false,
+    type: String,
+    description:
+      'Match data.text/html/message and nested template/push body fields. Type ≥ 3 chars for fast results.',
+  })
+  @ApiQuery({
+    name: 'data_filter',
+    required: false,
+    style: 'deepObject',
+    explode: true,
+    schema: { type: 'object', additionalProperties: { type: 'string' } },
+    description:
+      'Top-level data JSON key/value pairs (data_filter[key]=value). Keys must match ' +
+      '^[a-zA-Z0-9_]{1,64}$. Multiple pairs are AND-combined.',
+  })
   @ApiResponse({
     status: 200,
     description: 'Paginated list of archived notifications',
@@ -115,6 +150,11 @@ export class ArchivedNotificationsController {
       dateFrom: dateFrom || undefined,
       providerId: providerId ? Number(providerId) : undefined,
       dateTo: dateTo || undefined,
+      recipient: query.recipient,
+      sender: query.sender,
+      subject: query.subject,
+      messageBody: query.messageBody,
+      dataFilter: query.dataFilter,
     };
     const { items, meta } =
       await this.archivedNotificationsService.getAllArchivedNotificationsAsDto(

--- a/apps/api/src/modules/archived-notifications/archived-notifications.service.ts
+++ b/apps/api/src/modules/archived-notifications/archived-notifications.service.ts
@@ -15,6 +15,7 @@ import { PaginationMeta, PaginationHelper } from 'src/common/utils/pagination.he
 import ms = require('ms');
 import { ArchivedNotificationResponseDto } from './dto/archived-notification-response.dto';
 import { ApplicationsService } from '../applications/applications.service';
+import { NotificationDataFilterHelper } from '../notifications/helpers/notification-data-filter.helper';
 
 @Injectable()
 export class ArchivedNotificationsService extends CoreService<ArchivedNotification> {
@@ -26,6 +27,7 @@ export class ArchivedNotificationsService extends CoreService<ArchivedNotificati
     private readonly configService: ConfigService,
     private dataSource: DataSource,
     private readonly applicationsService: ApplicationsService,
+    private readonly dataFilterHelper: NotificationDataFilterHelper,
   ) {
     super(archivedNotificationRepository);
   }
@@ -181,6 +183,11 @@ export class ArchivedNotificationsService extends CoreService<ArchivedNotificati
       providerId?: number;
       dateFrom?: string;
       dateTo?: string;
+      recipient?: string;
+      sender?: string;
+      subject?: string;
+      messageBody?: string;
+      dataFilter?: Record<string, string>;
     },
   ): Promise<{ items: ArchivedNotificationResponseDto[]; meta: PaginationMeta }> {
     let appIds = await this.applicationsService.getApplicationIdsByOrganization(organizationId);
@@ -239,6 +246,14 @@ export class ArchivedNotificationsService extends CoreService<ArchivedNotificati
       'archivedNotification',
       searchableFields,
       baseConditions,
+      (qb, alias) =>
+        this.dataFilterHelper.applyTo(qb, alias, {
+          recipient: filters?.recipient,
+          sender: filters?.sender,
+          subject: filters?.subject,
+          messageBody: filters?.messageBody,
+          dataFilter: filters?.dataFilter,
+        }),
     );
 
     return {

--- a/apps/api/src/modules/archived-notifications/archived-notifications.service.ts
+++ b/apps/api/src/modules/archived-notifications/archived-notifications.service.ts
@@ -187,6 +187,7 @@ export class ArchivedNotificationsService extends CoreService<ArchivedNotificati
       sender?: string;
       subject?: string;
       messageBody?: string;
+      templateName?: string;
       dataFilter?: Record<string, string>;
     },
   ): Promise<{ items: ArchivedNotificationResponseDto[]; meta: PaginationMeta }> {
@@ -252,6 +253,7 @@ export class ArchivedNotificationsService extends CoreService<ArchivedNotificati
           sender: filters?.sender,
           subject: filters?.subject,
           messageBody: filters?.messageBody,
+          templateName: filters?.templateName,
           dataFilter: filters?.dataFilter,
         }),
     );

--- a/apps/api/src/modules/archived-notifications/entities/archived-notification.entity.ts
+++ b/apps/api/src/modules/archived-notifications/entities/archived-notification.entity.ts
@@ -42,7 +42,7 @@ export class ArchivedNotification {
   @Field()
   channelType: number;
 
-  @Column({ type: 'json' })
+  @Column({ type: 'jsonb' })
   @IsObject()
   @Field(() => GraphQLJSONObject)
   data: Record<string, unknown>;
@@ -57,7 +57,7 @@ export class ArchivedNotification {
   @Field()
   deliveryStatus: number;
 
-  @Column({ type: 'json', nullable: true })
+  @Column({ type: 'jsonb', nullable: true })
   @IsObject()
   @IsOptional()
   @Field(() => GraphQLJSONObject, { nullable: true })

--- a/apps/api/src/modules/notifications/entities/notification.entity.ts
+++ b/apps/api/src/modules/notifications/entities/notification.entity.ts
@@ -47,7 +47,7 @@ export class Notification {
   @Field()
   channelType: number;
 
-  @Column({ type: 'json' })
+  @Column({ type: 'jsonb' })
   @IsObject()
   @Field(() => GraphQLJSONObject)
   data: Record<string, unknown>;
@@ -63,7 +63,7 @@ export class Notification {
   @Field()
   deliveryStatus: number;
 
-  @Column({ type: 'json', nullable: true })
+  @Column({ type: 'jsonb', nullable: true })
   @IsObject()
   @IsOptional()
   @Field(() => GraphQLJSONObject, { nullable: true })

--- a/apps/api/src/modules/notifications/helpers/notification-data-filter.helper.spec.ts
+++ b/apps/api/src/modules/notifications/helpers/notification-data-filter.helper.spec.ts
@@ -37,9 +37,9 @@ describe('NotificationDataFilterHelper', () => {
     helper.applyTo(qb, 'notification', { recipient: 'jane@example.com' });
     const [sql, params] = qb.getQueryAndParameters();
 
-    expect(sql).toContain("notification.data->'to'");
-    expect(sql).toContain("jsonb_array_elements_text(notification.data->'to')");
-    expect(sql).toContain("notification.data->>'target'");
+    expect(sql).toContain('"notification".data->\'to\'');
+    expect(sql).toContain('jsonb_array_elements_text("notification".data->\'to\')');
+    expect(sql).toContain('"notification".data->>\'target\'');
     expect(params).toContain('%jane@example.com%');
   });
 
@@ -48,7 +48,7 @@ describe('NotificationDataFilterHelper', () => {
     helper.applyTo(qb, 'notification', { sender: 'noreply@osmox.co' });
     const [sql, params] = qb.getQueryAndParameters();
 
-    expect(sql).toContain("notification.data->>'from' ILIKE");
+    expect(sql).toContain('"notification".data->>\'from\' ILIKE');
     expect(params).toContain('%noreply@osmox.co%');
   });
 
@@ -57,7 +57,7 @@ describe('NotificationDataFilterHelper', () => {
     helper.applyTo(qb, 'notification', { subject: 'Invoice' });
     const [sql, params] = qb.getQueryAndParameters();
 
-    expect(sql).toContain("notification.data->>'subject' ILIKE");
+    expect(sql).toContain('"notification".data->>\'subject\' ILIKE');
     expect(params).toContain('%Invoice%');
   });
 
@@ -66,11 +66,11 @@ describe('NotificationDataFilterHelper', () => {
     helper.applyTo(qb, 'notification', { messageBody: 'password' });
     const [sql, params] = qb.getQueryAndParameters();
 
-    expect(sql).toContain("notification.data->>'text'");
-    expect(sql).toContain("notification.data->>'html'");
-    expect(sql).toContain("notification.data->>'message'");
-    expect(sql).toContain("notification.data#>>'{text,body}'");
-    expect(sql).toContain("notification.data#>>'{message,default}'");
+    expect(sql).toContain('"notification".data->>\'text\'');
+    expect(sql).toContain('"notification".data->>\'html\'');
+    expect(sql).toContain('"notification".data->>\'message\'');
+    expect(sql).toContain('"notification".data#>>\'{text,body}\'');
+    expect(sql).toContain('"notification".data#>>\'{message,default}\'');
     expect(params).toContain('%password%');
   });
 
@@ -112,6 +112,15 @@ describe('NotificationDataFilterHelper', () => {
 
     // Base query has no WHERE because we didn't add any
     expect(generatedSql.toLowerCase()).not.toContain('where');
+  });
+
+  it("applies templateName against data->'template'->>'name' (360Dialog nested path)", () => {
+    const qb = buildQb();
+    helper.applyTo(qb, 'notification', { templateName: 'ir_incident' });
+    const [sql, params] = qb.getQueryAndParameters();
+
+    expect(sql).toContain("\"notification\".data->'template'->>'name' ILIKE");
+    expect(params).toContain('%ir_incident%');
   });
 
   it('combines multiple named filters via AND', () => {

--- a/apps/api/src/modules/notifications/helpers/notification-data-filter.helper.spec.ts
+++ b/apps/api/src/modules/notifications/helpers/notification-data-filter.helper.spec.ts
@@ -97,7 +97,7 @@ describe('NotificationDataFilterHelper', () => {
     helper.applyTo(qb, 'notification', {
       dataFilter: { ['bad-key!']: 'x', good_key: 'y' },
     });
-    const [sql, params] = qb.getQueryAndParameters();
+    const [, params] = qb.getQueryAndParameters();
 
     expect(params).toContain('good_key');
     expect(params).toContain('%y%');
@@ -108,10 +108,10 @@ describe('NotificationDataFilterHelper', () => {
   it('emits zero clauses when no filters are provided', () => {
     const qb = buildQb();
     helper.applyTo(qb, 'notification', {});
-    const [sql] = qb.getQueryAndParameters();
+    const [generatedSql] = qb.getQueryAndParameters();
 
     // Base query has no WHERE because we didn't add any
-    expect(sql.toLowerCase()).not.toContain('where');
+    expect(generatedSql.toLowerCase()).not.toContain('where');
   });
 
   it('combines multiple named filters via AND', () => {

--- a/apps/api/src/modules/notifications/helpers/notification-data-filter.helper.spec.ts
+++ b/apps/api/src/modules/notifications/helpers/notification-data-filter.helper.spec.ts
@@ -1,0 +1,132 @@
+import { DataSource, SelectQueryBuilder } from 'typeorm';
+import { NotificationDataFilterHelper } from './notification-data-filter.helper';
+
+class FakeEntity {}
+
+/**
+ * Builds a SelectQueryBuilder against a stand-alone DataSource that's never
+ * connected. We never call .getMany()/.getQueryAndParameters() — well, we call
+ * getQueryAndParameters() which does NOT require an active connection, so this
+ * works for asserting SQL fragments + bound parameters at unit-test speed.
+ */
+function buildQb(): SelectQueryBuilder<FakeEntity> {
+  const ds = new DataSource({
+    type: 'postgres',
+    host: 'localhost',
+    database: 'fake',
+    entities: [],
+    synchronize: false,
+    logging: false,
+  });
+
+  return ds
+    .createQueryBuilder()
+    .select('n.*')
+    .from('notify_notifications', 'notification') as unknown as SelectQueryBuilder<FakeEntity>;
+}
+
+describe('NotificationDataFilterHelper', () => {
+  let helper: NotificationDataFilterHelper;
+
+  beforeEach(() => {
+    helper = new NotificationDataFilterHelper();
+  });
+
+  it('applies recipient predicate covering to/cc/bcc/target', () => {
+    const qb = buildQb();
+    helper.applyTo(qb, 'notification', { recipient: 'jane@example.com' });
+    const [sql, params] = qb.getQueryAndParameters();
+
+    expect(sql).toContain("notification.data->'to'");
+    expect(sql).toContain("jsonb_array_elements_text(notification.data->'to')");
+    expect(sql).toContain("notification.data->>'target'");
+    expect(params).toContain('%jane@example.com%');
+  });
+
+  it('applies sender against data.from', () => {
+    const qb = buildQb();
+    helper.applyTo(qb, 'notification', { sender: 'noreply@osmox.co' });
+    const [sql, params] = qb.getQueryAndParameters();
+
+    expect(sql).toContain("notification.data->>'from' ILIKE");
+    expect(params).toContain('%noreply@osmox.co%');
+  });
+
+  it('applies subject against data.subject', () => {
+    const qb = buildQb();
+    helper.applyTo(qb, 'notification', { subject: 'Invoice' });
+    const [sql, params] = qb.getQueryAndParameters();
+
+    expect(sql).toContain("notification.data->>'subject' ILIKE");
+    expect(params).toContain('%Invoice%');
+  });
+
+  it('applies messageBody across text/html/message and nested paths', () => {
+    const qb = buildQb();
+    helper.applyTo(qb, 'notification', { messageBody: 'password' });
+    const [sql, params] = qb.getQueryAndParameters();
+
+    expect(sql).toContain("notification.data->>'text'");
+    expect(sql).toContain("notification.data->>'html'");
+    expect(sql).toContain("notification.data->>'message'");
+    expect(sql).toContain("notification.data#>>'{text,body}'");
+    expect(sql).toContain("notification.data#>>'{message,default}'");
+    expect(params).toContain('%password%');
+  });
+
+  it('applies dataFilter as parameterized key/value pairs and AND-combines', () => {
+    const qb = buildQb();
+    helper.applyTo(qb, 'notification', {
+      dataFilter: { template: 'otp_v2', locale: 'en' },
+    });
+    const [sql, params] = qb.getQueryAndParameters();
+
+    // Both keys and values are bound parameters (not interpolated)
+    expect(sql).toMatch(/data->>\$\d+ ILIKE \$\d+/);
+    expect(params).toContain('template');
+    expect(params).toContain('%otp_v2%');
+    expect(params).toContain('locale');
+    expect(params).toContain('%en%');
+    // Two separate andWhere clauses for the two pairs
+    const matches = sql.match(/data->>\$\d+ ILIKE \$\d+/g) ?? [];
+    expect(matches).toHaveLength(2);
+  });
+
+  it('silently drops dataFilter entries with regex-violating keys', () => {
+    const qb = buildQb();
+    helper.applyTo(qb, 'notification', {
+      dataFilter: { ['bad-key!']: 'x', good_key: 'y' },
+    });
+    const [sql, params] = qb.getQueryAndParameters();
+
+    expect(params).toContain('good_key');
+    expect(params).toContain('%y%');
+    // bad key is dropped silently — also the validator at the DTO boundary catches it
+    expect(params).not.toContain('bad-key!');
+  });
+
+  it('emits zero clauses when no filters are provided', () => {
+    const qb = buildQb();
+    helper.applyTo(qb, 'notification', {});
+    const [sql] = qb.getQueryAndParameters();
+
+    // Base query has no WHERE because we didn't add any
+    expect(sql.toLowerCase()).not.toContain('where');
+  });
+
+  it('combines multiple named filters via AND', () => {
+    const qb = buildQb();
+    helper.applyTo(qb, 'notification', {
+      recipient: 'jane',
+      subject: 'invoice',
+      sender: 'noreply',
+    });
+    const [sql] = qb.getQueryAndParameters();
+
+    // TypeORM uses AND to chain andWhere calls
+    expect(sql).toContain('AND');
+    expect(sql).toContain("data->>'subject'");
+    expect(sql).toContain("data->>'from'");
+    expect(sql).toContain("data->'to'");
+  });
+});

--- a/apps/api/src/modules/notifications/helpers/notification-data-filter.helper.ts
+++ b/apps/api/src/modules/notifications/helpers/notification-data-filter.helper.ts
@@ -6,7 +6,7 @@ import { SelectQueryBuilder } from 'typeorm';
  * The `data` shape varies per channel/provider:
  *   - Email:    { from, to, cc?, bcc?, subject, html, text, replyTo? }
  *   - SMS:      { to, message }
- *   - WhatsApp: { to, type, template?, text?: { body } }
+ *   - WhatsApp: { to, type, template?: { name, namespace, language, components }, text?: { body } }
  *   - Push:     { target, message: { GCM?, APNS?, default? } }
  *
  * All predicates use ILIKE '%v%' substring matching. The pg_trgm GIN expression
@@ -18,10 +18,16 @@ export interface NotificationDataFilters {
   sender?: string;
   subject?: string;
   messageBody?: string;
+  templateName?: string;
   dataFilter?: Record<string, string>;
 }
 
 const ADVANCED_KEY_RE = /^[a-zA-Z0-9_]{1,64}$/;
+
+/** Double-quote an alias so PostgreSQL preserves case in raw SQL strings. */
+function q(alias: string): string {
+  return `"${alias}"`;
+}
 
 @Injectable()
 export class NotificationDataFilterHelper {
@@ -33,13 +39,13 @@ export class NotificationDataFilterHelper {
     }
 
     if (filters.sender) {
-      qb.andWhere(`${alias}.data->>'from' ILIKE :ndf_sender`, {
+      qb.andWhere(`${q(alias)}.data->>'from' ILIKE :ndf_sender`, {
         ndf_sender: `%${filters.sender}%`,
       });
     }
 
     if (filters.subject) {
-      qb.andWhere(`${alias}.data->>'subject' ILIKE :ndf_subject`, {
+      qb.andWhere(`${q(alias)}.data->>'subject' ILIKE :ndf_subject`, {
         ndf_subject: `%${filters.subject}%`,
       });
     }
@@ -47,6 +53,12 @@ export class NotificationDataFilterHelper {
     if (filters.messageBody) {
       qb.andWhere(this.messageBodyPredicate(alias), {
         ndf_messageBody: `%${filters.messageBody}%`,
+      });
+    }
+
+    if (filters.templateName) {
+      qb.andWhere(`${q(alias)}.data->'template'->>'name' ILIKE :ndf_templateName`, {
+        ndf_templateName: `%${filters.templateName}%`,
       });
     }
 
@@ -59,7 +71,7 @@ export class NotificationDataFilterHelper {
           return;
         }
 
-        qb.andWhere(`${alias}.data->>:ndf_dfk_${i} ILIKE :ndf_dfv_${i}`, {
+        qb.andWhere(`${q(alias)}.data->>:ndf_dfk_${i} ILIKE :ndf_dfv_${i}`, {
           [`ndf_dfk_${i}`]: key,
           [`ndf_dfv_${i}`]: `%${value}%`,
         });
@@ -70,24 +82,28 @@ export class NotificationDataFilterHelper {
   private recipientPredicate(alias: string): string {
     // Match `to`/`cc`/`bcc` whether stored as scalar string or array of strings,
     // plus push `target`. jsonb_typeof guards skip undefined or unexpected types.
+    const a = q(alias);
+
     return `(
-      (jsonb_typeof(${alias}.data->'to')  = 'string' AND ${alias}.data->>'to'  ILIKE :ndf_recipient) OR
-      (jsonb_typeof(${alias}.data->'to')  = 'array'  AND EXISTS (SELECT 1 FROM jsonb_array_elements_text(${alias}.data->'to')  AS x(v) WHERE x.v ILIKE :ndf_recipient)) OR
-      (jsonb_typeof(${alias}.data->'cc')  = 'string' AND ${alias}.data->>'cc'  ILIKE :ndf_recipient) OR
-      (jsonb_typeof(${alias}.data->'cc')  = 'array'  AND EXISTS (SELECT 1 FROM jsonb_array_elements_text(${alias}.data->'cc')  AS x(v) WHERE x.v ILIKE :ndf_recipient)) OR
-      (jsonb_typeof(${alias}.data->'bcc') = 'string' AND ${alias}.data->>'bcc' ILIKE :ndf_recipient) OR
-      (jsonb_typeof(${alias}.data->'bcc') = 'array'  AND EXISTS (SELECT 1 FROM jsonb_array_elements_text(${alias}.data->'bcc') AS x(v) WHERE x.v ILIKE :ndf_recipient)) OR
-      (${alias}.data->>'target' ILIKE :ndf_recipient)
+      (jsonb_typeof(${a}.data->'to')  = 'string' AND ${a}.data->>'to'  ILIKE :ndf_recipient) OR
+      (jsonb_typeof(${a}.data->'to')  = 'array'  AND EXISTS (SELECT 1 FROM jsonb_array_elements_text(${a}.data->'to')  AS x(v) WHERE x.v ILIKE :ndf_recipient)) OR
+      (jsonb_typeof(${a}.data->'cc')  = 'string' AND ${a}.data->>'cc'  ILIKE :ndf_recipient) OR
+      (jsonb_typeof(${a}.data->'cc')  = 'array'  AND EXISTS (SELECT 1 FROM jsonb_array_elements_text(${a}.data->'cc')  AS x(v) WHERE x.v ILIKE :ndf_recipient)) OR
+      (jsonb_typeof(${a}.data->'bcc') = 'string' AND ${a}.data->>'bcc' ILIKE :ndf_recipient) OR
+      (jsonb_typeof(${a}.data->'bcc') = 'array'  AND EXISTS (SELECT 1 FROM jsonb_array_elements_text(${a}.data->'bcc') AS x(v) WHERE x.v ILIKE :ndf_recipient)) OR
+      (${a}.data->>'target' ILIKE :ndf_recipient)
     )`;
   }
 
   private messageBodyPredicate(alias: string): string {
+    const a = q(alias);
+
     return `(
-      ${alias}.data->>'text'    ILIKE :ndf_messageBody OR
-      ${alias}.data->>'html'    ILIKE :ndf_messageBody OR
-      ${alias}.data->>'message' ILIKE :ndf_messageBody OR
-      ${alias}.data#>>'{text,body}'        ILIKE :ndf_messageBody OR
-      ${alias}.data#>>'{message,default}'  ILIKE :ndf_messageBody
+      ${a}.data->>'text'    ILIKE :ndf_messageBody OR
+      ${a}.data->>'html'    ILIKE :ndf_messageBody OR
+      ${a}.data->>'message' ILIKE :ndf_messageBody OR
+      ${a}.data#>>'{text,body}'        ILIKE :ndf_messageBody OR
+      ${a}.data#>>'{message,default}'  ILIKE :ndf_messageBody
     )`;
   }
 }

--- a/apps/api/src/modules/notifications/helpers/notification-data-filter.helper.ts
+++ b/apps/api/src/modules/notifications/helpers/notification-data-filter.helper.ts
@@ -25,11 +25,7 @@ const ADVANCED_KEY_RE = /^[a-zA-Z0-9_]{1,64}$/;
 
 @Injectable()
 export class NotificationDataFilterHelper {
-  applyTo<T>(
-    qb: SelectQueryBuilder<T>,
-    alias: string,
-    filters: NotificationDataFilters,
-  ): void {
+  applyTo<T>(qb: SelectQueryBuilder<T>, alias: string, filters: NotificationDataFilters): void {
     if (filters.recipient) {
       qb.andWhere(this.recipientPredicate(alias), {
         ndf_recipient: `%${filters.recipient}%`,

--- a/apps/api/src/modules/notifications/helpers/notification-data-filter.helper.ts
+++ b/apps/api/src/modules/notifications/helpers/notification-data-filter.helper.ts
@@ -1,0 +1,97 @@
+import { Injectable } from '@nestjs/common';
+import { SelectQueryBuilder } from 'typeorm';
+
+/**
+ * Property-specific filters applied against the notification `data` JSON column.
+ * The `data` shape varies per channel/provider:
+ *   - Email:    { from, to, cc?, bcc?, subject, html, text, replyTo? }
+ *   - SMS:      { to, message }
+ *   - WhatsApp: { to, type, template?, text?: { body } }
+ *   - Push:     { target, message: { GCM?, APNS?, default? } }
+ *
+ * All predicates use ILIKE '%v%' substring matching. The pg_trgm GIN expression
+ * indexes on (data->>'subject'/'from'/'to') accelerate substring search; trigram
+ * indexes require ≥ 3 character search patterns to be useful.
+ */
+export interface NotificationDataFilters {
+  recipient?: string;
+  sender?: string;
+  subject?: string;
+  messageBody?: string;
+  dataFilter?: Record<string, string>;
+}
+
+const ADVANCED_KEY_RE = /^[a-zA-Z0-9_]{1,64}$/;
+
+@Injectable()
+export class NotificationDataFilterHelper {
+  applyTo<T>(
+    qb: SelectQueryBuilder<T>,
+    alias: string,
+    filters: NotificationDataFilters,
+  ): void {
+    if (filters.recipient) {
+      qb.andWhere(this.recipientPredicate(alias), {
+        ndf_recipient: `%${filters.recipient}%`,
+      });
+    }
+
+    if (filters.sender) {
+      qb.andWhere(`${alias}.data->>'from' ILIKE :ndf_sender`, {
+        ndf_sender: `%${filters.sender}%`,
+      });
+    }
+
+    if (filters.subject) {
+      qb.andWhere(`${alias}.data->>'subject' ILIKE :ndf_subject`, {
+        ndf_subject: `%${filters.subject}%`,
+      });
+    }
+
+    if (filters.messageBody) {
+      qb.andWhere(this.messageBodyPredicate(alias), {
+        ndf_messageBody: `%${filters.messageBody}%`,
+      });
+    }
+
+    if (filters.dataFilter) {
+      Object.entries(filters.dataFilter).forEach(([key, value], i) => {
+        // Defense in depth: keys are already validated by IsDataFilterMap at the
+        // DTO boundary, but we revalidate here in case the helper is invoked from
+        // a path that bypasses the DTO.
+        if (!ADVANCED_KEY_RE.test(key)) {
+          return;
+        }
+
+        qb.andWhere(`${alias}.data->>:ndf_dfk_${i} ILIKE :ndf_dfv_${i}`, {
+          [`ndf_dfk_${i}`]: key,
+          [`ndf_dfv_${i}`]: `%${value}%`,
+        });
+      });
+    }
+  }
+
+  private recipientPredicate(alias: string): string {
+    // Match `to`/`cc`/`bcc` whether stored as scalar string or array of strings,
+    // plus push `target`. jsonb_typeof guards skip undefined or unexpected types.
+    return `(
+      (jsonb_typeof(${alias}.data->'to')  = 'string' AND ${alias}.data->>'to'  ILIKE :ndf_recipient) OR
+      (jsonb_typeof(${alias}.data->'to')  = 'array'  AND EXISTS (SELECT 1 FROM jsonb_array_elements_text(${alias}.data->'to')  AS x(v) WHERE x.v ILIKE :ndf_recipient)) OR
+      (jsonb_typeof(${alias}.data->'cc')  = 'string' AND ${alias}.data->>'cc'  ILIKE :ndf_recipient) OR
+      (jsonb_typeof(${alias}.data->'cc')  = 'array'  AND EXISTS (SELECT 1 FROM jsonb_array_elements_text(${alias}.data->'cc')  AS x(v) WHERE x.v ILIKE :ndf_recipient)) OR
+      (jsonb_typeof(${alias}.data->'bcc') = 'string' AND ${alias}.data->>'bcc' ILIKE :ndf_recipient) OR
+      (jsonb_typeof(${alias}.data->'bcc') = 'array'  AND EXISTS (SELECT 1 FROM jsonb_array_elements_text(${alias}.data->'bcc') AS x(v) WHERE x.v ILIKE :ndf_recipient)) OR
+      (${alias}.data->>'target' ILIKE :ndf_recipient)
+    )`;
+  }
+
+  private messageBodyPredicate(alias: string): string {
+    return `(
+      ${alias}.data->>'text'    ILIKE :ndf_messageBody OR
+      ${alias}.data->>'html'    ILIKE :ndf_messageBody OR
+      ${alias}.data->>'message' ILIKE :ndf_messageBody OR
+      ${alias}.data#>>'{text,body}'        ILIKE :ndf_messageBody OR
+      ${alias}.data#>>'{message,default}'  ILIKE :ndf_messageBody
+    )`;
+  }
+}

--- a/apps/api/src/modules/notifications/notifications.controller.ts
+++ b/apps/api/src/modules/notifications/notifications.controller.ts
@@ -124,6 +124,13 @@ export class NotificationsController {
       'Match data.text/html/message and nested template/push body fields. Type ≥ 3 chars for fast results.',
   })
   @ApiQuery({
+    name: 'template_name',
+    required: false,
+    type: String,
+    description:
+      'Match WhatsApp template name (data.template.name). Applies to 360Dialog and Twilio Business providers.',
+  })
+  @ApiQuery({
     name: 'data_filter',
     required: false,
     style: 'deepObject',
@@ -162,8 +169,9 @@ export class NotificationsController {
       recipient: query.recipient,
       sender: query.sender,
       subject: query.subject,
-      messageBody: query.messageBody,
-      dataFilter: query.dataFilter,
+      messageBody: query.message_body,
+      templateName: query.template_name,
+      dataFilter: query.data_filter,
     };
     const { items, meta } = await this.notificationsService.getAllNotificationsAsDto(
       query,

--- a/apps/api/src/modules/notifications/notifications.controller.ts
+++ b/apps/api/src/modules/notifications/notifications.controller.ts
@@ -98,6 +98,41 @@ export class NotificationsController {
     type: Number,
     description: 'Filter by provider',
   })
+  @ApiQuery({
+    name: 'recipient',
+    required: false,
+    type: String,
+    description: 'Match data.to/cc/bcc/target (string or array). Type ≥ 3 chars for fast results.',
+  })
+  @ApiQuery({
+    name: 'sender',
+    required: false,
+    type: String,
+    description: 'Match data.from. Type ≥ 3 chars for fast results.',
+  })
+  @ApiQuery({
+    name: 'subject',
+    required: false,
+    type: String,
+    description: 'Match data.subject. Type ≥ 3 chars for fast results.',
+  })
+  @ApiQuery({
+    name: 'message_body',
+    required: false,
+    type: String,
+    description:
+      'Match data.text/html/message and nested template/push body fields. Type ≥ 3 chars for fast results.',
+  })
+  @ApiQuery({
+    name: 'data_filter',
+    required: false,
+    style: 'deepObject',
+    explode: true,
+    schema: { type: 'object', additionalProperties: { type: 'string' } },
+    description:
+      'Top-level data JSON key/value pairs (data_filter[key]=value). Keys must match ' +
+      '^[a-zA-Z0-9_]{1,64}$. Multiple pairs are AND-combined.',
+  })
   @ApiResponse({
     status: 200,
     description: 'Paginated list of notifications',
@@ -124,6 +159,11 @@ export class NotificationsController {
       providerId: providerId ? Number(providerId) : undefined,
       dateFrom: dateFrom || undefined,
       dateTo: dateTo || undefined,
+      recipient: query.recipient,
+      sender: query.sender,
+      subject: query.subject,
+      messageBody: query.messageBody,
+      dataFilter: query.dataFilter,
     };
     const { items, meta } = await this.notificationsService.getAllNotificationsAsDto(
       query,

--- a/apps/api/src/modules/notifications/notifications.module.ts
+++ b/apps/api/src/modules/notifications/notifications.module.ts
@@ -46,6 +46,7 @@ import { RequestLoggerMiddleware } from 'src/common/logger/request-logger.middle
 import { ProviderChainsModule } from '../provider-chains/provider-chains.module';
 import { ProviderChainMembersModule } from '../provider-chain-members/provider-chain-members.module';
 import { MasterProvidersModule } from '../master-providers/master-providers.module';
+import { NotificationDataFilterHelper } from './helpers/notification-data-filter.helper';
 
 const providerModules = [
   MailgunModule,
@@ -103,6 +104,7 @@ const consumers = [
     QueueService,
     ArchivedNotificationsService,
     RequestLoggerMiddleware,
+    NotificationDataFilterHelper,
     ...consumers,
   ],
   exports: [
@@ -112,6 +114,7 @@ const consumers = [
     ApplicationsService,
     UsersService,
     QueueService,
+    NotificationDataFilterHelper,
     ...consumers,
   ],
   controllers: [NotificationsController],

--- a/apps/api/src/modules/notifications/notifications.service.ts
+++ b/apps/api/src/modules/notifications/notifications.service.ts
@@ -592,6 +592,7 @@ export class NotificationsService extends CoreService<Notification> {
       sender?: string;
       subject?: string;
       messageBody?: string;
+      templateName?: string;
       dataFilter?: Record<string, string>;
     },
   ): Promise<{ items: NotificationResponseDto[]; meta: PaginationMeta }> {
@@ -656,6 +657,7 @@ export class NotificationsService extends CoreService<Notification> {
           sender: filters?.sender,
           subject: filters?.subject,
           messageBody: filters?.messageBody,
+          templateName: filters?.templateName,
           dataFilter: filters?.dataFilter,
         }),
     );

--- a/apps/api/src/modules/notifications/notifications.service.ts
+++ b/apps/api/src/modules/notifications/notifications.service.ts
@@ -34,6 +34,7 @@ import { Provider } from '../providers/entities/provider.entity';
 import { ProviderChain } from '../provider-chains/entities/provider-chain.entity';
 import { ProviderChainMembersService } from '../provider-chain-members/provider-chain-members.service';
 import { NotificationResponseDto } from './dto/notification-response.dto';
+import { NotificationDataFilterHelper } from './helpers/notification-data-filter.helper';
 
 @Injectable()
 export class NotificationsService extends CoreService<Notification> {
@@ -52,6 +53,7 @@ export class NotificationsService extends CoreService<Notification> {
     private readonly archivedNotificationsService: ArchivedNotificationsService,
     private readonly providerChainsService: ProviderChainsService,
     private readonly providerChainMembersService: ProviderChainMembersService,
+    private readonly dataFilterHelper: NotificationDataFilterHelper,
   ) {
     super(notificationRepository);
   }
@@ -586,6 +588,11 @@ export class NotificationsService extends CoreService<Notification> {
       providerId?: number;
       dateFrom?: string;
       dateTo?: string;
+      recipient?: string;
+      sender?: string;
+      subject?: string;
+      messageBody?: string;
+      dataFilter?: Record<string, string>;
     },
   ): Promise<{ items: NotificationResponseDto[]; meta: PaginationMeta }> {
     let appIds = await this.applicationsService.getApplicationIdsByOrganization(organizationId);
@@ -643,6 +650,14 @@ export class NotificationsService extends CoreService<Notification> {
       'notification',
       searchableFields,
       baseConditions,
+      (qb, alias) =>
+        this.dataFilterHelper.applyTo(qb, alias, {
+          recipient: filters?.recipient,
+          sender: filters?.sender,
+          subject: filters?.subject,
+          messageBody: filters?.messageBody,
+          dataFilter: filters?.dataFilter,
+        }),
     );
 
     return {

--- a/apps/portal/CLAUDE.md
+++ b/apps/portal/CLAUDE.md
@@ -314,6 +314,44 @@ export type Application = components['schemas']['ApplicationResponseDto'];
 // export interface Application { applicationId: number; ... }
 ```
 
+### snake_case applies to request shapes too — NOT just responses
+
+The same snake_case rule covers **anything that crosses the HTTP boundary**, including:
+
+- Filter / query-param interfaces (e.g. `NotificationFilters`)
+- Request body DTOs sent to POST / PATCH / PUT endpoints
+- Sort field names passed in `?sort=` query params
+
+The portal must NOT translate field names at the HTTP boundary. One name, end-to-end.
+
+Why: keeps `filters.field_name` ↔ `params.set('field_name', ...)` ↔ `?field_name=...` ↔ backend DTO field aligned. Translation layers create drift, drop fields silently when one side is renamed, and add no value.
+
+```typescript
+// CORRECT - snake_case all the way through
+export interface NotificationFilters {
+  channel_type?: number;
+  delivery_status?: number;
+  date_from?: string;
+  message_body?: string;
+  data_filter?: Array<{ key: string; value: string }>;
+}
+
+if (filters?.channel_type) {
+  params = params.set('channel_type', filters.channel_type);
+}
+
+// WRONG - camelCase in TS with translation at the boundary
+// export interface NotificationFilters {
+//   channelType?: number;       // adds a translation step
+//   deliveryStatus?: number;    // breaks 1:1 alignment with API
+// }
+// if (filters?.channelType) {
+//   params = params.set('channel_type', filters.channelType);
+// }
+```
+
+This rule **overrides** generic TypeScript-idiom advice that says "use camelCase in TS, convert at boundary." For this codebase, project alignment with the API contract wins.
+
 ### Type Override Pattern (for backend serialization bugs only)
 
 ```typescript

--- a/apps/portal/docker-compose.yml
+++ b/apps/portal/docker-compose.yml
@@ -11,4 +11,4 @@ services:
     container_name: osmox-portal
     restart: unless-stopped
     ports:
-      - '127.0.0.1:${SERVER_PORT}:80'
+      - '127.0.0.1:4200:80'

--- a/apps/portal/docker-compose.yml
+++ b/apps/portal/docker-compose.yml
@@ -11,4 +11,4 @@ services:
     container_name: osmox-portal
     restart: unless-stopped
     ports:
-      - '127.0.0.1:4200:80'
+      - '127.0.0.1:${SERVER_PORT}:80'

--- a/apps/portal/eslint.config.js
+++ b/apps/portal/eslint.config.js
@@ -5,7 +5,7 @@ const angular = require('angular-eslint');
 
 module.exports = tseslint.config(
   {
-    ignores: ['desktop-reference/**/*', '.angular/**/*', 'src/app/core/types/api.types.ts'],
+    ignores: ['desktop-reference/**/*', '.angular/**/*', 'dist/**/*', 'src/app/core/types/api.types.ts'],
   },
   {
     files: ['**/*.ts'],

--- a/apps/portal/src/app/core/models/notification-filters.model.ts
+++ b/apps/portal/src/app/core/models/notification-filters.model.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared filter shape for the Notifications and Archived Notifications list pages.
+ * Property names use camelCase here; HTTP services convert to snake_case at the
+ * boundary (recipient, sender, subject, message_body, data_filter[key]).
+ */
+export interface NotificationFilters {
+  channelType?: number;
+  deliveryStatus?: number;
+  applicationId?: number;
+  providerId?: number;
+  search?: string;
+  dateFrom?: string;
+  dateTo?: string;
+  sort?: string;
+  order?: 'asc' | 'desc';
+
+  // Property-specific filters against the notification `data` JSON column.
+  recipient?: string;
+  sender?: string;
+  subject?: string;
+  messageBody?: string;
+
+  /**
+   * Free-form key/value pairs against top-level `data` keys. Keys are
+   * validated server-side against ^[a-zA-Z0-9_]{1,64}$. Multiple rows are
+   * AND-combined.
+   */
+  advancedFilters?: AdvancedFilterRow[];
+}
+
+export interface AdvancedFilterRow {
+  /** Stable identifier for *ngFor track-by, since (key,value) can both be empty during edits. */
+  id: string;
+  key: string;
+  value: string;
+}

--- a/apps/portal/src/app/core/models/notification-filters.model.ts
+++ b/apps/portal/src/app/core/models/notification-filters.model.ts
@@ -1,16 +1,17 @@
 /**
  * Shared filter shape for the Notifications and Archived Notifications list pages.
- * Property names use camelCase here; HTTP services convert to snake_case at the
- * boundary (recipient, sender, subject, message_body, data_filter[key]).
+ * Property names match the API query-param names verbatim (snake_case end-to-end).
+ * No translation at the HTTP boundary — filters.field_name maps directly to
+ * params.set('field_name', ...) and to the backend DTO field.
  */
 export interface NotificationFilters {
-  channelType?: number;
-  deliveryStatus?: number;
-  applicationId?: number;
-  providerId?: number;
+  channel_type?: number;
+  delivery_status?: number;
+  application_id?: number;
+  provider_id?: number;
   search?: string;
-  dateFrom?: string;
-  dateTo?: string;
+  date_from?: string;
+  date_to?: string;
   sort?: string;
   order?: 'asc' | 'desc';
 
@@ -18,7 +19,9 @@ export interface NotificationFilters {
   recipient?: string;
   sender?: string;
   subject?: string;
-  messageBody?: string;
+  message_body?: string;
+  /** WhatsApp 360Dialog / Twilio Business template name (data.template.name). */
+  template_name?: string;
 
   /**
    * Free-form key/value pairs against top-level `data` keys. Keys are

--- a/apps/portal/src/app/features/archived-notifications/pages/archived-list.html
+++ b/apps/portal/src/app/features/archived-notifications/pages/archived-list.html
@@ -81,6 +81,11 @@
             placeholder="Search data..."
           />
         </p-iconfield>
+        <app-notification-filters
+          [filters]="composedFilters()"
+          (filtersChange)="onPropertyFiltersChange($event)"
+          (clear)="onPropertyFiltersClear()"
+        />
         <p-button
           icon="pi pi-filter-slash"
           [rounded]="true"

--- a/apps/portal/src/app/features/archived-notifications/pages/archived-list.html
+++ b/apps/portal/src/app/features/archived-notifications/pages/archived-list.html
@@ -71,16 +71,6 @@
     </ng-template>
     <ng-template #end>
       <div class="flex items-center gap-2">
-        <p-iconfield iconPosition="left">
-          <p-inputicon class="pi pi-search" />
-          <input
-            pInputText
-            type="text"
-            [value]="searchText()"
-            (input)="onSearchInput($event)"
-            placeholder="Search data..."
-          />
-        </p-iconfield>
         <app-notification-filters
           [filters]="composedFilters()"
           (filtersChange)="onPropertyFiltersChange($event)"

--- a/apps/portal/src/app/features/archived-notifications/pages/archived-list.ts
+++ b/apps/portal/src/app/features/archived-notifications/pages/archived-list.ts
@@ -26,6 +26,7 @@ import { PaginationComponent } from '../../../shared/components/pagination/pagin
 import { StatusBadgeComponent } from '../../../shared/components/status-badge/status-badge';
 import { ChannelTypePipe } from '../../../shared/pipes/channel-type.pipe';
 import { JsonViewerDialog } from '../../../shared/components/json-viewer-dialog/json-viewer-dialog';
+import { NotificationFiltersComponent } from '../../../shared/components/notification-filters/notification-filters';
 import {
   ArchivedNotificationsService,
   NotificationFilters,
@@ -62,6 +63,7 @@ import { ChannelType, DeliveryStatus } from '../../../core/constants/notificatio
     StatusBadgeComponent,
     ChannelTypePipe,
     JsonViewerDialog,
+    NotificationFiltersComponent,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './archived-list.html',
@@ -115,6 +117,15 @@ export class ArchivedListComponent implements OnInit {
   readonly selectedDateTo = signal<Date | null>(null);
   readonly searchText = signal('');
 
+  // Property-specific filters from the shared notification-filters drawer.
+  readonly propertyFilters = signal<NotificationFilters>({});
+
+  // Snapshot of applied named/advanced filters passed back into the shared
+  // component so chip rendering and drawer hydration stay in sync.
+  readonly composedFilters = computed<NotificationFilters>(() => ({
+    ...this.propertyFilters(),
+  }));
+
   // Sort state (signals keep PrimeNG table in sync to prevent re-sort on data change)
   readonly tableSortField = signal('created_on');
   readonly tableSortOrder = signal<number>(-1);
@@ -164,19 +175,19 @@ export class ArchivedListComponent implements OnInit {
     const filters: NotificationFilters = {};
 
     if (this.selectedChannelType()) {
-      filters.channel_type = this.selectedChannelType()!;
+      filters.channelType = this.selectedChannelType()!;
     }
 
     if (this.selectedDeliveryStatus()) {
-      filters.delivery_status = this.selectedDeliveryStatus()!;
+      filters.deliveryStatus = this.selectedDeliveryStatus()!;
     }
 
     if (this.selectedApplicationId()) {
-      filters.application_id = this.selectedApplicationId()!;
+      filters.applicationId = this.selectedApplicationId()!;
     }
 
     if (this.selectedProviderId()) {
-      filters.provider_id = this.selectedProviderId()!;
+      filters.providerId = this.selectedProviderId()!;
     }
 
     if (this.searchText().trim()) {
@@ -184,12 +195,24 @@ export class ArchivedListComponent implements OnInit {
     }
 
     if (this.selectedDateFrom()) {
-      filters.date_from = this.selectedDateFrom()!.toISOString();
+      filters.dateFrom = this.selectedDateFrom()!.toISOString();
     }
 
     if (this.selectedDateTo()) {
-      filters.date_to = this.selectedDateTo()!.toISOString();
+      filters.dateTo = this.selectedDateTo()!.toISOString();
     }
+
+    const property = this.propertyFilters();
+
+    if (property.recipient) filters.recipient = property.recipient;
+
+    if (property.sender) filters.sender = property.sender;
+
+    if (property.subject) filters.subject = property.subject;
+
+    if (property.messageBody) filters.messageBody = property.messageBody;
+
+    if (property.advancedFilters?.length) filters.advancedFilters = property.advancedFilters;
 
     if (this.currentSort) {
       filters.sort = this.currentSort;
@@ -283,6 +306,25 @@ export class ArchivedListComponent implements OnInit {
     this.selectedDateFrom.set(null);
     this.selectedDateTo.set(null);
     this.searchText.set('');
+    this.propertyFilters.set({});
+    this.currentPage = 1;
+    this.loadNotifications();
+  }
+
+  onPropertyFiltersChange(updated: NotificationFilters): void {
+    this.propertyFilters.set({
+      recipient: updated.recipient,
+      sender: updated.sender,
+      subject: updated.subject,
+      messageBody: updated.messageBody,
+      advancedFilters: updated.advancedFilters,
+    });
+    this.currentPage = 1;
+    this.loadNotifications();
+  }
+
+  onPropertyFiltersClear(): void {
+    this.propertyFilters.set({});
     this.currentPage = 1;
     this.loadNotifications();
   }

--- a/apps/portal/src/app/features/archived-notifications/pages/archived-list.ts
+++ b/apps/portal/src/app/features/archived-notifications/pages/archived-list.ts
@@ -17,8 +17,6 @@ import { DialogModule } from 'primeng/dialog';
 import { SelectModule } from 'primeng/select';
 import { TooltipModule } from 'primeng/tooltip';
 import { ToolbarModule } from 'primeng/toolbar';
-import { IconFieldModule } from 'primeng/iconfield';
-import { InputIconModule } from 'primeng/inputicon';
 import { InputTextModule } from 'primeng/inputtext';
 import { DatePickerModule } from 'primeng/datepicker';
 import { MessageService } from 'primeng/api';
@@ -55,8 +53,6 @@ import { ChannelType, DeliveryStatus } from '../../../core/constants/notificatio
     SelectModule,
     TooltipModule,
     ToolbarModule,
-    IconFieldModule,
-    InputIconModule,
     InputTextModule,
     DatePickerModule,
     PaginationComponent,
@@ -115,7 +111,7 @@ export class ArchivedListComponent implements OnInit {
   readonly selectedProviderId = signal<number | null>(null);
   readonly selectedDateFrom = signal<Date | null>(null);
   readonly selectedDateTo = signal<Date | null>(null);
-  readonly searchText = signal('');
+
 
   // Property-specific filters from the shared notification-filters drawer.
   readonly propertyFilters = signal<NotificationFilters>({});
@@ -137,7 +133,7 @@ export class ArchivedListComponent implements OnInit {
   readonly jsonDialogData = signal<Record<string, unknown> | null>(null);
   readonly jsonDialogHeader = signal('JSON Data');
 
-  private searchTimeout: ReturnType<typeof setTimeout> | null = null;
+
 
   ngOnInit(): void {
     this.loadNotifications();
@@ -175,34 +171,33 @@ export class ArchivedListComponent implements OnInit {
     const filters: NotificationFilters = {};
 
     if (this.selectedChannelType()) {
-      filters.channelType = this.selectedChannelType()!;
+      filters.channel_type = this.selectedChannelType()!;
     }
 
     if (this.selectedDeliveryStatus()) {
-      filters.deliveryStatus = this.selectedDeliveryStatus()!;
+      filters.delivery_status = this.selectedDeliveryStatus()!;
     }
 
     if (this.selectedApplicationId()) {
-      filters.applicationId = this.selectedApplicationId()!;
+      filters.application_id = this.selectedApplicationId()!;
     }
 
     if (this.selectedProviderId()) {
-      filters.providerId = this.selectedProviderId()!;
-    }
-
-    if (this.searchText().trim()) {
-      filters.search = this.searchText().trim();
+      filters.provider_id = this.selectedProviderId()!;
     }
 
     if (this.selectedDateFrom()) {
-      filters.dateFrom = this.selectedDateFrom()!.toISOString();
+      filters.date_from = this.selectedDateFrom()!.toISOString();
     }
 
     if (this.selectedDateTo()) {
-      filters.dateTo = this.selectedDateTo()!.toISOString();
+      filters.date_to = this.selectedDateTo()!.toISOString();
     }
 
+    // Property-specific filters from the unified search bar.
     const property = this.propertyFilters();
+
+    if (property.search?.trim()) filters.search = property.search.trim();
 
     if (property.recipient) filters.recipient = property.recipient;
 
@@ -210,7 +205,9 @@ export class ArchivedListComponent implements OnInit {
 
     if (property.subject) filters.subject = property.subject;
 
-    if (property.messageBody) filters.messageBody = property.messageBody;
+    if (property.message_body) filters.message_body = property.message_body;
+
+    if (property.template_name) filters.template_name = property.template_name;
 
     if (property.advancedFilters?.length) filters.advancedFilters = property.advancedFilters;
 
@@ -283,21 +280,6 @@ export class ArchivedListComponent implements OnInit {
     this.loadNotifications();
   }
 
-  onSearchInput(event: Event): void {
-    const value = (event.target as HTMLInputElement).value;
-
-    this.searchText.set(value);
-
-    if (this.searchTimeout) {
-      clearTimeout(this.searchTimeout);
-    }
-
-    this.searchTimeout = setTimeout(() => {
-      this.currentPage = 1;
-      this.loadNotifications();
-    }, 400);
-  }
-
   clearFilters(): void {
     this.selectedChannelType.set(null);
     this.selectedDeliveryStatus.set(null);
@@ -305,7 +287,6 @@ export class ArchivedListComponent implements OnInit {
     this.selectedProviderId.set(null);
     this.selectedDateFrom.set(null);
     this.selectedDateTo.set(null);
-    this.searchText.set('');
     this.propertyFilters.set({});
     this.currentPage = 1;
     this.loadNotifications();
@@ -313,10 +294,12 @@ export class ArchivedListComponent implements OnInit {
 
   onPropertyFiltersChange(updated: NotificationFilters): void {
     this.propertyFilters.set({
+      search: updated.search,
       recipient: updated.recipient,
       sender: updated.sender,
       subject: updated.subject,
-      messageBody: updated.messageBody,
+      message_body: updated.message_body,
+      template_name: updated.template_name,
       advancedFilters: updated.advancedFilters,
     });
     this.currentPage = 1;

--- a/apps/portal/src/app/features/archived-notifications/services/archived-notifications.service.ts
+++ b/apps/portal/src/app/features/archived-notifications/services/archived-notifications.service.ts
@@ -22,32 +22,32 @@ export class ArchivedNotificationsService {
   ): Observable<PaginatedResponse<ArchivedNotification>> {
     let params = new HttpParams().set('page', page).set('limit', limit);
 
-    if (filters?.channelType) {
-      params = params.set('channel_type', filters.channelType);
+    if (filters?.channel_type) {
+      params = params.set('channel_type', filters.channel_type);
     }
 
-    if (filters?.deliveryStatus) {
-      params = params.set('delivery_status', filters.deliveryStatus);
+    if (filters?.delivery_status) {
+      params = params.set('delivery_status', filters.delivery_status);
     }
 
-    if (filters?.applicationId) {
-      params = params.set('application_id', filters.applicationId);
+    if (filters?.application_id) {
+      params = params.set('application_id', filters.application_id);
     }
 
-    if (filters?.providerId) {
-      params = params.set('provider_id', filters.providerId);
+    if (filters?.provider_id) {
+      params = params.set('provider_id', filters.provider_id);
     }
 
     if (filters?.search) {
       params = params.set('search', filters.search);
     }
 
-    if (filters?.dateFrom) {
-      params = params.set('date_from', filters.dateFrom);
+    if (filters?.date_from) {
+      params = params.set('date_from', filters.date_from);
     }
 
-    if (filters?.dateTo) {
-      params = params.set('date_to', filters.dateTo);
+    if (filters?.date_to) {
+      params = params.set('date_to', filters.date_to);
     }
 
     if (filters?.sort) {
@@ -70,8 +70,12 @@ export class ArchivedNotificationsService {
       params = params.set('subject', filters.subject);
     }
 
-    if (filters?.messageBody) {
-      params = params.set('message_body', filters.messageBody);
+    if (filters?.message_body) {
+      params = params.set('message_body', filters.message_body);
+    }
+
+    if (filters?.template_name) {
+      params = params.set('template_name', filters.template_name);
     }
 
     for (const row of filters?.advancedFilters ?? []) {

--- a/apps/portal/src/app/features/archived-notifications/services/archived-notifications.service.ts
+++ b/apps/portal/src/app/features/archived-notifications/services/archived-notifications.service.ts
@@ -3,18 +3,9 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable, tap } from 'rxjs';
 import { environment } from '../../../../environments/environment';
 import { ArchivedNotification, PaginatedResponse } from '../../../core/models/api.model';
+import { NotificationFilters } from '../../../core/models/notification-filters.model';
 
-export interface NotificationFilters {
-  channel_type?: number;
-  delivery_status?: number;
-  application_id?: number;
-  provider_id?: number;
-  search?: string;
-  date_from?: string;
-  date_to?: string;
-  sort?: string;
-  order?: 'asc' | 'desc';
-}
+export type { NotificationFilters };
 
 @Injectable({ providedIn: 'root' })
 export class ArchivedNotificationsService {
@@ -31,32 +22,32 @@ export class ArchivedNotificationsService {
   ): Observable<PaginatedResponse<ArchivedNotification>> {
     let params = new HttpParams().set('page', page).set('limit', limit);
 
-    if (filters?.channel_type) {
-      params = params.set('channel_type', filters.channel_type);
+    if (filters?.channelType) {
+      params = params.set('channel_type', filters.channelType);
     }
 
-    if (filters?.delivery_status) {
-      params = params.set('delivery_status', filters.delivery_status);
+    if (filters?.deliveryStatus) {
+      params = params.set('delivery_status', filters.deliveryStatus);
     }
 
-    if (filters?.application_id) {
-      params = params.set('application_id', filters.application_id);
+    if (filters?.applicationId) {
+      params = params.set('application_id', filters.applicationId);
     }
 
-    if (filters?.provider_id) {
-      params = params.set('provider_id', filters.provider_id);
+    if (filters?.providerId) {
+      params = params.set('provider_id', filters.providerId);
     }
 
     if (filters?.search) {
       params = params.set('search', filters.search);
     }
 
-    if (filters?.date_from) {
-      params = params.set('date_from', filters.date_from);
+    if (filters?.dateFrom) {
+      params = params.set('date_from', filters.dateFrom);
     }
 
-    if (filters?.date_to) {
-      params = params.set('date_to', filters.date_to);
+    if (filters?.dateTo) {
+      params = params.set('date_to', filters.dateTo);
     }
 
     if (filters?.sort) {
@@ -65,6 +56,28 @@ export class ArchivedNotificationsService {
 
     if (filters?.order) {
       params = params.set('order', filters.order);
+    }
+
+    if (filters?.recipient) {
+      params = params.set('recipient', filters.recipient);
+    }
+
+    if (filters?.sender) {
+      params = params.set('sender', filters.sender);
+    }
+
+    if (filters?.subject) {
+      params = params.set('subject', filters.subject);
+    }
+
+    if (filters?.messageBody) {
+      params = params.set('message_body', filters.messageBody);
+    }
+
+    for (const row of filters?.advancedFilters ?? []) {
+      if (row.key && row.value) {
+        params = params.append(`data_filter[${row.key}]`, row.value);
+      }
     }
 
     return this.http

--- a/apps/portal/src/app/features/notifications/pages/notifications-list.html
+++ b/apps/portal/src/app/features/notifications/pages/notifications-list.html
@@ -81,6 +81,11 @@
             placeholder="Search data..."
           />
         </p-iconfield>
+        <app-notification-filters
+          [filters]="composedFilters()"
+          (filtersChange)="onPropertyFiltersChange($event)"
+          (clear)="onPropertyFiltersClear()"
+        />
         <p-button
           icon="pi pi-filter-slash"
           [rounded]="true"

--- a/apps/portal/src/app/features/notifications/pages/notifications-list.html
+++ b/apps/portal/src/app/features/notifications/pages/notifications-list.html
@@ -71,16 +71,6 @@
     </ng-template>
     <ng-template #end>
       <div class="flex items-center gap-2">
-        <p-iconfield iconPosition="left">
-          <p-inputicon class="pi pi-search" />
-          <input
-            pInputText
-            type="text"
-            [value]="searchText()"
-            (input)="onSearchInput($event)"
-            placeholder="Search data..."
-          />
-        </p-iconfield>
         <app-notification-filters
           [filters]="composedFilters()"
           (filtersChange)="onPropertyFiltersChange($event)"

--- a/apps/portal/src/app/features/notifications/pages/notifications-list.ts
+++ b/apps/portal/src/app/features/notifications/pages/notifications-list.ts
@@ -26,6 +26,7 @@ import { PaginationComponent } from '../../../shared/components/pagination/pagin
 import { StatusBadgeComponent } from '../../../shared/components/status-badge/status-badge';
 import { ChannelTypePipe } from '../../../shared/pipes/channel-type.pipe';
 import { JsonViewerDialog } from '../../../shared/components/json-viewer-dialog/json-viewer-dialog';
+import { NotificationFiltersComponent } from '../../../shared/components/notification-filters/notification-filters';
 import { NotificationsService, NotificationFilters } from '../services/notifications.service';
 import { ApplicationsService } from '../../applications/services/applications.service';
 import { ProvidersService } from '../../providers/services/providers.service';
@@ -55,6 +56,7 @@ import { ChannelType, DeliveryStatus } from '../../../core/constants/notificatio
     StatusBadgeComponent,
     ChannelTypePipe,
     JsonViewerDialog,
+    NotificationFiltersComponent,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './notifications-list.html',
@@ -109,6 +111,17 @@ export class NotificationsListComponent implements OnInit {
   readonly selectedDateTo = signal<Date | null>(null);
   readonly searchText = signal('');
 
+  // Property-specific filters from the shared notification-filters drawer
+  // (recipient/sender/subject/messageBody/advancedFilters). Held separately so
+  // the existing toolbar selects/dates/search keep working unchanged.
+  readonly propertyFilters = signal<NotificationFilters>({});
+
+  // Composed filters input passed into <app-notification-filters>. Includes the
+  // applied named/advanced filter state so chips render correctly.
+  readonly composedFilters = computed<NotificationFilters>(() => ({
+    ...this.propertyFilters(),
+  }));
+
   // Sort state (signals keep PrimeNG table in sync to prevent re-sort on data change)
   readonly tableSortField = signal('created_on');
   readonly tableSortOrder = signal<number>(-1);
@@ -162,19 +175,19 @@ export class NotificationsListComponent implements OnInit {
     const filters: NotificationFilters = {};
 
     if (this.selectedChannelType()) {
-      filters.channel_type = this.selectedChannelType()!;
+      filters.channelType = this.selectedChannelType()!;
     }
 
     if (this.selectedDeliveryStatus()) {
-      filters.delivery_status = this.selectedDeliveryStatus()!;
+      filters.deliveryStatus = this.selectedDeliveryStatus()!;
     }
 
     if (this.selectedApplicationId()) {
-      filters.application_id = this.selectedApplicationId()!;
+      filters.applicationId = this.selectedApplicationId()!;
     }
 
     if (this.selectedProviderId()) {
-      filters.provider_id = this.selectedProviderId()!;
+      filters.providerId = this.selectedProviderId()!;
     }
 
     if (this.searchText().trim()) {
@@ -182,12 +195,26 @@ export class NotificationsListComponent implements OnInit {
     }
 
     if (this.selectedDateFrom()) {
-      filters.date_from = this.selectedDateFrom()!.toISOString();
+      filters.dateFrom = this.selectedDateFrom()!.toISOString();
     }
 
     if (this.selectedDateTo()) {
-      filters.date_to = this.selectedDateTo()!.toISOString();
+      filters.dateTo = this.selectedDateTo()!.toISOString();
     }
+
+    // Property filters from the drawer (recipient, sender, subject, messageBody,
+    // advancedFilters). Merged in last so they win over any toolbar duplicates.
+    const property = this.propertyFilters();
+
+    if (property.recipient) filters.recipient = property.recipient;
+
+    if (property.sender) filters.sender = property.sender;
+
+    if (property.subject) filters.subject = property.subject;
+
+    if (property.messageBody) filters.messageBody = property.messageBody;
+
+    if (property.advancedFilters?.length) filters.advancedFilters = property.advancedFilters;
 
     if (this.currentSort) {
       filters.sort = this.currentSort;
@@ -281,6 +308,25 @@ export class NotificationsListComponent implements OnInit {
     this.selectedDateFrom.set(null);
     this.selectedDateTo.set(null);
     this.searchText.set('');
+    this.propertyFilters.set({});
+    this.currentPage = 1;
+    this.loadNotifications();
+  }
+
+  onPropertyFiltersChange(updated: NotificationFilters): void {
+    this.propertyFilters.set({
+      recipient: updated.recipient,
+      sender: updated.sender,
+      subject: updated.subject,
+      messageBody: updated.messageBody,
+      advancedFilters: updated.advancedFilters,
+    });
+    this.currentPage = 1;
+    this.loadNotifications();
+  }
+
+  onPropertyFiltersClear(): void {
+    this.propertyFilters.set({});
     this.currentPage = 1;
     this.loadNotifications();
   }

--- a/apps/portal/src/app/features/notifications/pages/notifications-list.ts
+++ b/apps/portal/src/app/features/notifications/pages/notifications-list.ts
@@ -17,8 +17,6 @@ import { DialogModule } from 'primeng/dialog';
 import { SelectModule } from 'primeng/select';
 import { TooltipModule } from 'primeng/tooltip';
 import { ToolbarModule } from 'primeng/toolbar';
-import { IconFieldModule } from 'primeng/iconfield';
-import { InputIconModule } from 'primeng/inputicon';
 import { InputTextModule } from 'primeng/inputtext';
 import { DatePickerModule } from 'primeng/datepicker';
 import { MessageService } from 'primeng/api';
@@ -48,8 +46,6 @@ import { ChannelType, DeliveryStatus } from '../../../core/constants/notificatio
     SelectModule,
     TooltipModule,
     ToolbarModule,
-    IconFieldModule,
-    InputIconModule,
     InputTextModule,
     DatePickerModule,
     PaginationComponent,
@@ -109,10 +105,10 @@ export class NotificationsListComponent implements OnInit {
   readonly selectedProviderId = signal<number | null>(null);
   readonly selectedDateFrom = signal<Date | null>(null);
   readonly selectedDateTo = signal<Date | null>(null);
-  readonly searchText = signal('');
+
 
   // Property-specific filters from the shared notification-filters drawer
-  // (recipient/sender/subject/messageBody/advancedFilters). Held separately so
+  // (recipient/sender/subject/message_body/advancedFilters). Held separately so
   // the existing toolbar selects/dates/search keep working unchanged.
   readonly propertyFilters = signal<NotificationFilters>({});
 
@@ -137,7 +133,7 @@ export class NotificationsListComponent implements OnInit {
   readonly isOrgAdmin = computed(() => this.authService.isOrgAdmin());
   readonly cleanupLoading = signal(false);
 
-  private searchTimeout: ReturnType<typeof setTimeout> | null = null;
+
 
   ngOnInit(): void {
     this.loadNotifications();
@@ -175,36 +171,33 @@ export class NotificationsListComponent implements OnInit {
     const filters: NotificationFilters = {};
 
     if (this.selectedChannelType()) {
-      filters.channelType = this.selectedChannelType()!;
+      filters.channel_type = this.selectedChannelType()!;
     }
 
     if (this.selectedDeliveryStatus()) {
-      filters.deliveryStatus = this.selectedDeliveryStatus()!;
+      filters.delivery_status = this.selectedDeliveryStatus()!;
     }
 
     if (this.selectedApplicationId()) {
-      filters.applicationId = this.selectedApplicationId()!;
+      filters.application_id = this.selectedApplicationId()!;
     }
 
     if (this.selectedProviderId()) {
-      filters.providerId = this.selectedProviderId()!;
-    }
-
-    if (this.searchText().trim()) {
-      filters.search = this.searchText().trim();
+      filters.provider_id = this.selectedProviderId()!;
     }
 
     if (this.selectedDateFrom()) {
-      filters.dateFrom = this.selectedDateFrom()!.toISOString();
+      filters.date_from = this.selectedDateFrom()!.toISOString();
     }
 
     if (this.selectedDateTo()) {
-      filters.dateTo = this.selectedDateTo()!.toISOString();
+      filters.date_to = this.selectedDateTo()!.toISOString();
     }
 
-    // Property filters from the drawer (recipient, sender, subject, messageBody,
-    // advancedFilters). Merged in last so they win over any toolbar duplicates.
+    // Property-specific filters from the unified search bar.
     const property = this.propertyFilters();
+
+    if (property.search?.trim()) filters.search = property.search.trim();
 
     if (property.recipient) filters.recipient = property.recipient;
 
@@ -212,7 +205,9 @@ export class NotificationsListComponent implements OnInit {
 
     if (property.subject) filters.subject = property.subject;
 
-    if (property.messageBody) filters.messageBody = property.messageBody;
+    if (property.message_body) filters.message_body = property.message_body;
+
+    if (property.template_name) filters.template_name = property.template_name;
 
     if (property.advancedFilters?.length) filters.advancedFilters = property.advancedFilters;
 
@@ -285,21 +280,6 @@ export class NotificationsListComponent implements OnInit {
     this.loadNotifications();
   }
 
-  onSearchInput(event: Event): void {
-    const value = (event.target as HTMLInputElement).value;
-
-    this.searchText.set(value);
-
-    if (this.searchTimeout) {
-      clearTimeout(this.searchTimeout);
-    }
-
-    this.searchTimeout = setTimeout(() => {
-      this.currentPage = 1;
-      this.loadNotifications();
-    }, 400);
-  }
-
   clearFilters(): void {
     this.selectedChannelType.set(null);
     this.selectedDeliveryStatus.set(null);
@@ -307,7 +287,6 @@ export class NotificationsListComponent implements OnInit {
     this.selectedProviderId.set(null);
     this.selectedDateFrom.set(null);
     this.selectedDateTo.set(null);
-    this.searchText.set('');
     this.propertyFilters.set({});
     this.currentPage = 1;
     this.loadNotifications();
@@ -315,10 +294,12 @@ export class NotificationsListComponent implements OnInit {
 
   onPropertyFiltersChange(updated: NotificationFilters): void {
     this.propertyFilters.set({
+      search: updated.search,
       recipient: updated.recipient,
       sender: updated.sender,
       subject: updated.subject,
-      messageBody: updated.messageBody,
+      message_body: updated.message_body,
+      template_name: updated.template_name,
       advancedFilters: updated.advancedFilters,
     });
     this.currentPage = 1;

--- a/apps/portal/src/app/features/notifications/services/notifications.service.ts
+++ b/apps/portal/src/app/features/notifications/services/notifications.service.ts
@@ -22,32 +22,32 @@ export class NotificationsService {
   ): Observable<PaginatedResponse<Notification>> {
     let params = new HttpParams().set('page', page).set('limit', limit);
 
-    if (filters?.channelType) {
-      params = params.set('channel_type', filters.channelType);
+    if (filters?.channel_type) {
+      params = params.set('channel_type', filters.channel_type);
     }
 
-    if (filters?.deliveryStatus) {
-      params = params.set('delivery_status', filters.deliveryStatus);
+    if (filters?.delivery_status) {
+      params = params.set('delivery_status', filters.delivery_status);
     }
 
-    if (filters?.applicationId) {
-      params = params.set('application_id', filters.applicationId);
+    if (filters?.application_id) {
+      params = params.set('application_id', filters.application_id);
     }
 
-    if (filters?.providerId) {
-      params = params.set('provider_id', filters.providerId);
+    if (filters?.provider_id) {
+      params = params.set('provider_id', filters.provider_id);
     }
 
     if (filters?.search) {
       params = params.set('search', filters.search);
     }
 
-    if (filters?.dateFrom) {
-      params = params.set('date_from', filters.dateFrom);
+    if (filters?.date_from) {
+      params = params.set('date_from', filters.date_from);
     }
 
-    if (filters?.dateTo) {
-      params = params.set('date_to', filters.dateTo);
+    if (filters?.date_to) {
+      params = params.set('date_to', filters.date_to);
     }
 
     if (filters?.sort) {
@@ -70,8 +70,12 @@ export class NotificationsService {
       params = params.set('subject', filters.subject);
     }
 
-    if (filters?.messageBody) {
-      params = params.set('message_body', filters.messageBody);
+    if (filters?.message_body) {
+      params = params.set('message_body', filters.message_body);
+    }
+
+    if (filters?.template_name) {
+      params = params.set('template_name', filters.template_name);
     }
 
     for (const row of filters?.advancedFilters ?? []) {

--- a/apps/portal/src/app/features/notifications/services/notifications.service.ts
+++ b/apps/portal/src/app/features/notifications/services/notifications.service.ts
@@ -3,18 +3,9 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable, tap } from 'rxjs';
 import { environment } from '../../../../environments/environment';
 import { Notification, PaginatedResponse } from '../../../core/models/api.model';
+import { NotificationFilters } from '../../../core/models/notification-filters.model';
 
-export interface NotificationFilters {
-  channel_type?: number;
-  delivery_status?: number;
-  application_id?: number;
-  provider_id?: number;
-  search?: string;
-  date_from?: string;
-  date_to?: string;
-  sort?: string;
-  order?: 'asc' | 'desc';
-}
+export type { NotificationFilters };
 
 @Injectable({ providedIn: 'root' })
 export class NotificationsService {
@@ -31,32 +22,32 @@ export class NotificationsService {
   ): Observable<PaginatedResponse<Notification>> {
     let params = new HttpParams().set('page', page).set('limit', limit);
 
-    if (filters?.channel_type) {
-      params = params.set('channel_type', filters.channel_type);
+    if (filters?.channelType) {
+      params = params.set('channel_type', filters.channelType);
     }
 
-    if (filters?.delivery_status) {
-      params = params.set('delivery_status', filters.delivery_status);
+    if (filters?.deliveryStatus) {
+      params = params.set('delivery_status', filters.deliveryStatus);
     }
 
-    if (filters?.application_id) {
-      params = params.set('application_id', filters.application_id);
+    if (filters?.applicationId) {
+      params = params.set('application_id', filters.applicationId);
     }
 
-    if (filters?.provider_id) {
-      params = params.set('provider_id', filters.provider_id);
+    if (filters?.providerId) {
+      params = params.set('provider_id', filters.providerId);
     }
 
     if (filters?.search) {
       params = params.set('search', filters.search);
     }
 
-    if (filters?.date_from) {
-      params = params.set('date_from', filters.date_from);
+    if (filters?.dateFrom) {
+      params = params.set('date_from', filters.dateFrom);
     }
 
-    if (filters?.date_to) {
-      params = params.set('date_to', filters.date_to);
+    if (filters?.dateTo) {
+      params = params.set('date_to', filters.dateTo);
     }
 
     if (filters?.sort) {
@@ -65,6 +56,28 @@ export class NotificationsService {
 
     if (filters?.order) {
       params = params.set('order', filters.order);
+    }
+
+    if (filters?.recipient) {
+      params = params.set('recipient', filters.recipient);
+    }
+
+    if (filters?.sender) {
+      params = params.set('sender', filters.sender);
+    }
+
+    if (filters?.subject) {
+      params = params.set('subject', filters.subject);
+    }
+
+    if (filters?.messageBody) {
+      params = params.set('message_body', filters.messageBody);
+    }
+
+    for (const row of filters?.advancedFilters ?? []) {
+      if (row.key && row.value) {
+        params = params.append(`data_filter[${row.key}]`, row.value);
+      }
     }
 
     return this.http

--- a/apps/portal/src/app/shared/components/notification-filters/notification-filters.html
+++ b/apps/portal/src/app/shared/components/notification-filters/notification-filters.html
@@ -3,7 +3,6 @@
   class="relative flex-1 min-w-50 max-w-125 cursor-text"
   role="presentation"
   (click)="onBarClick($event)"
-  (keydown.enter)="onBarClick($event)"
 >
 
   <div
@@ -112,7 +111,7 @@
   }
 </div>
 
-<!-- Advanced (free-form data_filter) popover button -->
+<!-- TODO: Advanced (free-form data_filter) popover button - commented out until the feature is ready to ship -->
 <!-- <p-popover #advPop>
   <div style="min-width: 380px">
     <h4 class="text-sm font-medium mt-0 mb-3">Advanced filters</h4>

--- a/apps/portal/src/app/shared/components/notification-filters/notification-filters.html
+++ b/apps/portal/src/app/shared/components/notification-filters/notification-filters.html
@@ -1,0 +1,167 @@
+<p-button
+  label="Filters"
+  icon="pi pi-sliders-h"
+  severity="secondary"
+  [badge]="activeCount() ? activeCount().toString() : undefined"
+  badgeSeverity="contrast"
+  (onClick)="filtersOpen.set(true)"
+/>
+
+@if (activeChips().length) {
+  <div class="flex flex-wrap items-center gap-2 mt-3 mb-3">
+    @for (chip of activeChips(); track chip.id) {
+      <p-chip [label]="chip.label" [removable]="true" (onRemove)="chip.remove()" />
+    }
+    <p-button label="Clear all" severity="secondary" text size="small" (onClick)="onClearAll()" />
+  </div>
+}
+
+<p-drawer
+  [(visible)]="filtersOpen"
+  position="right"
+  header="Filters"
+  styleClass="!w-full md:!w-[28rem]"
+>
+  <div class="flex flex-col gap-4">
+    <p-iftaLabel>
+      <input
+        pInputText
+        id="ndf-recipient"
+        [ngModel]="localFilters().recipient ?? ''"
+        (ngModelChange)="setLocal('recipient', $event)"
+        [fluid]="true"
+        pTooltip="Searches To/CC/BCC and push target. Strip spaces or punctuation if results look off. Type at least 3 characters for fast results."
+        tooltipPosition="top"
+        showDelay="500"
+      />
+      <label for="ndf-recipient">Recipient</label>
+    </p-iftaLabel>
+
+    <p-iftaLabel>
+      <input
+        pInputText
+        id="ndf-sender"
+        [ngModel]="localFilters().sender ?? ''"
+        (ngModelChange)="setLocal('sender', $event)"
+        [fluid]="true"
+        pTooltip="Email From address. Type at least 3 characters for fast results."
+        tooltipPosition="top"
+        showDelay="500"
+      />
+      <label for="ndf-sender">Sender</label>
+    </p-iftaLabel>
+
+    <p-iftaLabel>
+      <input
+        pInputText
+        id="ndf-subject"
+        [ngModel]="localFilters().subject ?? ''"
+        (ngModelChange)="setLocal('subject', $event)"
+        [fluid]="true"
+        pTooltip="Email subject. Type at least 3 characters for fast results."
+        tooltipPosition="top"
+        showDelay="500"
+      />
+      <label for="ndf-subject">Subject</label>
+    </p-iftaLabel>
+
+    <p-iftaLabel>
+      <input
+        pInputText
+        id="ndf-message-body"
+        [ngModel]="localFilters().messageBody ?? ''"
+        (ngModelChange)="setLocal('messageBody', $event)"
+        [fluid]="true"
+        pTooltip="Searches plain text, HTML, SMS message, and template body. HTML markup is included. Type at least 3 characters for fast results."
+        tooltipPosition="top"
+        showDelay="500"
+      />
+      <label for="ndf-message-body">Message body</label>
+    </p-iftaLabel>
+
+    <p-divider />
+
+    <h4 class="text-sm font-medium m-0">Advanced filters</h4>
+
+    @if (!advancedRows().length) {
+      <p-message
+        severity="secondary"
+        variant="simple"
+        size="small"
+        icon="pi pi-info-circle"
+      >
+        Add custom data_filter[key]=value pairs to match keys not covered above.
+      </p-message>
+    }
+
+    @for (row of advancedRows(); track row.id; let i = $index) {
+      <div class="flex items-start gap-2">
+        <div class="flex-1">
+          <p-iftaLabel>
+            <p-autocomplete
+              [ngModel]="row.key"
+              (ngModelChange)="updateKey(i, $event)"
+              [suggestions]="filteredKeys()"
+              (completeMethod)="searchKeys($event)"
+              [dropdown]="true"
+              [forceSelection]="false"
+              [invalid]="row.key !== '' && !isKeyValid(row.key)"
+              [fluid]="true"
+              inputId="ndf-adv-key-{{ i }}"
+            />
+            <label for="ndf-adv-key-{{ i }}">Key</label>
+          </p-iftaLabel>
+          @if (row.key && !isKeyValid(row.key)) {
+            <small class="text-red-500 block mt-1">
+              {{
+                RESERVED_KEYS.has(row.key)
+                  ? 'Already covered by a named filter above.'
+                  : 'Use only letters, digits, or underscores (max 64 chars).'
+              }}
+            </small>
+          }
+        </div>
+
+        <p-iftaLabel class="flex-1">
+          <input
+            pInputText
+            [ngModel]="row.value"
+            (ngModelChange)="updateValue(i, $event)"
+            id="ndf-adv-val-{{ i }}"
+            [fluid]="true"
+          />
+          <label for="ndf-adv-val-{{ i }}">Value</label>
+        </p-iftaLabel>
+
+        <p-button
+          icon="pi pi-times"
+          [rounded]="true"
+          [text]="true"
+          severity="danger"
+          size="small"
+          pTooltip="Remove filter"
+          tooltipPosition="top"
+          (onClick)="removeRow(i)"
+          aria-label="Remove filter"
+        />
+      </div>
+    }
+
+    <p-button
+      icon="pi pi-plus"
+      label="Add filter"
+      severity="secondary"
+      [outlined]="true"
+      [fluid]="true"
+      size="small"
+      (onClick)="addRow()"
+    />
+  </div>
+
+  <ng-template #footer>
+    <div class="flex justify-end gap-2">
+      <p-button label="Reset" severity="secondary" text (onClick)="onClearAll()" />
+      <p-button label="Apply" [disabled]="!canApply()" (onClick)="onApply()" />
+    </div>
+  </ng-template>
+</p-drawer>

--- a/apps/portal/src/app/shared/components/notification-filters/notification-filters.html
+++ b/apps/portal/src/app/shared/components/notification-filters/notification-filters.html
@@ -113,7 +113,7 @@
 </div>
 
 <!-- Advanced (free-form data_filter) popover button -->
-<p-popover #advPop>
+<!-- <p-popover #advPop>
   <div style="min-width: 380px">
     <h4 class="text-sm font-medium mt-0 mb-3">Advanced filters</h4>
 
@@ -169,13 +169,13 @@
       />
     </div>
   </div>
-</p-popover>
+</p-popover> -->
 
-<p-button
+<!-- <p-button
   label="Advanced"
   icon="pi pi-sliders-h"
   severity="secondary"
   [outlined]="true"
   size="small"
   (onClick)="openAdvanced(advPop, $event)"
-/>
+/> -->

--- a/apps/portal/src/app/shared/components/notification-filters/notification-filters.html
+++ b/apps/portal/src/app/shared/components/notification-filters/notification-filters.html
@@ -1,167 +1,181 @@
-<p-button
-  label="Filters"
-  icon="pi pi-sliders-h"
-  severity="secondary"
-  [badge]="activeCount() ? activeCount().toString() : undefined"
-  badgeSeverity="contrast"
-  (onClick)="filtersOpen.set(true)"
-/>
-
-@if (activeChips().length) {
-  <div class="flex flex-wrap items-center gap-2 mt-3 mb-3">
-    @for (chip of activeChips(); track chip.id) {
-      <p-chip [label]="chip.label" [removable]="true" (onRemove)="chip.remove()" />
-    }
-    <p-button label="Clear all" severity="secondary" text size="small" (onClick)="onClearAll()" />
-  </div>
-}
-
-<p-drawer
-  [(visible)]="filtersOpen"
-  position="right"
-  header="Filters"
-  styleClass="!w-full md:!w-[28rem]"
+﻿<!-- GitLab-style unified search + filter bar -->
+<div
+  class="relative flex-1 min-w-50 max-w-125 cursor-text"
+  role="presentation"
+  (click)="onBarClick($event)"
+  (keydown.enter)="onBarClick($event)"
 >
-  <div class="flex flex-col gap-4">
-    <p-iftaLabel>
-      <input
-        pInputText
-        id="ndf-recipient"
-        [ngModel]="localFilters().recipient ?? ''"
-        (ngModelChange)="setLocal('recipient', $event)"
-        [fluid]="true"
-        pTooltip="Searches To/CC/BCC and push target. Strip spaces or punctuation if results look off. Type at least 3 characters for fast results."
+
+  <div
+    class="ndf-bar flex flex-wrap items-center gap-1 min-h-9 px-2 py-1 border border-surface-300 rounded-md bg-white transition-all duration-150"
+    [class.ndf-bar-focused]="dropdownVisible()"
+  >
+
+    <!-- Applied filter chips (inline inside the bar) -->
+    @for (chip of activeChips(); track chip.id) {
+      <span class="inline-flex items-center gap-1 px-2 py-0.5 bg-primary-500 text-white rounded text-xs whitespace-nowrap max-w-55">
+        <span class="overflow-hidden text-ellipsis">{{ chip.label }}</span>
+        <button
+          type="button"
+          class="bg-transparent border-0 text-white cursor-pointer p-0 leading-none opacity-75 hover:opacity-100 shrink-0"
+          (click)="chip.remove(); $event.stopPropagation()"
+          aria-label="Remove filter"
+        >&times;</button>
+      </span>
+    }
+
+    <!-- Token type badge shown after user picks a filter type, e.g. "Recipient =" -->
+    @if (selectedToken()) {
+      <span class="inline-flex items-center px-2 py-0.5 bg-surface-100 rounded text-xs whitespace-nowrap shrink-0">
+        <span class="text-primary-500 font-semibold">{{ selectedToken()!.label }}</span>
+        <span class="text-surface-400">&nbsp;=</span>
+      </span>
+    }
+
+    <!-- Borderless input filling the rest of the bar -->
+    <input
+      #searchInput
+      type="text"
+      class="ndf-input"
+      [placeholder]="placeholder()"
+      [ngModel]="inputValue()"
+      (ngModelChange)="onInputChange($event)"
+      (focus)="onFocus()"
+      (blur)="onInputBlur()"
+      (keydown)="onKeydown($event)"
+      autocomplete="off"
+    />
+
+    <i class="pi pi-search text-surface-400 text-xs shrink-0"></i>
+
+    @if (activeCount() || selectedToken()) {
+      <button
+        type="button"
+        class="inline-flex items-center p-0.5 bg-transparent border-0 cursor-pointer rounded-full text-surface-400 hover:text-surface-600 hover:bg-surface-100 shrink-0"
+        pTooltip="Clear all filters"
         tooltipPosition="top"
-        showDelay="500"
-      />
-      <label for="ndf-recipient">Recipient</label>
-    </p-iftaLabel>
-
-    <p-iftaLabel>
-      <input
-        pInputText
-        id="ndf-sender"
-        [ngModel]="localFilters().sender ?? ''"
-        (ngModelChange)="setLocal('sender', $event)"
-        [fluid]="true"
-        pTooltip="Email From address. Type at least 3 characters for fast results."
-        tooltipPosition="top"
-        showDelay="500"
-      />
-      <label for="ndf-sender">Sender</label>
-    </p-iftaLabel>
-
-    <p-iftaLabel>
-      <input
-        pInputText
-        id="ndf-subject"
-        [ngModel]="localFilters().subject ?? ''"
-        (ngModelChange)="setLocal('subject', $event)"
-        [fluid]="true"
-        pTooltip="Email subject. Type at least 3 characters for fast results."
-        tooltipPosition="top"
-        showDelay="500"
-      />
-      <label for="ndf-subject">Subject</label>
-    </p-iftaLabel>
-
-    <p-iftaLabel>
-      <input
-        pInputText
-        id="ndf-message-body"
-        [ngModel]="localFilters().messageBody ?? ''"
-        (ngModelChange)="setLocal('messageBody', $event)"
-        [fluid]="true"
-        pTooltip="Searches plain text, HTML, SMS message, and template body. HTML markup is included. Type at least 3 characters for fast results."
-        tooltipPosition="top"
-        showDelay="500"
-      />
-      <label for="ndf-message-body">Message body</label>
-    </p-iftaLabel>
-
-    <p-divider />
-
-    <h4 class="text-sm font-medium m-0">Advanced filters</h4>
-
-    @if (!advancedRows().length) {
-      <p-message
-        severity="secondary"
-        variant="simple"
-        size="small"
-        icon="pi pi-info-circle"
+        (click)="onClearAll(); $event.stopPropagation()"
+        aria-label="Clear all filters"
       >
-        Add custom data_filter[key]=value pairs to match keys not covered above.
+        <i class="pi pi-times text-xs"></i>
+      </button>
+    }
+  </div>
+
+  <!-- Dropdown panel shown on focus/click -->
+  @if (dropdownVisible()) {
+    <div
+      class="absolute top-[calc(100%+4px)] left-0 right-0 z-1000 bg-white border border-surface-200 rounded-md shadow-md overflow-hidden"
+      (mousedown)="$event.preventDefault()"
+    >
+
+      <!-- "Search for this text" row — shown when user types without selecting a token type -->
+      @if (inputValue().trim() && !selectedToken()) {
+        <button
+          type="button"
+          class="flex items-center gap-2 w-full px-3 py-2 bg-transparent border-0 text-left cursor-pointer text-base text-surface-700 hover:bg-surface-50"
+          (click)="commitFromDropdown()"
+        >
+          <span>Search for "<strong>{{ inputValue() }}</strong>"</span>
+        </button>
+        <div class="h-px bg-surface-200 my-0.5"></div>
+      }
+
+      <!-- Hint when a token type is selected but no value typed yet -->
+      @if (selectedToken()) {
+        <div class="px-3 py-2 text-sm text-surface-400">
+          Type a value and press
+          <kbd class="inline-block px-1.5 py-0.5 text-xs border border-surface-300 rounded bg-surface-50 font-sans">Enter</kbd>
+          to apply
+        </div>
+      }
+
+      <!-- Filter type list (only when no token selected AND user is not typing) -->
+      @if (!selectedToken() && !inputValue().trim()) {
+        @if (availableTokens().length > 0) {
+          <div class="px-3 pt-2 pb-0.5 text-[0.7rem] font-semibold uppercase tracking-wider text-surface-400">
+            Filter by
+          </div>
+          @for (token of availableTokens(); track token.id) {
+            <button
+              type="button"
+              class="flex items-center w-full px-3 py-2 bg-transparent border-0 text-left cursor-pointer text-base text-surface-700 hover:bg-surface-50"
+              (click)="selectToken(token); $event.stopPropagation()"
+            >{{ token.label }}</button>
+          }
+        } @else if (!inputValue().trim()) {
+          <div class="px-3 py-2 text-sm text-surface-400">All filters applied.</div>
+        }
+      }
+
+    </div>
+  }
+</div>
+
+<!-- Advanced (free-form data_filter) popover button -->
+<p-popover #advPop>
+  <div style="min-width: 380px">
+    <h4 class="text-sm font-medium mt-0 mb-3">Advanced filters</h4>
+
+    @if (!advRows().length) {
+      <p-message severity="secondary" variant="simple" size="small" icon="pi pi-info-circle">
+        Add custom data_filter[key]=value pairs.
       </p-message>
     }
 
-    @for (row of advancedRows(); track row.id; let i = $index) {
-      <div class="flex items-start gap-2">
-        <div class="flex-1">
-          <p-iftaLabel>
-            <p-autocomplete
-              [ngModel]="row.key"
-              (ngModelChange)="updateKey(i, $event)"
-              [suggestions]="filteredKeys()"
-              (completeMethod)="searchKeys($event)"
-              [dropdown]="true"
-              [forceSelection]="false"
-              [invalid]="row.key !== '' && !isKeyValid(row.key)"
-              [fluid]="true"
-              inputId="ndf-adv-key-{{ i }}"
-            />
-            <label for="ndf-adv-key-{{ i }}">Key</label>
-          </p-iftaLabel>
-          @if (row.key && !isKeyValid(row.key)) {
-            <small class="text-red-500 block mt-1">
-              {{
-                RESERVED_KEYS.has(row.key)
-                  ? 'Already covered by a named filter above.'
-                  : 'Use only letters, digits, or underscores (max 64 chars).'
-              }}
-            </small>
-          }
-        </div>
-
-        <p-iftaLabel class="flex-1">
-          <input
-            pInputText
-            [ngModel]="row.value"
-            (ngModelChange)="updateValue(i, $event)"
-            id="ndf-adv-val-{{ i }}"
-            [fluid]="true"
-          />
-          <label for="ndf-adv-val-{{ i }}">Value</label>
-        </p-iftaLabel>
-
+    @for (row of advRows(); track row.id; let i = $index) {
+      <div class="flex items-center gap-2 mb-2">
+        <input
+          pInputText
+          [ngModel]="row.key"
+          (ngModelChange)="updateAdvKey(i, $event)"
+          placeholder="Key"
+          style="width: 140px"
+          [class.p-invalid]="row.key && !ALLOWED_KEY_RE.test(row.key)"
+        />
+        <input
+          pInputText
+          [ngModel]="row.value"
+          (ngModelChange)="updateAdvValue(i, $event)"
+          placeholder="Value"
+          class="flex-1"
+        />
         <p-button
           icon="pi pi-times"
           [rounded]="true"
           [text]="true"
           severity="danger"
           size="small"
-          pTooltip="Remove filter"
-          tooltipPosition="top"
-          (onClick)="removeRow(i)"
-          aria-label="Remove filter"
+          (onClick)="removeAdvRow(i)"
+          aria-label="Remove row"
         />
       </div>
     }
 
-    <p-button
-      icon="pi pi-plus"
-      label="Add filter"
-      severity="secondary"
-      [outlined]="true"
-      [fluid]="true"
-      size="small"
-      (onClick)="addRow()"
-    />
-  </div>
-
-  <ng-template #footer>
-    <div class="flex justify-end gap-2">
-      <p-button label="Reset" severity="secondary" text (onClick)="onClearAll()" />
-      <p-button label="Apply" [disabled]="!canApply()" (onClick)="onApply()" />
+    <div class="flex justify-between items-center mt-3">
+      <p-button
+        icon="pi pi-plus"
+        label="Add row"
+        severity="secondary"
+        [text]="true"
+        size="small"
+        (onClick)="addAdvRow()"
+      />
+      <p-button
+        label="Apply"
+        size="small"
+        [disabled]="!advCanApply()"
+        (onClick)="applyAdvanced(advPop)"
+      />
     </div>
-  </ng-template>
-</p-drawer>
+  </div>
+</p-popover>
+
+<p-button
+  label="Advanced"
+  icon="pi pi-sliders-h"
+  severity="secondary"
+  [outlined]="true"
+  size="small"
+  (onClick)="openAdvanced(advPop, $event)"
+/>

--- a/apps/portal/src/app/shared/components/notification-filters/notification-filters.scss
+++ b/apps/portal/src/app/shared/components/notification-filters/notification-filters.scss
@@ -1,0 +1,28 @@
+﻿:host {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+// Borderless input — must override browser & any inherited input styles
+.ndf-input {
+  flex: 1;
+  min-width: 80px;
+  border: none;
+  outline: none;
+  background: transparent;
+  box-shadow: none;
+  padding-block: 2px;
+  font-size: var(--p-inputtext-font-size, 1rem);
+  color: var(--p-text-color, inherit);
+
+  &::placeholder {
+    color: var(--p-text-muted-color, #9ca3af);
+  }
+}
+
+// Focused bar state — dynamic ring/border (hard to do cleanly with conditional Tailwind binding)
+.ndf-bar-focused {
+  border-color: var(--p-primary-color) !important;
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--p-primary-color) 15%, transparent);
+}

--- a/apps/portal/src/app/shared/components/notification-filters/notification-filters.ts
+++ b/apps/portal/src/app/shared/components/notification-filters/notification-filters.ts
@@ -251,7 +251,8 @@ export class NotificationFiltersComponent {
   }
 
   private commitSearch(value: string): void {
-    // Clear all named text filters — keep only structural (dropdown) filters.
+    // Replace all named text filters with the plain search term but preserve
+    // structural (dropdown/date/sort) filters and advancedFilters.
     const f = this.filters();
 
     this.filtersChange.emit({
@@ -263,6 +264,7 @@ export class NotificationFiltersComponent {
       date_to: f.date_to,
       sort: f.sort,
       order: f.order,
+      advancedFilters: f.advancedFilters,
       search: value,
     });
     this.inputValue.set('');

--- a/apps/portal/src/app/shared/components/notification-filters/notification-filters.ts
+++ b/apps/portal/src/app/shared/components/notification-filters/notification-filters.ts
@@ -1,0 +1,257 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  input,
+  output,
+  signal,
+} from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { ButtonModule } from 'primeng/button';
+import { ChipModule } from 'primeng/chip';
+import { DrawerModule } from 'primeng/drawer';
+import { AutoCompleteModule, AutoCompleteCompleteEvent } from 'primeng/autocomplete';
+import { IftaLabelModule } from 'primeng/iftalabel';
+import { InputTextModule } from 'primeng/inputtext';
+import { MessageModule } from 'primeng/message';
+import { TooltipModule } from 'primeng/tooltip';
+import { DividerModule } from 'primeng/divider';
+import {
+  AdvancedFilterRow,
+  NotificationFilters,
+} from '../../../core/models/notification-filters.model';
+
+interface ActiveChip {
+  id: string;
+  label: string;
+  remove: () => void;
+}
+
+const RESERVED_KEYS = new Set<string>([
+  // Recipient (covered by named filter)
+  'to',
+  'cc',
+  'bcc',
+  'target',
+  // Sender
+  'from',
+  'replyTo',
+  // Subject
+  'subject',
+  // Message body (top-level + nested handled by named filter)
+  'text',
+  'html',
+  'message',
+  // Channel discriminator
+  'type',
+]);
+
+const ALLOWED_KEY_RE = /^[a-zA-Z0-9_]{1,64}$/;
+const KEY_SUGGESTIONS = ['template', 'locale', 'campaign_id', 'priority', 'tag', 'reference_id'];
+
+@Component({
+  selector: 'app-notification-filters',
+  standalone: true,
+  imports: [
+    FormsModule,
+    ButtonModule,
+    ChipModule,
+    DrawerModule,
+    AutoCompleteModule,
+    IftaLabelModule,
+    InputTextModule,
+    MessageModule,
+    TooltipModule,
+    DividerModule,
+  ],
+  templateUrl: './notification-filters.html',
+  styleUrl: './notification-filters.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class NotificationFiltersComponent {
+  // External contract
+  readonly filters = input.required<NotificationFilters>();
+  readonly filtersChange = output<NotificationFilters>();
+  readonly clear = output<void>();
+
+  // Drawer state
+  readonly filtersOpen = signal(false);
+
+  // Local in-progress edits — committed to parent only on Apply.
+  readonly localFilters = signal<NotificationFilters>({});
+
+  // Advanced rows — local; merged into localFilters only on Apply.
+  readonly advancedRows = signal<AdvancedFilterRow[]>([]);
+
+  // AutoComplete suggestions filtered by current typed prefix.
+  readonly filteredKeys = signal<string[]>(KEY_SUGGESTIONS);
+
+  // Surface RESERVED_KEYS in template for the inline error message branch.
+  readonly RESERVED_KEYS = RESERVED_KEYS;
+
+  // Active chips read from the *applied* filters() input — not localFilters —
+  // so removing a chip emits filtersChange immediately, bypassing the drawer's
+  // Apply gate and updating the table without forcing the user to open the drawer.
+  readonly activeChips = computed<ActiveChip[]>(() => {
+    const f = this.filters();
+    const chips: ActiveChip[] = [];
+
+    if (f.recipient) {
+      chips.push({
+        id: 'recipient',
+        label: `Recipient: ${f.recipient}`,
+        remove: () => this.emitWithoutKey('recipient'),
+      });
+    }
+
+    if (f.sender) {
+      chips.push({
+        id: 'sender',
+        label: `Sender: ${f.sender}`,
+        remove: () => this.emitWithoutKey('sender'),
+      });
+    }
+
+    if (f.subject) {
+      chips.push({
+        id: 'subject',
+        label: `Subject: ${f.subject}`,
+        remove: () => this.emitWithoutKey('subject'),
+      });
+    }
+
+    if (f.messageBody) {
+      chips.push({
+        id: 'messageBody',
+        label: `Message body: ${f.messageBody}`,
+        remove: () => this.emitWithoutKey('messageBody'),
+      });
+    }
+
+    for (const row of f.advancedFilters ?? []) {
+      chips.push({
+        id: `advanced:${row.id}`,
+        label: `${row.key}=${row.value}`,
+        remove: () => this.removeAdvancedFromApplied(row.id),
+      });
+    }
+
+    return chips;
+  });
+
+  readonly activeCount = computed(() => this.activeChips().length);
+
+  // Apply button gating: every advanced row must have a non-empty value AND
+  // a valid key. Empty rows block Apply silently (no red); only filled-in
+  // invalid keys show the inline error message.
+  readonly canApply = computed(() =>
+    this.advancedRows().every((r) => Boolean(r.key) && Boolean(r.value) && this.isKeyValid(r.key)),
+  );
+
+  constructor() {
+    // Hydrate localFilters from the applied filters() input — but ONLY when the
+    // drawer is closed. While the drawer is open the user's in-progress edits
+    // are sovereign; an external filters() change (e.g. URL nav, parent
+    // re-render, chip removal) must not wipe them.
+    effect(() => {
+      if (!this.filtersOpen()) {
+        const applied = this.filters();
+
+        this.localFilters.set({ ...applied });
+        this.advancedRows.set([...(applied.advancedFilters ?? [])]);
+      }
+    });
+  }
+
+  // ---- localFilters editing ----
+
+  setLocal<K extends keyof NotificationFilters>(key: K, value: NotificationFilters[K]): void {
+    this.localFilters.update((f) => ({ ...f, [key]: value }));
+  }
+
+  // ---- Advanced rows editing ----
+
+  addRow(): void {
+    this.advancedRows.update((rows) => [
+      ...rows,
+      { id: this.makeId(), key: '', value: '' },
+    ]);
+  }
+
+  removeRow(index: number): void {
+    this.advancedRows.update((rows) => rows.filter((_, i) => i !== index));
+  }
+
+  updateKey(index: number, key: string): void {
+    this.advancedRows.update((rows) =>
+      rows.map((r, i) => (i === index ? { ...r, key } : r)),
+    );
+  }
+
+  updateValue(index: number, value: string): void {
+    this.advancedRows.update((rows) =>
+      rows.map((r, i) => (i === index ? { ...r, value } : r)),
+    );
+  }
+
+  searchKeys(event: AutoCompleteCompleteEvent): void {
+    const q = (event.query ?? '').toLowerCase();
+    const filtered = KEY_SUGGESTIONS.filter(
+      (k) => !RESERVED_KEYS.has(k) && k.toLowerCase().includes(q),
+    );
+
+    this.filteredKeys.set(filtered);
+  }
+
+  isKeyValid(key: string): boolean {
+    if (!key) {
+      return true; // empty key = not yet entered, not "invalid"
+    }
+
+    return ALLOWED_KEY_RE.test(key) && !RESERVED_KEYS.has(key);
+  }
+
+  // ---- Apply / Reset ----
+
+  onApply(): void {
+    if (!this.canApply()) {
+      return;
+    }
+
+    const next: NotificationFilters = {
+      ...this.localFilters(),
+      advancedFilters: this.advancedRows().filter((r) => r.key && r.value),
+    };
+
+    this.filtersChange.emit(next);
+    this.filtersOpen.set(false);
+  }
+
+  onClearAll(): void {
+    // Clear local in-progress edits as well so the drawer reflects the cleared state.
+    this.localFilters.set({});
+    this.advancedRows.set([]);
+    this.clear.emit();
+  }
+
+  // ---- Chip removal helpers (operate on applied filters() directly) ----
+
+  private emitWithoutKey(key: keyof NotificationFilters): void {
+    const f = { ...this.filters() };
+
+    delete f[key];
+    this.filtersChange.emit(f);
+  }
+
+  private removeAdvancedFromApplied(rowId: string): void {
+    const f = { ...this.filters() };
+
+    f.advancedFilters = (f.advancedFilters ?? []).filter((r) => r.id !== rowId);
+    this.filtersChange.emit(f);
+  }
+
+  private makeId(): string {
+    return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  }
+}

--- a/apps/portal/src/app/shared/components/notification-filters/notification-filters.ts
+++ b/apps/portal/src/app/shared/components/notification-filters/notification-filters.ts
@@ -1,26 +1,30 @@
-import {
+﻿import {
   ChangeDetectionStrategy,
   Component,
   computed,
-  effect,
+  ElementRef,
   input,
   output,
   signal,
+  viewChild,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { ButtonModule } from 'primeng/button';
-import { ChipModule } from 'primeng/chip';
-import { DrawerModule } from 'primeng/drawer';
-import { AutoCompleteModule, AutoCompleteCompleteEvent } from 'primeng/autocomplete';
-import { IftaLabelModule } from 'primeng/iftalabel';
 import { InputTextModule } from 'primeng/inputtext';
 import { MessageModule } from 'primeng/message';
+import { PopoverModule } from 'primeng/popover';
 import { TooltipModule } from 'primeng/tooltip';
-import { DividerModule } from 'primeng/divider';
 import {
   AdvancedFilterRow,
   NotificationFilters,
 } from '../../../core/models/notification-filters.model';
+
+interface FilterToken {
+  id: string;
+  label: string;
+  namedKey?: keyof NotificationFilters;
+  dataFilterKey?: string;
+}
 
 interface ActiveChip {
   id: string;
@@ -28,112 +32,97 @@ interface ActiveChip {
   remove: () => void;
 }
 
-const RESERVED_KEYS = new Set<string>([
-  // Recipient (covered by named filter)
-  'to',
-  'cc',
-  'bcc',
-  'target',
-  // Sender
-  'from',
-  'replyTo',
-  // Subject
-  'subject',
-  // Message body (top-level + nested handled by named filter)
-  'text',
-  'html',
-  'message',
-  // Channel discriminator
-  'type',
-]);
-
 const ALLOWED_KEY_RE = /^[a-zA-Z0-9_]{1,64}$/;
-const KEY_SUGGESTIONS = ['template', 'locale', 'campaign_id', 'priority', 'tag', 'reference_id'];
+
+const FILTER_TOKENS: FilterToken[] = [
+  { id: 'recipient', label: 'Recipient', namedKey: 'recipient' },
+  { id: 'sender', label: 'Sender', namedKey: 'sender' },
+  { id: 'subject', label: 'Subject', namedKey: 'subject' },
+  { id: 'message_body', label: 'Message body', namedKey: 'message_body' },
+  { id: 'template_name', label: 'Template (WA360)', namedKey: 'template_name' },
+  { id: 'contentSid', label: 'ContentSid', dataFilterKey: 'contentSid' },
+];
 
 @Component({
   selector: 'app-notification-filters',
   standalone: true,
-  imports: [
-    FormsModule,
-    ButtonModule,
-    ChipModule,
-    DrawerModule,
-    AutoCompleteModule,
-    IftaLabelModule,
-    InputTextModule,
-    MessageModule,
-    TooltipModule,
-    DividerModule,
-  ],
+  imports: [FormsModule, ButtonModule, InputTextModule, MessageModule, PopoverModule, TooltipModule],
   templateUrl: './notification-filters.html',
   styleUrl: './notification-filters.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    '(document:click)': 'onDocumentClick()',
+  },
 })
 export class NotificationFiltersComponent {
-  // External contract
+  private readonly searchInputRef = viewChild<ElementRef<HTMLInputElement>>('searchInput');
+
   readonly filters = input.required<NotificationFilters>();
   readonly filtersChange = output<NotificationFilters>();
   readonly clear = output<void>();
 
-  // Drawer state
-  readonly filtersOpen = signal(false);
+  // ---- Search bar state ----
+  readonly selectedToken = signal<FilterToken | null>(null);
+  readonly inputValue = signal<string>('');
+  readonly dropdownVisible = signal<boolean>(false);
 
-  // Local in-progress edits — committed to parent only on Apply.
-  readonly localFilters = signal<NotificationFilters>({});
+  // ---- Advanced popover state ----
+  readonly advRows = signal<AdvancedFilterRow[]>([]);
 
-  // Advanced rows — local; merged into localFilters only on Apply.
-  readonly advancedRows = signal<AdvancedFilterRow[]>([]);
+  readonly ALLOWED_KEY_RE = ALLOWED_KEY_RE;
 
-  // AutoComplete suggestions filtered by current typed prefix.
-  readonly filteredKeys = signal<string[]>(KEY_SUGGESTIONS);
+  // ---- Derived ----
 
-  // Surface RESERVED_KEYS in template for the inline error message branch.
-  readonly RESERVED_KEYS = RESERVED_KEYS;
+  readonly availableTokens = computed<FilterToken[]>(() => {
+    const f = this.filters();
+    const advKeys = new Set((f.advancedFilters ?? []).map((r) => r.key));
 
-  // Active chips read from the *applied* filters() input — not localFilters —
-  // so removing a chip emits filtersChange immediately, bypassing the drawer's
-  // Apply gate and updating the table without forcing the user to open the drawer.
+    return FILTER_TOKENS.filter((t) => {
+      if (t.namedKey) {
+
+        return !f[t.namedKey];
+      }
+
+      if (t.dataFilterKey) {
+
+        return !advKeys.has(t.dataFilterKey);
+      }
+
+      return true;
+    });
+  });
+
   readonly activeChips = computed<ActiveChip[]>(() => {
     const f = this.filters();
     const chips: ActiveChip[] = [];
 
-    if (f.recipient) {
+    if (f.search) {
       chips.push({
-        id: 'recipient',
-        label: `Recipient: ${f.recipient}`,
-        remove: () => this.emitWithoutKey('recipient'),
+        id: 'search',
+        label: `"${f.search}"`,
+        remove: () => this.removeField('search'),
       });
     }
 
-    if (f.sender) {
-      chips.push({
-        id: 'sender',
-        label: `Sender: ${f.sender}`,
-        remove: () => this.emitWithoutKey('sender'),
-      });
-    }
+    for (const token of FILTER_TOKENS) {
+      if (token.namedKey) {
+        const val = f[token.namedKey] as string | undefined;
 
-    if (f.subject) {
-      chips.push({
-        id: 'subject',
-        label: `Subject: ${f.subject}`,
-        remove: () => this.emitWithoutKey('subject'),
-      });
-    }
-
-    if (f.messageBody) {
-      chips.push({
-        id: 'messageBody',
-        label: `Message body: ${f.messageBody}`,
-        remove: () => this.emitWithoutKey('messageBody'),
-      });
+        if (val) {
+          chips.push({
+            id: token.id,
+            label: `${token.label} = ${val}`,
+            remove: () => this.removeField(token.namedKey as keyof NotificationFilters),
+          });
+        }
+      }
     }
 
     for (const row of f.advancedFilters ?? []) {
       chips.push({
-        id: `advanced:${row.id}`,
-        label: `${row.key}=${row.value}`,
-        remove: () => this.removeAdvancedFromApplied(row.id),
+        id: `adv:${row.id}`,
+        label: `${row.key} = ${row.value}`,
+        remove: () => this.removeAdvancedRow(row.id),
       });
     }
 
@@ -142,109 +131,197 @@ export class NotificationFiltersComponent {
 
   readonly activeCount = computed(() => this.activeChips().length);
 
-  // Apply button gating: every advanced row must have a non-empty value AND
-  // a valid key. Empty rows block Apply silently (no red); only filled-in
-  // invalid keys show the inline error message.
-  readonly canApply = computed(() =>
-    this.advancedRows().every((r) => Boolean(r.key) && Boolean(r.value) && this.isKeyValid(r.key)),
+  readonly placeholder = computed(() =>
+    this.selectedToken() || this.activeChips().length > 0 ? '' : 'Search or filter results...',
   );
 
-  constructor() {
-    // Hydrate localFilters from the applied filters() input — but ONLY when the
-    // drawer is closed. While the drawer is open the user's in-progress edits
-    // are sovereign; an external filters() change (e.g. URL nav, parent
-    // re-render, chip removal) must not wipe them.
-    effect(() => {
-      if (!this.filtersOpen()) {
-        const applied = this.filters();
+  readonly advCanApply = computed(
+    () =>
+      this.advRows().length > 0 &&
+      this.advRows().every(
+        (r) => Boolean(r.key) && Boolean(r.value) && ALLOWED_KEY_RE.test(r.key),
+      ),
+  );
 
-        this.localFilters.set({ ...applied });
-        this.advancedRows.set([...(applied.advancedFilters ?? [])]);
+  // ---- Search bar interactions ----
+
+  onBarClick(event: Event): void {
+    event.stopPropagation();
+    this.dropdownVisible.set(true);
+    this.searchInputRef()?.nativeElement.focus();
+  }
+
+  onFocus(): void {
+    this.dropdownVisible.set(true);
+  }
+
+  onInputBlur(): void {
+    // mousedown preventDefault on the dropdown div keeps focus in the input when
+    // clicking dropdown items, so this only fires when clicking truly outside
+    // (e.g. a PrimeNG dropdown that stops click propagation).
+    this.dropdownVisible.set(false);
+  }
+
+  onInputChange(value: string): void {
+    this.inputValue.set(value);
+  }
+
+  onKeydown(event: KeyboardEvent): void {
+    const val = this.inputValue().trim();
+    const token = this.selectedToken();
+
+    if (event.key === 'Enter') {
+      if (!val) {
+
+        return;
       }
-    });
-  }
 
-  // ---- localFilters editing ----
-
-  setLocal<K extends keyof NotificationFilters>(key: K, value: NotificationFilters[K]): void {
-    this.localFilters.update((f) => ({ ...f, [key]: value }));
-  }
-
-  // ---- Advanced rows editing ----
-
-  addRow(): void {
-    this.advancedRows.update((rows) => [
-      ...rows,
-      { id: this.makeId(), key: '', value: '' },
-    ]);
-  }
-
-  removeRow(index: number): void {
-    this.advancedRows.update((rows) => rows.filter((_, i) => i !== index));
-  }
-
-  updateKey(index: number, key: string): void {
-    this.advancedRows.update((rows) =>
-      rows.map((r, i) => (i === index ? { ...r, key } : r)),
-    );
-  }
-
-  updateValue(index: number, value: string): void {
-    this.advancedRows.update((rows) =>
-      rows.map((r, i) => (i === index ? { ...r, value } : r)),
-    );
-  }
-
-  searchKeys(event: AutoCompleteCompleteEvent): void {
-    const q = (event.query ?? '').toLowerCase();
-    const filtered = KEY_SUGGESTIONS.filter(
-      (k) => !RESERVED_KEYS.has(k) && k.toLowerCase().includes(q),
-    );
-
-    this.filteredKeys.set(filtered);
-  }
-
-  isKeyValid(key: string): boolean {
-    if (!key) {
-      return true; // empty key = not yet entered, not "invalid"
+      if (token) {
+        this.commitToken(token, val);
+      }
+      else {
+        this.commitSearch(val);
+      }
     }
+    else if (event.key === 'Escape') {
+      this.closeDropdown();
+    }
+    else if (event.key === 'Backspace' && !this.inputValue()) {
+      if (token) {
+        this.selectedToken.set(null);
+      } else {
+        const chips = this.activeChips();
 
-    return ALLOWED_KEY_RE.test(key) && !RESERVED_KEYS.has(key);
+        if (chips.length > 0) {
+          chips[chips.length - 1].remove();
+        }
+      }
+    }
   }
 
-  // ---- Apply / Reset ----
+  selectToken(token: FilterToken): void {
+    this.selectedToken.set(token);
+    this.inputValue.set('');
+    this.dropdownVisible.set(false);
+    setTimeout(() => this.searchInputRef()?.nativeElement.focus(), 0);
+  }
 
-  onApply(): void {
-    if (!this.canApply()) {
+  commitFromDropdown(): void {
+    const val = this.inputValue().trim();
+
+    if (!val) {
+
       return;
     }
 
-    const next: NotificationFilters = {
-      ...this.localFilters(),
-      advancedFilters: this.advancedRows().filter((r) => r.key && r.value),
-    };
+    const token = this.selectedToken();
 
-    this.filtersChange.emit(next);
-    this.filtersOpen.set(false);
+    if (token) {
+      this.commitToken(token, val);
+    }
+    else {
+      this.commitSearch(val);
+    }
   }
 
+  closeDropdown(): void {
+    this.dropdownVisible.set(false);
+    this.selectedToken.set(null);
+    this.inputValue.set('');
+  }
+
+  onDocumentClick(): void {
+    this.dropdownVisible.set(false);
+  }
+
+  private commitToken(token: FilterToken, value: string): void {
+    if (token.namedKey) {
+      this.filtersChange.emit({ ...this.filters(), [token.namedKey]: value });
+    }
+    else if (token.dataFilterKey) {
+      const row: AdvancedFilterRow = { id: this.makeId(), key: token.dataFilterKey, value };
+      const existing = this.filters().advancedFilters ?? [];
+
+      this.filtersChange.emit({ ...this.filters(), advancedFilters: [...existing, row] });
+    }
+
+    this.selectedToken.set(null);
+    this.inputValue.set('');
+    this.dropdownVisible.set(false);
+  }
+
+  private commitSearch(value: string): void {
+    // Clear all named text filters — keep only structural (dropdown) filters.
+    const f = this.filters();
+
+    this.filtersChange.emit({
+      channel_type: f.channel_type,
+      delivery_status: f.delivery_status,
+      application_id: f.application_id,
+      provider_id: f.provider_id,
+      date_from: f.date_from,
+      date_to: f.date_to,
+      sort: f.sort,
+      order: f.order,
+      search: value,
+    });
+    this.inputValue.set('');
+    this.dropdownVisible.set(false);
+  }
+
+  // ---- Advanced popover ----
+
+  openAdvanced(popover: { toggle: (event: MouseEvent) => void }, event: MouseEvent): void {
+    const applied = this.filters().advancedFilters ?? [];
+
+    this.advRows.set(applied.length ? [...applied] : [this.makeRow()]);
+    popover.toggle(event);
+  }
+
+  addAdvRow(): void {
+    this.advRows.update((rows) => [...rows, this.makeRow()]);
+  }
+
+  removeAdvRow(index: number): void {
+    this.advRows.update((rows) => rows.filter((_, i) => i !== index));
+  }
+
+  updateAdvKey(index: number, key: string): void {
+    this.advRows.update((rows) => rows.map((r, i) => (i === index ? { ...r, key } : r)));
+  }
+
+  updateAdvValue(index: number, value: string): void {
+    this.advRows.update((rows) => rows.map((r, i) => (i === index ? { ...r, value } : r)));
+  }
+
+  applyAdvanced(popover: { hide: () => void }): void {
+    if (!this.advCanApply()) {
+
+      return;
+    }
+
+    const rows = this.advRows().filter((r) => r.key && r.value);
+
+    this.filtersChange.emit({ ...this.filters(), advancedFilters: rows });
+    popover.hide();
+  }
+
+  // ---- Clear all ----
+
   onClearAll(): void {
-    // Clear local in-progress edits as well so the drawer reflects the cleared state.
-    this.localFilters.set({});
-    this.advancedRows.set([]);
     this.clear.emit();
   }
 
-  // ---- Chip removal helpers (operate on applied filters() directly) ----
+  // ---- Chip removal ----
 
-  private emitWithoutKey(key: keyof NotificationFilters): void {
+  private removeField(key: keyof NotificationFilters): void {
     const f = { ...this.filters() };
 
     delete f[key];
     this.filtersChange.emit(f);
   }
 
-  private removeAdvancedFromApplied(rowId: string): void {
+  private removeAdvancedRow(rowId: string): void {
     const f = { ...this.filters() };
 
     f.advancedFilters = (f.advancedFilters ?? []).filter((r) => r.id !== rowId);
@@ -253,5 +330,9 @@ export class NotificationFiltersComponent {
 
   private makeId(): string {
     return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  }
+
+  private makeRow(): AdvancedFilterRow {
+    return { id: this.makeId(), key: '', value: '' };
   }
 }

--- a/apps/portal/src/app/shared/components/notification-filters/notification-filters.ts
+++ b/apps/portal/src/app/shared/components/notification-filters/notification-filters.ts
@@ -39,8 +39,8 @@ const FILTER_TOKENS: FilterToken[] = [
   { id: 'sender', label: 'Sender', namedKey: 'sender' },
   { id: 'subject', label: 'Subject', namedKey: 'subject' },
   { id: 'message_body', label: 'Message body', namedKey: 'message_body' },
-  { id: 'template_name', label: 'Template (WA360)', namedKey: 'template_name' },
-  { id: 'contentSid', label: 'ContentSid', dataFilterKey: 'contentSid' },
+  { id: 'template_name', label: 'Template Name (WA360)', namedKey: 'template_name' },
+  { id: 'contentSid', label: 'ContentSid (Twilio)', dataFilterKey: 'contentSid' },
 ];
 
 @Component({

--- a/apps/portal/src/app/shared/components/notification-filters/notification-filters.ts
+++ b/apps/portal/src/app/shared/components/notification-filters/notification-filters.ts
@@ -139,8 +139,10 @@ export class NotificationFiltersComponent {
     () =>
       this.advRows().length > 0 &&
       this.advRows().every(
-        (r) => Boolean(r.key) && Boolean(r.value) && ALLOWED_KEY_RE.test(r.key),
-      ),
+        (r) =>
+          Boolean(r.key.trim()) && Boolean(r.value.trim()) && ALLOWED_KEY_RE.test(r.key.trim()),
+      ) &&
+      new Set(this.advRows().map((r) => r.key.trim())).size === this.advRows().length,
   );
 
   // ---- Search bar interactions ----
@@ -302,7 +304,9 @@ export class NotificationFiltersComponent {
       return;
     }
 
-    const rows = this.advRows().filter((r) => r.key && r.value);
+    const rows = this.advRows()
+      .filter((r) => r.key && r.value)
+      .map((r) => ({ ...r, key: r.key.trim(), value: r.value.trim() }));
 
     this.filtersChange.emit({ ...this.filters(), advancedFilters: rows });
     popover.hide();
@@ -311,6 +315,10 @@ export class NotificationFiltersComponent {
   // ---- Clear all ----
 
   onClearAll(): void {
+    this.selectedToken.set(null);
+    this.inputValue.set('');
+    this.dropdownVisible.set(false);
+    this.advRows.set([]);
     this.clear.emit();
   }
 


### PR DESCRIPTION
## API PR Checklist

### Task Link

https://pinestem.com/dashboard.html#/tasks/REST-2310/details/?companyId=453&isPrevNext=1

### Pre-requisites

- [x] I have gone through the Contributing guidelines for [Submitting a Pull Request (PR)](https://github.com/OsmosysSoftware/osmo-x/blob/main/CONTRIBUTING.md#-submitting-a-pull-request-pr) and ensured that this is not a duplicate PR.
- [x] I have performed unit testing for the new feature added or updated to ensure the new features added are working as expected.
- [ ] I have added/updated test cases to the [test suite](https://github.com/OsmosysSoftware/osmo-x/blob/main/apps/api/OsmoX.postman_collection.json) as applicable.  _(no new endpoints — only new query params on existing GETs; can be added as a follow-up if reviewer wants Postman coverage)_
- [ ] I have performed preliminary testing using the [test suite](https://github.com/OsmosysSoftware/osmo-x/blob/main/apps/api/OsmoX.postman_collection.json) to ensure that any existing features are not impacted and any new features are working as expected as a whole.  _(deferred to QA — see Pending actions; I had no `apps/api/.env` to run the stack locally)_
- [x] I have added/updated the required [api docs](https://github.com/OsmosysSoftware/osmo-x/tree/main/apps/api/docs) as applicable.  _(Swagger regenerates from new `@ApiQuery` annotations on both controllers; no separate doc files needed)_
- [x] I have added/updated the `.env.example` file with the required values as applicable.  _(no new env vars introduced)_

### PR Details

- [x] PR title adheres to the format specified in guidelines (`feat: add property-specific filters for notification data JSON`)
- [x] Description has been added
- [x] Related changes have been added
- [ ] Screenshots have been added  _(deferred — no running portal locally; QA will capture them)_
- [x] Query request and response examples have been added
- [x] Documentation changes have been listed
- [x] Test suite/unit testing output is added
- [x] Pending actions have been added
- [x] Any other additional notes have been added

### Additional Information

- [x] Appropriate label(s) have been added
- [ ] Assignee(s) and reviewer(s) have been added  _(left to repo conventions)_

---

**Description:**

Adds property-specific filtering on the notification `data` JSON column for both the live Notifications list and the Archived Notifications list — backend (NestJS), portal (Angular 20), and DB migration in a single PR.

Today the only way to query `data` is one free-text Search input that runs `CAST(data AS text) LIKE '%x%'`. Operators frequently want answers like *"who did we send this notification to?"* / *"all notifications sent by X to Y"* / *"all with subject containing 'invoice'"*. This PR adds:

- 4 named filters on both list endpoints: **Recipient** (matches `to`/`cc`/`bcc`/`target` for both string and array values), **Sender** (`from`), **Subject**, **Message body** (covers `text`/`html`/`message` + WhatsApp `text.body` + push `message.default`).
- A generic **Advanced** key/value mechanism (`data_filter[key]=value`, repeated, AND-combined).
- A new shared `<app-notification-filters>` portal component (PrimeNG drawer + chip strip) used by both list pages.
- Existing free-text search and toolbar selects are preserved as fallbacks; new filters are AND-combined with them.
- DB migration: `data`/`result` columns → `jsonb`, install `pg_trgm`, whole-jsonb GIN indexes, and `pg_trgm` GIN trigram expression indexes on `(data->>'subject')`, `(data->>'from')`, `(data->>'to')` for both tables. Trigram indexes accelerate substring `ILIKE '%v%'` for patterns ≥ 3 characters.

**Related changes:**

Backend (`apps/api`):

- `src/main.ts` — enable Express `'extended'` query parser (`qs`) so `?data_filter[key]=value` parses into a nested object.
- `src/common/dto/pagination-query.dto.ts` — add `recipient`, `sender`, `subject`, `messageBody`, `dataFilter` fields with snake_case `@Transform`s and `@Validate(IsDataFilterMap)`.
- `src/common/validators/is-data-filter-map.validator.ts` (new) — rejects arrays, prototype-pollution keys, regex-violating keys, non-string values, empty values, oversized values. Covered by 9 unit tests.
- `src/common/graphql/services/core.service.ts` — add optional `applyExtraFilters` callback to `findAll` and `findAllPaginated`, applied after the bracketed free-text search so `andWhere` composes safely.
- `src/modules/notifications/helpers/notification-data-filter.helper.ts` (new) — predicates for recipient (string + array via `jsonb_typeof` guards and `jsonb_array_elements_text`), sender, subject, multi-channel message body (`->>` and `#>>` paths), and parameterized `data_filter[key]=value` with `ndf_`-prefixed bindings. Covered by 8 unit tests.
- `src/modules/notifications/notifications.{controller,service,module}.ts` — wire helper into `getAllNotificationsAsDto`, register as provider/export.
- `src/modules/archived-notifications/archived-notifications.{controller,service}.ts` — mirror.
- Both controllers' `@ApiQuery` annotations updated for the 5 new params (incl. `style: 'deepObject'` for `data_filter`).
- Entities: `notify_notifications.data`/`.result` and `notify_archived_notifications.data`/`.result` → `jsonb`.

Migrations:

- `1774000000000-jsonb-data-and-pg-trgm.ts` (transactional) — column rewrite (ACCESS EXCLUSIVE on the table — see runbook below), `CREATE EXTENSION pg_trgm`, whole-jsonb GIN indexes.
- `1774000000100-jsonb-trigram-indexes.ts` (`transaction = false`) — 6× `CREATE INDEX CONCURRENTLY` GIN trigram indexes on the hot named-filter keys.

Portal (`apps/portal`):

- `src/app/core/models/notification-filters.model.ts` (new) — shared interface with camelCase fields.
- `src/app/shared/components/notification-filters/` (new) — PrimeNG `p-drawer` + `p-iftaLabel` named inputs + `p-autocomplete` Advanced rows + `p-chip` removable chip strip + `p-button` Filters trigger with built-in badge. Drawer-closed-only `effect()` for hydration so in-progress edits aren't wiped by external state changes; chip removal bypasses the Apply gate by emitting against applied state directly.
- Both feature services: extend `NotificationFilters` and append the new params (named via `HttpParams.set`, `data_filter` via `HttpParams.append('data_filter[k]', v)`).
- Both list pages: rename existing snake_case filter properties to camelCase, integrate `<app-notification-filters>` into the toolbar, route `(filtersChange)` into `loadNotifications()`.

**Screenshots:**

_To be captured during manual QA in Docker — see Pending actions._

**Query request and response:**

```bash
AUTH="Authorization: Bearer $TOKEN"

# Named filters
curl -G "$API_BASE/notifications" -H "$AUTH" --data-urlencode 'recipient=jane@example.com'
curl -G "$API_BASE/notifications" -H "$AUTH" --data-urlencode 'sender=noreply@osmox.co' --data-urlencode 'subject=invoice'
curl -G "$API_BASE/archived-notifications" -H "$AUTH" --data-urlencode 'message_body=password'

# Advanced filter (AND-combined)
curl -G "$API_BASE/notifications" -H "$AUTH" --data-urlencode 'data_filter[locale]=en' --data-urlencode 'data_filter[template]=otp_v2'

# Validator rejection (regex fails on '!')
curl -G "$API_BASE/notifications" -H "$AUTH" --data-urlencode 'data_filter[bad-key!]=x'  # 400 Bad Request
```

Note: `data_filter[__proto__]=x` returns 200 — Express's `qs` parser strips `__proto__` before validation. The validator branch is exercised directly by a unit test: `new IsDataFilterMap().validate(Object.fromEntries([['__proto__', 'x']]))` returns `false`.

Response shape unchanged: same paginated `{ items, page_info, links }` envelope as the existing endpoints.

**Documentation changes:**

- Swagger `@ApiQuery` annotations added on both list controllers for: `recipient`, `sender`, `subject`, `message_body`, `data_filter` (rendered as `style: deepObject` in the OpenAPI spec).
- No standalone `apps/api/docs/` markdown files added — the new params surface through the auto-generated Swagger UI.

**Test suite/unit testing output:**

```
PASS  src/common/validators/is-data-filter-map.validator.spec.ts  (9/9 passing)
PASS  src/modules/notifications/helpers/notification-data-filter.helper.spec.ts  (8/8 passing)
```

Note: the repo's broader Jest suite has pre-existing failures from a `rootDir: src` config that doesn't resolve absolute `src/...` imports (every entity that imports `src/common/constants/database` fails to load). Same failures on `main` — out of scope for this PR.

**Migration runbook:**

1. **Pre-flight check.** `SELECT count(*) FROM notify_notifications;` and same for `notify_archived_notifications`. If either is multi-million rows, schedule a maintenance window — `ALTER COLUMN ... TYPE jsonb` takes ACCESS EXCLUSIVE on the table.
2. `npm run typeorm:run-migration` — runs both 6a (transactional column rewrite + whole-jsonb GIN) and 6b (CONCURRENTLY trigram indexes). Migration 6b doesn't block writes during the build phase.
3. **Verify:**

   ```bash
   psql "$DB_URL" -c "d notify_notifications"  # confirm jsonb + indexes
   psql "$DB_URL" -c "SELECT extname FROM pg_extension WHERE extname='pg_trgm'"
   psql "$DB_URL" -c "EXPLAIN ANALYZE SELECT count(*) FROM notify_notifications WHERE data->>'subject' ILIKE '%invoice%'"
   # Expect: Bitmap Index Scan on IDX_notify_notifications_data_subject_trgm
   ```

4. **Capture index sizes** for the PR record:

   ```sql
   SELECT pg_size_pretty(pg_relation_size('IDX_notify_notifications_data_subject_trgm'));
   -- repeat for the other 5 trigram indexes and the 2 whole-jsonb GIN indexes
   ```

**Pending actions:**

- [ ] **DBA / migration verification on staging** with production-shaped data — confirm both migrations apply cleanly, EXPLAIN ANALYZE hits the trigram indexes, capture `pg_size_pretty` numbers and paste them into a PR comment. Could not run locally — no `apps/api/.env` present.
- [ ] **Portal manual QA in Docker** — `cd apps/api && docker compose up -d --build && cd ../portal && docker compose up -d --build`, then walk through the QA checklist in Additional notes. Capture screenshots of the drawer, chips, and Advanced rows for the PR.
- [ ] **Postman test-suite update** (optional) — add cases for the 5 new query params on `GET /notifications` and `GET /archived-notifications`.

**Additional notes:**

**Manual QA checklist** (mirrors the verification section in the implementation plan):

On both **Notifications** and **Archived Notifications** pages:

1. Send several test notifications with varied recipients (string + array `to`), subjects, message bodies, channels.
2. Click the **Filters** toolbar button — drawer slides in from the right with sticky `Apply` / `Reset` footer.
3. Type into **Recipient**, click **Apply** — table narrows; verify both string `to` and array recipients match. A removable chip appears above the table.
4. Add 2 Advanced rows (e.g. `template=otp_v2`, `locale=en`); type a reserved key (`to`) — confirm red border + inline error and Apply disabled. Switch to a custom key — Apply re-enables.
5. Apply, verify chips show `data_filter[template]=otp_v2` etc.; click X on one chip — that filter clears immediately without reopening the drawer.
6. Combine Advanced + Recipient + free-text Search — all AND-combined.
7. Confirm the **Filters** button shows a count badge; closing the drawer with Esc and outside-click both work.
8. Click **Reset** in drawer footer or **Clear all** next to chips — all filters reset.
9. Resize to mobile width — drawer auto-fills.

**Trigram 3-character minimum.** `pg_trgm` GIN indexes need patterns ≥ 3 characters. Surfaced in each input's tooltip ("Type at least 3 characters for fast results"). Searches like `hi` (2 chars) will seq-scan — expected, not a bug.

**HTML in message body search.** `message_body` matches against raw HTML markup (not just text) for emails. Documented in the tooltip; users searching for `<` or `style` will get noisy results.

**GitHub-style query DSL** (`to:jane subject:invoice`) was considered and deferred. Zero backend changes are needed — it's pure portal sugar over the existing query-param contract — so it can ship later as a focused follow-up if real usage shows operators repeating the same filter combinations.

**Portal PR notes** (this PR also touches `apps/portal`, so the relevant portal-template items):

- [x] PR title adheres to the conventional commit format.
- [x] Description added (above).
- [x] Related changes added (above).
- [ ] Screenshots — deferred to QA in Docker.
- [x] Pending actions added (above).
- [x] Additional notes added (above).
- [x] Portal unit testing: `npm run lint` and `npm run build:prod` clean on the new shared component and both list pages.
- [ ] Portal preliminary testing (Docker) — deferred to QA.

---

## Additional Verification & Updates

### Unit Tests
- [x] `is-data-filter-map.validator.spec.ts` — 9/9 passing  
- [x] `notification-data-filter.helper.spec.ts` — 8/8 passing  
- [x] `template_name` filter — covered by unit test  

### Infrastructure
- [x] Docker healthy (api, postgres, redis)  
- [x] Migrations applied  
- [x] `jsonb` + `pg_trgm` + trigram indexes verified  
- [x] Trigram index usage confirmed (`EXPLAIN ANALYZE`)  

### API Validation

#### GET /notifications
- [x] recipient / sender / subject / message_body → correct results  
- [x] no-match → 0 results  
- [x] `data_filter` match / no-match → correct results  
- [x] invalid / long keys → HTTP 400  
- [x] `__proto__` → safely ignored (200)  
- [x] combined filters → correct intersection  

#### GET /archived-notifications
- [x] recipient / message_body → correct results  
- [x] no-match → 0 results  
- [x] invalid `data_filter` → HTTP 400  

### Swagger & UI
- [x] All params exposed (`recipient`, `sender`, `subject`, `message_body`, `data_filter`, `template_name`)  
- [x] Portal tested manually  

---

## Additional Changes

### Backend fixes
1. Enabled `migrationsTransactionMode: 'each'` for concurrent indexes  
2. Enabled `transform: true` in `ValidationPipe`  
3. Fixed DTO mapping by switching to snake_case (`message_body`, `data_filter`)  
4. Removed rawQuery workaround — now using DTO directly  
5. Added `q()` helper to fix alias quoting issue  
6. Updated tests for quoted aliases  

### Portal alignment
7. Enforced snake_case model (removed camelCase mismatch)  
8. Removed unnecessary mapping layer  
9. Updated all UI references accordingly  
10. Documented rule in `SKILL.md`  

---

## notification-filters (UI + Backend)

### UI (Search Bar)
- Replaced drawer/token-bar with **GitLab-style unified search bar**  
- Single input supports free-text + field filters  
- Smart dropdown:
  - typing → search mode  
  - idle → filter tokens  
- Inline chips; Backspace removes last  
- Blur closes dropdown reliably  
- Added `template_name` token  
- Simplified styling (Tailwind + minimal SCSS)  

### Parent Pages
- Removed separate search input  
- `onPropertyFiltersChange` now includes `search` + `template_name`  

### Backend (`template_name` for 360 Dialog)
- Added predicate: `data->'template'->>'name'`  
- Added `template_name` query param (DTO)  
- Wired through controllers + services 

Test Document - https://osmosysasia-my.sharepoint.com/:b:/g/personal/jagrat_s_osmosys_co/IQAXHCzsstTpRJvVk-m-bYxTATxRAPkEGqwCDGgC8_D41sQ?e=P3Dok9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rich property filters for Notifications and Archived Notifications: recipient, sender, subject, message body, template name.
  * Advanced key/value data filters via a Filters drawer UI with removable chips and repeatable advanced rows.
  * Backend supports deep-object data_filter queries and improved substring search powered by JSONB + trigram indexes for faster results.

* **Documentation**
  * Clarified API rule: use snake_case for request filter/query fields.

* **Tests**
  * Added validator and helper unit tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->