### PR TITLE
feat: load portal API URL at runtime via /assets/config.json

### DIFF
--- a/apps/api/docs-site/getting-started/development.mdx
+++ b/apps/api/docs-site/getting-started/development.mdx
@@ -127,7 +127,7 @@ The portal is the Angular frontend for managing notifications, providers, and ap
     cp .env.example .env
     ```
 
-    The portal's API URL is configured at **runtime** via `API_URL` in `.env` — no rebuild is needed when switching backends. The container generates `/assets/config.json` from this env var on every start. `API_DOCS_URL` is optional; when unset it's derived from `${API_URL}/docs`.
+    The portal's API URL is configured at **runtime** via `API_URL` in `.env` — no rebuild is needed when switching backends. The container generates `/assets/config.json` from this env var on every start.
   </Step>
 
   <Step title="Start with Docker (recommended)">
@@ -135,17 +135,70 @@ The portal is the Angular frontend for managing notifications, providers, and ap
     docker compose up -d --build
     ```
 
-    The portal will be available at `http://localhost:4200`.
+    The portal will be available at `http://localhost:4200` (or whichever `SERVER_PORT` is set in `.env`).
   </Step>
 
   <Step title="Repoint at a different backend">
-    Edit `API_URL` in `apps/portal/.env` and run `docker compose up -d` — no `--build` flag, no rebuild, ~2 seconds.
+    Edit `API_URL` in `apps/portal/.env` and run `docker compose up -d` — no `--build` flag, no rebuild, ~2 seconds. Compose recreates the container with the new env; the entrypoint regenerates `config.json`.
   </Step>
 </Steps>
 
-<Tip>
-  For live host-side edits to `config.json` (no container restart needed), uncomment the bind-mount and `SKIP_RUNTIME_CONFIG_GENERATION` blocks in `apps/portal/docker-compose.yml`. Use a directory bind mount, not a file mount — file-level mounts break when editors atomic-write.
-</Tip>
+### Required `.env` variables
+
+| Variable | Required | Default | Notes |
+| --- | --- | --- | --- |
+| `COMPOSE_PROJECT_NAME` | yes | `osmox-portal` | Docker project namespace |
+| `SERVER_PORT` | yes | `4200` | Host port the container binds to (`127.0.0.1` only) |
+| `API_URL` | yes | `http://localhost:3000` | Backend URL written into `/assets/config.json` at container start |
+| `API_DOCS_URL` | no | derived from `${API_URL}/docs` | Override only if your docs URL is on a different host or path |
+
+### Common operations
+
+```bash
+docker compose stop                                       # stop, keep container
+docker compose down                                       # stop + remove
+docker compose logs -f                                    # tail logs
+docker exec osmox-portal cat /runtime-config/config.json  # verify what got written
+```
+
+### Optional: host-managed config (live edits, no restart)
+
+Useful during active debugging — edit a host JSON file and the running container picks it up on the next browser refresh, no `docker` command needed.
+
+<Steps>
+  <Step title="Set up the host config file">
+    ```bash
+    cd osmo-x/apps/portal
+    mkdir runtime-config
+    cp runtime-config.example.json runtime-config/config.json
+    ```
+  </Step>
+
+  <Step title="Uncomment the override blocks in docker-compose.yml">
+    In `apps/portal/docker-compose.yml`, uncomment the pre-existing blocks:
+
+    ```yaml
+    environment:
+      # ...existing entries above...
+      SKIP_RUNTIME_CONFIG_GENERATION: "true"   # uncomment
+
+    volumes:                                    # uncomment block
+      - ./runtime-config:/runtime-config:ro
+    ```
+  </Step>
+
+  <Step title="Start the container">
+    ```bash
+    docker compose up -d
+    ```
+
+    From now on: edit `apps/portal/runtime-config/config.json`, refresh the browser. No `docker` command needed.
+  </Step>
+</Steps>
+
+<Warning>
+  Use a **directory** mount (`./runtime-config:/runtime-config:ro`), not a file mount — file-level bind mounts get severed when editors atomic-write (the default behavior for VS Code, vim, and most modern editors).
+</Warning>
 
 ### Development mode (hot reload)
 

--- a/apps/api/docs-site/getting-started/development.mdx
+++ b/apps/api/docs-site/getting-started/development.mdx
@@ -116,6 +116,47 @@ This script periodically calls OsmoX APIs to:
 
 You can also run OsmoX using Docker while using a local database. See the Docker guide in `apps/api/docs/use-local-db-instead-of-dockerized-db/README.md` for details.
 
+## Portal Setup
+
+The portal is the Angular frontend for managing notifications, providers, and applications.
+
+<Steps>
+  <Step title="Configure environment">
+    ```bash
+    cd osmo-x/apps/portal
+    cp .env.example .env
+    ```
+
+    The portal's API URL is configured at **runtime** via `API_URL` in `.env` — no rebuild is needed when switching backends. The container generates `/assets/config.json` from this env var on every start. `API_DOCS_URL` is optional; when unset it's derived from `${API_URL}/docs`.
+  </Step>
+
+  <Step title="Start with Docker (recommended)">
+    ```bash
+    docker compose up -d --build
+    ```
+
+    The portal will be available at `http://localhost:4200`.
+  </Step>
+
+  <Step title="Repoint at a different backend">
+    Edit `API_URL` in `apps/portal/.env` and run `docker compose up -d` — no `--build` flag, no rebuild, ~2 seconds.
+  </Step>
+</Steps>
+
+<Tip>
+  For live host-side edits to `config.json` (no container restart needed), uncomment the bind-mount and `SKIP_RUNTIME_CONFIG_GENERATION` blocks in `apps/portal/docker-compose.yml`. Use a directory bind mount, not a file mount — file-level mounts break when editors atomic-write.
+</Tip>
+
+### Development mode (hot reload)
+
+```bash
+cd osmo-x/apps/portal
+npm install
+npm start
+```
+
+The dev server runs at `http://localhost:4200`. In dev mode the API URL comes from the committed default at `apps/portal/src/assets/config.json` — edit it locally to point at a different backend, or use the Docker workflow above.
+
 ## Next Steps
 
 <CardGroup cols={2}>

--- a/apps/api/docs-site/getting-started/development.mdx
+++ b/apps/api/docs-site/getting-started/development.mdx
@@ -145,12 +145,12 @@ The portal is the Angular frontend for managing notifications, providers, and ap
 
 ### Required `.env` variables
 
-| Variable | Required | Default | Notes |
-| --- | --- | --- | --- |
-| `COMPOSE_PROJECT_NAME` | yes | `osmox-portal` | Docker project namespace |
-| `SERVER_PORT` | yes | `4200` | Host port the container binds to (`127.0.0.1` only) |
-| `API_URL` | yes | `http://localhost:3000` | Backend URL written into `/assets/config.json` at container start |
-| `API_DOCS_URL` | no | derived from `${API_URL}/docs` | Override only if your docs URL is on a different host or path |
+| Variable | Always required | Notes |
+| --- | --- | --- |
+| `COMPOSE_PROJECT_NAME` | yes | Docker project namespace |
+| `SERVER_PORT` | yes | Host port the container binds to (`127.0.0.1` only) |
+| `API_URL` | env-var workflow only | Backend URL the entrypoint writes into `/assets/config.json` at container start. **Ignored** under the host-file workflow (where `runtime-config/config.json` is the source of truth). |
+| `API_DOCS_URL` | env-var workflow only, optional | Derived from `${API_URL}/docs` when unset. Ignored under the host-file workflow. |
 
 ### Common operations
 

--- a/apps/api/docs-site/getting-started/development.mdx
+++ b/apps/api/docs-site/getting-started/development.mdx
@@ -120,37 +120,37 @@ You can also run OsmoX using Docker while using a local database. See the Docker
 
 The portal is the Angular frontend for managing notifications, providers, and applications.
 
+The portal's runtime config (`apiUrl`, `apiDocsUrl`) lives in a host file at `apps/portal/runtime-config/config.json`, bind-mounted into the container. To repoint the portal at a different backend, you edit that JSON file on the host — no container restart, no rebuild, no `docker` command.
+
 <Steps>
-  <Step title="Configure environment">
+  <Step title="First-time setup">
     ```bash
     cd osmo-x/apps/portal
     cp .env.example .env
-    ```
 
-    The portal's API URL is configured at **runtime** via `API_URL` in `.env` — no rebuild is needed when switching backends. The container generates `/assets/config.json` from this env var on every start.
-  </Step>
+    mkdir -p runtime-config
+    cp runtime-config.example.json runtime-config/config.json
+    # (optional) edit runtime-config/config.json to point at your backend
 
-  <Step title="Start with Docker (recommended)">
-    ```bash
     docker compose up -d --build
     ```
 
     The portal will be available at `http://localhost:4200` (or whichever `SERVER_PORT` is set in `.env`).
   </Step>
 
-  <Step title="Repoint at a different backend">
-    Edit `API_URL` in `apps/portal/.env` and run `docker compose up -d` — no `--build` flag, no rebuild, ~2 seconds. Compose recreates the container with the new env; the entrypoint regenerates `config.json`.
+  <Step title="Day-to-day: repoint at a different backend">
+    Edit `apps/portal/runtime-config/config.json` and refresh the browser. That's it — nginx serves the host file directly through the directory bind mount.
   </Step>
 </Steps>
 
 ### Required `.env` variables
 
-| Variable | Always required | Notes |
-| --- | --- | --- |
-| `COMPOSE_PROJECT_NAME` | yes | Docker project namespace |
-| `SERVER_PORT` | yes | Host port the container binds to (`127.0.0.1` only) |
-| `API_URL` | env-var workflow only | Backend URL the entrypoint writes into `/assets/config.json` at container start. **Ignored** under the host-file workflow (where `runtime-config/config.json` is the source of truth). |
-| `API_DOCS_URL` | env-var workflow only, optional | Derived from `${API_URL}/docs` when unset. Ignored under the host-file workflow. |
+| Variable | Notes |
+| --- | --- |
+| `COMPOSE_PROJECT_NAME` | Docker project namespace |
+| `SERVER_PORT` | Host port the container binds to (`127.0.0.1` only) |
+
+`apiUrl` / `apiDocsUrl` are **not** environment variables — they're fields in `runtime-config/config.json`.
 
 ### Common operations
 
@@ -158,46 +158,11 @@ The portal is the Angular frontend for managing notifications, providers, and ap
 docker compose stop                                       # stop, keep container
 docker compose down                                       # stop + remove
 docker compose logs -f                                    # tail logs
-docker exec osmox-portal cat /runtime-config/config.json  # verify what got written
+docker exec osmox-portal cat /runtime-config/config.json  # verify what's being served
 ```
 
-### Optional: host-managed config (live edits, no restart)
-
-Useful during active debugging — edit a host JSON file and the running container picks it up on the next browser refresh, no `docker` command needed.
-
-<Steps>
-  <Step title="Set up the host config file">
-    ```bash
-    cd osmo-x/apps/portal
-    mkdir runtime-config
-    cp runtime-config.example.json runtime-config/config.json
-    ```
-  </Step>
-
-  <Step title="Uncomment the override blocks in docker-compose.yml">
-    In `apps/portal/docker-compose.yml`, uncomment the pre-existing blocks:
-
-    ```yaml
-    environment:
-      # ...existing entries above...
-      SKIP_RUNTIME_CONFIG_GENERATION: "true"   # uncomment
-
-    volumes:                                    # uncomment block
-      - ./runtime-config:/runtime-config:ro
-    ```
-  </Step>
-
-  <Step title="Start the container">
-    ```bash
-    docker compose up -d
-    ```
-
-    From now on: edit `apps/portal/runtime-config/config.json`, refresh the browser. No `docker` command needed.
-  </Step>
-</Steps>
-
 <Warning>
-  Use a **directory** mount (`./runtime-config:/runtime-config:ro`), not a file mount — file-level bind mounts get severed when editors atomic-write (the default behavior for VS Code, vim, and most modern editors).
+  The bind mount is a **directory** mount (`./runtime-config:/runtime-config:ro`), not a file mount — file-level bind mounts get severed when editors atomic-write (the default behavior for VS Code, vim, and most modern editors).
 </Warning>
 
 ### Development mode (hot reload)

--- a/apps/api/docs/development-setup.md
+++ b/apps/api/docs/development-setup.md
@@ -68,23 +68,74 @@ The portal is the Angular frontend for managing notifications, providers, and ap
 
 ### Docker (Recommended)
 
+#### First-time setup
+
 ```bash
 cd osmo-x/apps/portal
-cp .env.example .env       # first-time setup
+cp .env.example .env       # creates the env file you'll edit going forward
 docker compose up -d --build
 ```
 
-The portal will be available at <http://localhost:4200>.
+The portal will be available at <http://localhost:4200> (or whichever `SERVER_PORT` you set in `.env`).
 
-The portal's API URL is configured at **runtime** via `API_URL` in `apps/portal/.env` — no rebuild is needed when switching backends. The container generates `/assets/config.json` from this env var on every start. Optionally, set `API_DOCS_URL`; if unset it's derived from `${API_URL}/docs`.
+#### Required env vars (`apps/portal/.env`)
+
+| Variable | Required | Default | Notes |
+| --- | --- | --- | --- |
+| `COMPOSE_PROJECT_NAME` | yes | `osmox-portal` | Docker project namespace |
+| `SERVER_PORT` | yes | `4200` | Host port the container binds to (`127.0.0.1` only) |
+| `API_URL` | yes | `http://localhost:3000` | Backend URL written into `/assets/config.json` at container start |
+| `API_DOCS_URL` | no | derived from `${API_URL}/docs` | Override only if your docs URL is on a different host or path |
+
+#### Repointing at a different backend (no rebuild)
 
 ```bash
-# Repoint the portal at a different backend without rebuilding:
-# 1. edit apps/portal/.env to set API_URL=http://my-api.example.com
-# 2. docker compose up -d
+# 1. edit apps/portal/.env  →  API_URL=http://my-api.example.com
+# 2. recreate the container — same image, ~2 seconds
+docker compose up -d
 ```
 
-For host-managed runtime config (live edits to `config.json` without container restart), see the commented bind-mount block in `apps/portal/docker-compose.yml`.
+The image is unchanged. Compose recreates the container with the new env, the entrypoint regenerates `/runtime-config/config.json`, nginx serves it.
+
+#### Common operations
+
+```bash
+docker compose stop                                       # stop, keep container
+docker compose down                                       # stop + remove
+docker compose logs -f                                    # tail logs
+docker exec osmox-portal cat /runtime-config/config.json  # verify what got written
+```
+
+#### Optional: host-managed config (live edits, no restart)
+
+Useful during active debugging — edit a host JSON file and the running container picks it up on the next browser refresh.
+
+```bash
+# 1. one-time setup
+cd osmo-x/apps/portal
+mkdir runtime-config
+cp runtime-config.example.json runtime-config/config.json
+```
+
+Then edit `apps/portal/docker-compose.yml` and uncomment the two pre-commented blocks:
+
+```yaml
+environment:
+  # ...existing entries above...
+  SKIP_RUNTIME_CONFIG_GENERATION: "true"   # uncomment
+
+volumes:                                    # uncomment block
+  - ./runtime-config:/runtime-config:ro
+```
+
+```bash
+# 2. start with the override active
+docker compose up -d
+
+# 3. from now on: edit runtime-config/config.json, refresh the browser. No docker command needed.
+```
+
+Use a **directory** mount (`./runtime-config:/runtime-config:ro`), not a file mount — file-level bind mounts get severed when editors atomic-write (the default for VS Code, vim, most modern editors).
 
 ### Development mode
 

--- a/apps/api/docs/development-setup.md
+++ b/apps/api/docs/development-setup.md
@@ -70,10 +70,21 @@ The portal is the Angular frontend for managing notifications, providers, and ap
 
 ```bash
 cd osmo-x/apps/portal
+cp .env.example .env       # first-time setup
 docker compose up -d --build
 ```
 
 The portal will be available at <http://localhost:4200>.
+
+The portal's API URL is configured at **runtime** via `API_URL` in `apps/portal/.env` — no rebuild is needed when switching backends. The container generates `/assets/config.json` from this env var on every start. Optionally, set `API_DOCS_URL`; if unset it's derived from `${API_URL}/docs`.
+
+```bash
+# Repoint the portal at a different backend without rebuilding:
+# 1. edit apps/portal/.env to set API_URL=http://my-api.example.com
+# 2. docker compose up -d
+```
+
+For host-managed runtime config (live edits to `config.json` without container restart), see the commented bind-mount block in `apps/portal/docker-compose.yml`.
 
 ### Development mode
 
@@ -85,7 +96,7 @@ npm install
 npm start
 ```
 
-The dev server runs at <http://localhost:4200>. The portal connects to the API at `http://localhost:3000` by default (configured in `src/environments/environment.ts`).
+The dev server runs at <http://localhost:4200>. The portal connects to the API at `http://localhost:3000` by default. In dev mode the URL comes from the committed default at `apps/portal/src/assets/config.json` — edit it locally to point at a different backend, or use the Docker workflow described above.
 
 ### Login to Portal
 

--- a/apps/api/docs/development-setup.md
+++ b/apps/api/docs/development-setup.md
@@ -80,12 +80,12 @@ The portal will be available at <http://localhost:4200> (or whichever `SERVER_PO
 
 #### Required env vars (`apps/portal/.env`)
 
-| Variable | Required | Default | Notes |
-| --- | --- | --- | --- |
-| `COMPOSE_PROJECT_NAME` | yes | `osmox-portal` | Docker project namespace |
-| `SERVER_PORT` | yes | `4200` | Host port the container binds to (`127.0.0.1` only) |
-| `API_URL` | yes | `http://localhost:3000` | Backend URL written into `/assets/config.json` at container start |
-| `API_DOCS_URL` | no | derived from `${API_URL}/docs` | Override only if your docs URL is on a different host or path |
+| Variable | Always required | Notes |
+| --- | --- | --- |
+| `COMPOSE_PROJECT_NAME` | yes | Docker project namespace |
+| `SERVER_PORT` | yes | Host port the container binds to (`127.0.0.1` only) |
+| `API_URL` | env-var workflow only | Backend URL the entrypoint writes into `/assets/config.json` at container start. **Ignored** under the host-file workflow (`SKIP_RUNTIME_CONFIG_GENERATION=true`) where `runtime-config/config.json` is the source of truth. |
+| `API_DOCS_URL` | env-var workflow only, optional | Derived from `${API_URL}/docs` when unset. Override only if your docs URL is on a different host or path. Ignored under the host-file workflow. |
 
 #### Repointing at a different backend (no rebuild)
 

--- a/apps/api/docs/development-setup.md
+++ b/apps/api/docs/development-setup.md
@@ -68,34 +68,35 @@ The portal is the Angular frontend for managing notifications, providers, and ap
 
 ### Docker (Recommended)
 
+The portal's runtime config (`apiUrl`, `apiDocsUrl`) lives in a host file at `apps/portal/runtime-config/config.json`, bind-mounted into the container. To repoint the portal at a different backend, you edit that JSON file on the host — no container restart, no rebuild.
+
 #### First-time setup
 
 ```bash
 cd osmo-x/apps/portal
-cp .env.example .env       # creates the env file you'll edit going forward
+cp .env.example .env
+
+mkdir -p runtime-config
+cp runtime-config.example.json runtime-config/config.json
+# (optional) edit runtime-config/config.json to point at your backend
+
 docker compose up -d --build
 ```
 
 The portal will be available at <http://localhost:4200> (or whichever `SERVER_PORT` you set in `.env`).
 
+#### Day-to-day
+
+To repoint at a different backend, edit `apps/portal/runtime-config/config.json` and refresh the browser. That's it — no `docker compose up`, no restart, no rebuild. nginx serves the host file directly through the bind mount.
+
 #### Required env vars (`apps/portal/.env`)
 
-| Variable | Always required | Notes |
-| --- | --- | --- |
-| `COMPOSE_PROJECT_NAME` | yes | Docker project namespace |
-| `SERVER_PORT` | yes | Host port the container binds to (`127.0.0.1` only) |
-| `API_URL` | env-var workflow only | Backend URL the entrypoint writes into `/assets/config.json` at container start. **Ignored** under the host-file workflow (`SKIP_RUNTIME_CONFIG_GENERATION=true`) where `runtime-config/config.json` is the source of truth. |
-| `API_DOCS_URL` | env-var workflow only, optional | Derived from `${API_URL}/docs` when unset. Override only if your docs URL is on a different host or path. Ignored under the host-file workflow. |
+| Variable | Notes |
+| --- | --- |
+| `COMPOSE_PROJECT_NAME` | Docker project namespace |
+| `SERVER_PORT` | Host port the container binds to (`127.0.0.1` only) |
 
-#### Repointing at a different backend (no rebuild)
-
-```bash
-# 1. edit apps/portal/.env  →  API_URL=http://my-api.example.com
-# 2. recreate the container — same image, ~2 seconds
-docker compose up -d
-```
-
-The image is unchanged. Compose recreates the container with the new env, the entrypoint regenerates `/runtime-config/config.json`, nginx serves it.
+`apiUrl` / `apiDocsUrl` are NOT environment variables — they're fields in `runtime-config/config.json`.
 
 #### Common operations
 
@@ -103,39 +104,8 @@ The image is unchanged. Compose recreates the container with the new env, the en
 docker compose stop                                       # stop, keep container
 docker compose down                                       # stop + remove
 docker compose logs -f                                    # tail logs
-docker exec osmox-portal cat /runtime-config/config.json  # verify what got written
+docker exec osmox-portal cat /runtime-config/config.json  # verify what's being served
 ```
-
-#### Optional: host-managed config (live edits, no restart)
-
-Useful during active debugging — edit a host JSON file and the running container picks it up on the next browser refresh.
-
-```bash
-# 1. one-time setup
-cd osmo-x/apps/portal
-mkdir runtime-config
-cp runtime-config.example.json runtime-config/config.json
-```
-
-Then edit `apps/portal/docker-compose.yml` and uncomment the two pre-commented blocks:
-
-```yaml
-environment:
-  # ...existing entries above...
-  SKIP_RUNTIME_CONFIG_GENERATION: "true"   # uncomment
-
-volumes:                                    # uncomment block
-  - ./runtime-config:/runtime-config:ro
-```
-
-```bash
-# 2. start with the override active
-docker compose up -d
-
-# 3. from now on: edit runtime-config/config.json, refresh the browser. No docker command needed.
-```
-
-Use a **directory** mount (`./runtime-config:/runtime-config:ro`), not a file mount — file-level bind mounts get severed when editors atomic-write (the default for VS Code, vim, most modern editors).
 
 ### Development mode
 

--- a/apps/portal/.env.example
+++ b/apps/portal/.env.example
@@ -1,9 +1,12 @@
 COMPOSE_PROJECT_NAME=osmox-portal
 SERVER_PORT=4200
 
-# Runtime configuration injected into the portal at container startup
-# (written to /usr/share/nginx/html/assets/config.json by docker-entrypoint.sh).
-# Change these to point the deployed portal at a different backend without
-# rebuilding the Docker image.
+# Backend API URL — written into /assets/config.json by docker-entrypoint.sh
+# at container startup. Change this to point a deployed portal at a different
+# backend without rebuilding the Docker image.
 API_URL=http://localhost:3000
-API_DOCS_URL=http://localhost:3000/docs
+
+# Optional. If unset, docker-entrypoint.sh derives it from ${API_URL}/docs.
+# Uncomment and set this only if your docs URL is hosted at a different host
+# or path than the API.
+# API_DOCS_URL=http://localhost:3000/docs

--- a/apps/portal/.env.example
+++ b/apps/portal/.env.example
@@ -1,34 +1,10 @@
-# --- Docker-level (always required) ---
 COMPOSE_PROJECT_NAME=osmox-portal
 SERVER_PORT=4200
 
-# --- Env-var workflow (default) ---
-# Used by docker-entrypoint.sh to generate /assets/config.json at container
-# startup. Change API_URL + `docker compose up -d` to repoint the portal at a
-# different backend without rebuilding the image.
-#
-# IGNORED when running the host-file workflow (SKIP_RUNTIME_CONFIG_GENERATION=true
-# in docker-compose.yml). In that mode the source of truth is
-# runtime-config/config.json, and you can leave the lines below unset.
-
-API_URL=http://localhost:3000
-
-# Optional. If unset, docker-entrypoint.sh derives it from ${API_URL}/docs.
-# Uncomment and set this only if your docs URL is on a different host or path.
-# API_DOCS_URL=http://localhost:3000/docs
-
-# ---
-# Two supported workflows:
-#
-# 1. Env-var workflow (default): set API_URL above, run `docker compose up -d`.
-#    The container regenerates /assets/config.json from API_URL on every start.
-#    No rebuild needed when switching backends — just edit + restart.
-#
-# 2. Host-file workflow: bind-mount a host directory containing config.json so
-#    you can edit it by hand and have nginx serve the new value on the next
-#    browser refresh without restarting the container. To enable:
-#      - mkdir runtime-config && cp runtime-config.example.json runtime-config/config.json
-#      - uncomment the volume mount and SKIP_RUNTIME_CONFIG_GENERATION block
-#        in docker-compose.yml
-#      - docker compose up -d
-#    In this mode, API_URL / API_DOCS_URL above are ignored.
+# Portal runtime config (apiUrl, apiDocsUrl) is NOT set here.
+# It lives in ./runtime-config/config.json — see runtime-config.example.json.
+# First-time setup:
+#   mkdir -p runtime-config
+#   cp runtime-config.example.json runtime-config/config.json
+#   docker compose up -d --build
+# Day-to-day: edit runtime-config/config.json on the host, refresh the browser.

--- a/apps/portal/.env.example
+++ b/apps/portal/.env.example
@@ -1,21 +1,28 @@
+# --- Docker-level (always required) ---
 COMPOSE_PROJECT_NAME=osmox-portal
 SERVER_PORT=4200
 
-# Backend API URL — written into /assets/config.json by docker-entrypoint.sh
-# at container startup. Change this to point a deployed portal at a different
-# backend without rebuilding the Docker image.
+# --- Env-var workflow (default) ---
+# Used by docker-entrypoint.sh to generate /assets/config.json at container
+# startup. Change API_URL + `docker compose up -d` to repoint the portal at a
+# different backend without rebuilding the image.
+#
+# IGNORED when running the host-file workflow (SKIP_RUNTIME_CONFIG_GENERATION=true
+# in docker-compose.yml). In that mode the source of truth is
+# runtime-config/config.json, and you can leave the lines below unset.
+
 API_URL=http://localhost:3000
 
 # Optional. If unset, docker-entrypoint.sh derives it from ${API_URL}/docs.
-# Uncomment and set this only if your docs URL is hosted at a different host
-# or path than the API.
+# Uncomment and set this only if your docs URL is on a different host or path.
 # API_DOCS_URL=http://localhost:3000/docs
 
-# Two ways to manage portal runtime config:
+# ---
+# Two supported workflows:
 #
 # 1. Env-var workflow (default): set API_URL above, run `docker compose up -d`.
-#    The container regenerates /assets/config.json from these env vars on every
-#    start. No rebuild needed when switching backends — just edit + restart.
+#    The container regenerates /assets/config.json from API_URL on every start.
+#    No rebuild needed when switching backends — just edit + restart.
 #
 # 2. Host-file workflow: bind-mount a host directory containing config.json so
 #    you can edit it by hand and have nginx serve the new value on the next
@@ -24,3 +31,4 @@ API_URL=http://localhost:3000
 #      - uncomment the volume mount and SKIP_RUNTIME_CONFIG_GENERATION block
 #        in docker-compose.yml
 #      - docker compose up -d
+#    In this mode, API_URL / API_DOCS_URL above are ignored.

--- a/apps/portal/.env.example
+++ b/apps/portal/.env.example
@@ -10,3 +10,17 @@ API_URL=http://localhost:3000
 # Uncomment and set this only if your docs URL is hosted at a different host
 # or path than the API.
 # API_DOCS_URL=http://localhost:3000/docs
+
+# Two ways to manage portal runtime config:
+#
+# 1. Env-var workflow (default): set API_URL above, run `docker compose up -d`.
+#    The container regenerates /assets/config.json from these env vars on every
+#    start. No rebuild needed when switching backends — just edit + restart.
+#
+# 2. Host-file workflow: bind-mount a host directory containing config.json so
+#    you can edit it by hand and have nginx serve the new value on the next
+#    browser refresh without restarting the container. To enable:
+#      - mkdir runtime-config && cp runtime-config.example.json runtime-config/config.json
+#      - uncomment the volume mount and SKIP_RUNTIME_CONFIG_GENERATION block
+#        in docker-compose.yml
+#      - docker compose up -d

--- a/apps/portal/.env.example
+++ b/apps/portal/.env.example
@@ -1,2 +1,9 @@
 COMPOSE_PROJECT_NAME=osmox-portal
 SERVER_PORT=4200
+
+# Runtime configuration injected into the portal at container startup
+# (written to /usr/share/nginx/html/assets/config.json by docker-entrypoint.sh).
+# Change these to point the deployed portal at a different backend without
+# rebuilding the Docker image.
+API_URL=http://localhost:3000
+API_DOCS_URL=http://localhost:3000/docs

--- a/apps/portal/.gitignore
+++ b/apps/portal/.gitignore
@@ -42,3 +42,7 @@ testem.log
 Thumbs.db
 
 .env
+
+# Host-managed runtime config (only used when SKIP_RUNTIME_CONFIG_GENERATION=true
+# in docker-compose.yml). See runtime-config.example.json for the template.
+runtime-config/

--- a/apps/portal/CLAUDE.md
+++ b/apps/portal/CLAUDE.md
@@ -279,17 +279,27 @@ export class DataService {
 
 ### Runtime Configuration (REQUIRED)
 
-There is no `environment.ts` file — those were removed and `fileReplacements` is gone from `angular.json`. The portal builds **once** and is configured at deploy time via Docker env vars.
+There is no `environment.ts` file — those were removed and `fileReplacements` is gone from `angular.json`. The portal builds **once**; deploy-specific values live in a host-managed `config.json` that the running container serves directly.
 
 - **`apps/portal/src/assets/config.json`** — committed default for `ng serve` and tests (localhost values). In Docker, this is **shadowed** by an nginx alias.
+- **`apps/portal/runtime-config/config.json`** — host-managed file (gitignored), bind-mounted into the container at `/runtime-config/config.json`. **This is the source of truth** for the deployed portal's `apiUrl` / `apiDocsUrl`.
 - **`ConfigService`** (`apps/portal/src/app/core/services/config.service.ts`) — fetches `/assets/config.json` via `provideAppInitializer` before bootstrap. Validates the payload shape (`apiUrl`, `apiDocsUrl` must be strings) and throws fail-fast on a malformed file.
-- **`docker-entrypoint.sh`** — generates `/runtime-config/config.json` from `$API_URL` / `$API_DOCS_URL` on container start. nginx aliases `/assets/config.json` to that path.
-- **`apps/portal/.env`** — single source of truth for runtime values. Edit `API_URL`, run `docker compose up -d` (no rebuild). `API_DOCS_URL` is optional and derived from `API_URL` when unset.
+- **`nginx.conf`** — aliases `/assets/config.json` → `/runtime-config/config.json` so the URL stays the same in dev (`ng serve`) and prod (Docker).
+- **`docker-entrypoint.sh`** — verifies the bind-mounted file is present, prints a clear error if not, then `exec`s nginx.
 
-Two workflows are supported:
+**Workflow (single path):**
 
-1. **Env-var workflow (default):** edit `.env`, `docker compose up -d`. Entrypoint regenerates `config.json`.
-2. **Host-managed workflow (opt-in):** uncomment the `volumes:` and `SKIP_RUNTIME_CONFIG_GENERATION` blocks in `docker-compose.yml`, place a `runtime-config/config.json` on the host, and edit it freely — atomic-write edits propagate live (next browser refresh) without restarting the container. Directory mount only — file-level mounts break when editors atomic-write.
+1. **First-time setup:**
+   ```bash
+   cd apps/portal
+   cp .env.example .env
+   mkdir -p runtime-config
+   cp runtime-config.example.json runtime-config/config.json
+   docker compose up -d --build
+   ```
+2. **Day-to-day:** edit `runtime-config/config.json` on the host. Browser refresh picks up the new value — no container restart needed. nginx serves the host file directly through the directory bind mount.
+
+The bind mount is a **directory** mount (`./runtime-config:/runtime-config:ro`), not a file mount — file-level mounts get severed by editor atomic-writes.
 
 ### Routing (REQUIRED)
 

--- a/apps/portal/CLAUDE.md
+++ b/apps/portal/CLAUDE.md
@@ -255,11 +255,16 @@ export class ExampleComponent {
 
 ### Service Pattern (REQUIRED)
 
+The base API URL is loaded **at runtime** from `/assets/config.json` via `ConfigService` (see `Runtime Configuration` below). Services must inject `ConfigService` and read `apiUrl` through a lazy getter — a class-field initializer would run before `provideAppInitializer` resolves and capture the wrong value.
+
 ```typescript
 @Injectable({ providedIn: 'root' })
 export class DataService {
   private readonly http = inject(HttpClient);
-  private readonly apiUrl = `${environment.apiUrl}/resource`;
+  private readonly config = inject(ConfigService);
+  private get apiUrl(): string {
+    return `${this.config.apiUrl}/resource`;
+  }
 
   private readonly _items = signal<Item[]>([]);
   readonly items = this._items.asReadonly();
@@ -271,6 +276,20 @@ export class DataService {
   }
 }
 ```
+
+### Runtime Configuration (REQUIRED)
+
+There is no `environment.ts` file — those were removed and `fileReplacements` is gone from `angular.json`. The portal builds **once** and is configured at deploy time via Docker env vars.
+
+- **`apps/portal/src/assets/config.json`** — committed default for `ng serve` and tests (localhost values). In Docker, this is **shadowed** by an nginx alias.
+- **`ConfigService`** (`apps/portal/src/app/core/services/config.service.ts`) — fetches `/assets/config.json` via `provideAppInitializer` before bootstrap. Validates the payload shape (`apiUrl`, `apiDocsUrl` must be strings) and throws fail-fast on a malformed file.
+- **`docker-entrypoint.sh`** — generates `/runtime-config/config.json` from `$API_URL` / `$API_DOCS_URL` on container start. nginx aliases `/assets/config.json` to that path.
+- **`apps/portal/.env`** — single source of truth for runtime values. Edit `API_URL`, run `docker compose up -d` (no rebuild). `API_DOCS_URL` is optional and derived from `API_URL` when unset.
+
+Two workflows are supported:
+
+1. **Env-var workflow (default):** edit `.env`, `docker compose up -d`. Entrypoint regenerates `config.json`.
+2. **Host-managed workflow (opt-in):** uncomment the `volumes:` and `SKIP_RUNTIME_CONFIG_GENERATION` blocks in `docker-compose.yml`, place a `runtime-config/config.json` on the host, and edit it freely — atomic-write edits propagate live (next browser refresh) without restarting the container. Directory mount only — file-level mounts break when editors atomic-write.
 
 ### Routing (REQUIRED)
 

--- a/apps/portal/Dockerfile
+++ b/apps/portal/Dockerfile
@@ -25,7 +25,7 @@ COPY --from=builder $APP_PATH /usr/share/nginx/html/
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
-RUN chmod +x /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh && mkdir -p /runtime-config
 
 EXPOSE 80
 

--- a/apps/portal/Dockerfile
+++ b/apps/portal/Dockerfile
@@ -24,6 +24,9 @@ COPY --from=builder $APP_PATH /usr/share/nginx/html/
 
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
 EXPOSE 80
 
-CMD ["nginx", "-g", "daemon off;"]
+CMD ["/docker-entrypoint.sh"]

--- a/apps/portal/angular.json
+++ b/apps/portal/angular.json
@@ -39,12 +39,6 @@
           },
           "configurations": {
             "production": {
-              "fileReplacements": [
-                {
-                  "replace": "src/environments/environment.ts",
-                  "with": "src/environments/environment.production.ts"
-                }
-              ],
               "budgets": [
                 {
                   "type": "initial",

--- a/apps/portal/docker-compose.yml
+++ b/apps/portal/docker-compose.yml
@@ -10,5 +10,10 @@ services:
     image: osmox-portal
     container_name: osmox-portal
     restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      API_URL: ${API_URL:-http://localhost:3000}
+      API_DOCS_URL: ${API_DOCS_URL:-http://localhost:3000/docs}
     ports:
       - '127.0.0.1:${SERVER_PORT}:80'

--- a/apps/portal/docker-compose.yml
+++ b/apps/portal/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - .env
     environment:
       API_URL: ${API_URL:-http://localhost:3000}
-      API_DOCS_URL: ${API_DOCS_URL:-http://localhost:3000/docs}
+      # API_DOCS_URL is intentionally not listed here. Set it in .env to
+      # override; otherwise docker-entrypoint.sh derives it from API_URL.
     ports:
       - '127.0.0.1:${SERVER_PORT}:80'

--- a/apps/portal/docker-compose.yml
+++ b/apps/portal/docker-compose.yml
@@ -12,21 +12,12 @@ services:
     restart: unless-stopped
     env_file:
       - .env
-    environment:
-      API_URL: ${API_URL:-http://localhost:3000}
-      # API_DOCS_URL is intentionally not listed here. Set it in .env to
-      # override; otherwise docker-entrypoint.sh derives it from API_URL.
-
-      # Uncomment to disable env-var-driven config generation and let
-      # the bind-mounted host file (below) be the source of truth instead.
-      # SKIP_RUNTIME_CONFIG_GENERATION: "true"
     ports:
       - '127.0.0.1:${SERVER_PORT}:80'
-    # Uncomment together with SKIP_RUNTIME_CONFIG_GENERATION above to manage
-    # config.json by hand on the host. Edit ./runtime-config/config.json and
-    # the running container will serve the new values on the next browser
-    # refresh (no container restart needed). Use a directory mount, not a file
-    # mount: file-level bind mounts get severed when editors atomic-write.
-    # See runtime-config.example.json for the file's expected shape.
-    # volumes:
-    #   - ./runtime-config:/runtime-config:ro
+    # The portal reads /assets/config.json at bootstrap. nginx aliases that URL
+    # to /runtime-config/config.json, which is bind-mounted from this host
+    # directory. Edit ./runtime-config/config.json on the host to repoint the
+    # portal at a different backend — no container restart needed (just a
+    # browser refresh). See runtime-config.example.json for the file shape.
+    volumes:
+      - ./runtime-config:/runtime-config:ro

--- a/apps/portal/docker-compose.yml
+++ b/apps/portal/docker-compose.yml
@@ -16,5 +16,17 @@ services:
       API_URL: ${API_URL:-http://localhost:3000}
       # API_DOCS_URL is intentionally not listed here. Set it in .env to
       # override; otherwise docker-entrypoint.sh derives it from API_URL.
+
+      # Uncomment to disable env-var-driven config generation and let
+      # the bind-mounted host file (below) be the source of truth instead.
+      # SKIP_RUNTIME_CONFIG_GENERATION: "true"
     ports:
       - '127.0.0.1:${SERVER_PORT}:80'
+    # Uncomment together with SKIP_RUNTIME_CONFIG_GENERATION above to manage
+    # config.json by hand on the host. Edit ./runtime-config/config.json and
+    # the running container will serve the new values on the next browser
+    # refresh (no container restart needed). Use a directory mount, not a file
+    # mount: file-level bind mounts get severed when editors atomic-write.
+    # See runtime-config.example.json for the file's expected shape.
+    # volumes:
+    #   - ./runtime-config:/runtime-config:ro

--- a/apps/portal/docker-entrypoint.sh
+++ b/apps/portal/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Generates the runtime config consumed by the Angular portal at startup.
+# Falls back to localhost defaults so the container still boots without env vars.
+set -e
+
+: "${API_URL:=http://localhost:3000}"
+: "${API_DOCS_URL:=${API_URL}/docs}"
+
+cat > /usr/share/nginx/html/assets/config.json <<EOF
+{
+  "apiUrl": "${API_URL}",
+  "apiDocsUrl": "${API_DOCS_URL}"
+}
+EOF
+
+exec nginx -g 'daemon off;'

--- a/apps/portal/docker-entrypoint.sh
+++ b/apps/portal/docker-entrypoint.sh
@@ -1,39 +1,24 @@
 #!/bin/sh
-# Generates the runtime config consumed by the Angular portal at startup.
+# Verifies that the host-managed runtime config is present, then starts nginx.
 #
-# Default workflow ("env-var workflow"): the container regenerates
-# /runtime-config/config.json from $API_URL / $API_DOCS_URL on every start, so
-# changing .env + `docker compose up -d` is enough to repoint the portal at a
-# different backend without rebuilding the image.
-#
-# Host-managed workflow: bind-mount a host directory containing config.json
-# onto /runtime-config (directory mount, not file mount — file mounts break
-# when editors atomic-write) AND set SKIP_RUNTIME_CONFIG_GENERATION=true. The
-# entrypoint then leaves the host file alone, and edits to the host config.json
-# are picked up live (next browser refresh) without restarting the container.
-#
-# nginx serves this file at /assets/config.json via an alias in nginx.conf.
+# The portal reads /assets/config.json at bootstrap (see ConfigService).
+# nginx aliases that URL to /runtime-config/config.json (see nginx.conf),
+# which is bind-mounted from the host directory ./runtime-config in
+# docker-compose.yml. To change apiUrl, edit the host file — nginx serves
+# the new value on the next browser refresh, no container restart needed.
 set -e
 
 CONFIG_PATH=/runtime-config/config.json
 
-if [ "${SKIP_RUNTIME_CONFIG_GENERATION:-false}" = "true" ]; then
-  if [ ! -f "$CONFIG_PATH" ]; then
-    echo "SKIP_RUNTIME_CONFIG_GENERATION=true but $CONFIG_PATH is missing" >&2
-    echo "Did you forget to bind-mount a directory containing config.json?" >&2
-    exit 1
-  fi
-  echo "Using host-managed config at $CONFIG_PATH (skipping env-var generation)"
-else
-  : "${API_URL:=http://localhost:3000}"
-  : "${API_DOCS_URL:=${API_URL}/docs}"
-
-  cat > "$CONFIG_PATH" <<EOF
-{
-  "apiUrl": "${API_URL}",
-  "apiDocsUrl": "${API_DOCS_URL}"
-}
-EOF
+if [ ! -f "$CONFIG_PATH" ]; then
+  echo "ERROR: $CONFIG_PATH is missing." >&2
+  echo "" >&2
+  echo "First-time setup (run from apps/portal/):" >&2
+  echo "  mkdir -p runtime-config" >&2
+  echo "  cp runtime-config.example.json runtime-config/config.json" >&2
+  echo "" >&2
+  echo "Then re-run: docker compose up -d" >&2
+  exit 1
 fi
 
 exec nginx -g 'daemon off;'

--- a/apps/portal/docker-entrypoint.sh
+++ b/apps/portal/docker-entrypoint.sh
@@ -1,16 +1,39 @@
 #!/bin/sh
 # Generates the runtime config consumed by the Angular portal at startup.
-# Falls back to localhost defaults so the container still boots without env vars.
+#
+# Default workflow ("env-var workflow"): the container regenerates
+# /runtime-config/config.json from $API_URL / $API_DOCS_URL on every start, so
+# changing .env + `docker compose up -d` is enough to repoint the portal at a
+# different backend without rebuilding the image.
+#
+# Host-managed workflow: bind-mount a host directory containing config.json
+# onto /runtime-config (directory mount, not file mount — file mounts break
+# when editors atomic-write) AND set SKIP_RUNTIME_CONFIG_GENERATION=true. The
+# entrypoint then leaves the host file alone, and edits to the host config.json
+# are picked up live (next browser refresh) without restarting the container.
+#
+# nginx serves this file at /assets/config.json via an alias in nginx.conf.
 set -e
 
-: "${API_URL:=http://localhost:3000}"
-: "${API_DOCS_URL:=${API_URL}/docs}"
+CONFIG_PATH=/runtime-config/config.json
 
-cat > /usr/share/nginx/html/assets/config.json <<EOF
+if [ "${SKIP_RUNTIME_CONFIG_GENERATION:-false}" = "true" ]; then
+  if [ ! -f "$CONFIG_PATH" ]; then
+    echo "SKIP_RUNTIME_CONFIG_GENERATION=true but $CONFIG_PATH is missing" >&2
+    echo "Did you forget to bind-mount a directory containing config.json?" >&2
+    exit 1
+  fi
+  echo "Using host-managed config at $CONFIG_PATH (skipping env-var generation)"
+else
+  : "${API_URL:=http://localhost:3000}"
+  : "${API_DOCS_URL:=${API_URL}/docs}"
+
+  cat > "$CONFIG_PATH" <<EOF
 {
   "apiUrl": "${API_URL}",
   "apiDocsUrl": "${API_DOCS_URL}"
 }
 EOF
+fi
 
 exec nginx -g 'daemon off;'

--- a/apps/portal/nginx.conf
+++ b/apps/portal/nginx.conf
@@ -1,11 +1,11 @@
 server {
     listen 80;
 
-    # Runtime config served from a separate location so it can be bind-mounted
-    # from the host (directory mount) without shadowing other assets. The
-    # container's docker-entrypoint.sh writes this file from env vars by
-    # default; when SKIP_RUNTIME_CONFIG_GENERATION=true and a directory is
-    # bind-mounted, the host file is the source of truth instead.
+    # Runtime config served from a separate location so the host directory
+    # mount (./runtime-config:/runtime-config:ro in docker-compose.yml) doesn't
+    # shadow other static assets. The host file is the source of truth — edit
+    # ./runtime-config/config.json on the host and the next request below
+    # serves the new value (Cache-Control: no-store keeps it fresh).
     location = /assets/config.json {
         alias /runtime-config/config.json;
         add_header Cache-Control "no-store";

--- a/apps/portal/nginx.conf
+++ b/apps/portal/nginx.conf
@@ -1,5 +1,16 @@
 server {
     listen 80;
+
+    # Runtime config served from a separate location so it can be bind-mounted
+    # from the host (directory mount) without shadowing other assets. The
+    # container's docker-entrypoint.sh writes this file from env vars by
+    # default; when SKIP_RUNTIME_CONFIG_GENERATION=true and a directory is
+    # bind-mounted, the host file is the source of truth instead.
+    location = /assets/config.json {
+        alias /runtime-config/config.json;
+        add_header Cache-Control "no-store";
+    }
+
     location / {
         root /usr/share/nginx/html;
         index index.html;

--- a/apps/portal/runtime-config.example.json
+++ b/apps/portal/runtime-config.example.json
@@ -1,0 +1,4 @@
+{
+  "apiUrl": "http://localhost:3000",
+  "apiDocsUrl": "http://localhost:3000/docs"
+}

--- a/apps/portal/src/app/app.config.ts
+++ b/apps/portal/src/app/app.config.ts
@@ -1,6 +1,8 @@
 import { provideHttpClient, withFetch, withInterceptors } from '@angular/common/http';
 import {
   ApplicationConfig,
+  inject,
+  provideAppInitializer,
   provideBrowserGlobalErrorListeners,
   provideZonelessChangeDetection,
 } from '@angular/core';
@@ -17,11 +19,13 @@ import { provideAnimationsAsync } from '@angular/platform-browser/animations/asy
 import { authInterceptor } from './core/interceptors/auth.interceptor';
 import { orgContextInterceptor } from './core/interceptors/org-context.interceptor';
 import { errorInterceptor } from './core/interceptors/error.interceptor';
+import { ConfigService } from './core/services/config.service';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideZonelessChangeDetection(),
+    provideAppInitializer(() => inject(ConfigService).load()),
     provideAnimationsAsync(),
     provideRouter(
       routes,

--- a/apps/portal/src/app/core/services/auth.service.ts
+++ b/apps/portal/src/app/core/services/auth.service.ts
@@ -2,7 +2,7 @@ import { Injectable, signal, computed, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Router } from '@angular/router';
 import { Observable, tap, map, catchError, throwError } from 'rxjs';
-import { environment } from '../../../environments/environment';
+import { ConfigService } from './config.service';
 import {
   User,
   AuthResponse,
@@ -19,6 +19,7 @@ import { UserRoles, UserRole } from '../constants/roles';
 export class AuthService {
   private readonly http = inject(HttpClient);
   private readonly router = inject(Router);
+  private readonly config = inject(ConfigService);
 
   private readonly STORAGE_KEY = 'auth_user';
   private readonly TOKEN_KEY = 'auth_token';
@@ -86,7 +87,7 @@ export class AuthService {
   }
 
   login(dto: LoginDto): Observable<AuthResponse> {
-    return this.http.post<AuthResponse>(`${environment.apiUrl}/auth/login`, dto).pipe(
+    return this.http.post<AuthResponse>(`${this.config.apiUrl}/auth/login`, dto).pipe(
       tap((response) => {
         this.handleAuthSuccess(response);
       }),
@@ -103,7 +104,7 @@ export class AuthService {
 
     const dto: RefreshTokenDto = { refresh_token: refreshToken };
 
-    return this.http.post<AuthResponse>(`${environment.apiUrl}/auth/refresh`, dto).pipe(
+    return this.http.post<AuthResponse>(`${this.config.apiUrl}/auth/refresh`, dto).pipe(
       tap((response) => {
         this.handleAuthSuccess(response);
       }),
@@ -116,7 +117,7 @@ export class AuthService {
   }
 
   getProfile(): Observable<User> {
-    return this.http.get<MeResponse>(`${environment.apiUrl}/auth/me`).pipe(
+    return this.http.get<MeResponse>(`${this.config.apiUrl}/auth/me`).pipe(
       tap((response) => {
         this.currentUser.set(response.user);
         localStorage.setItem(this.STORAGE_KEY, JSON.stringify(response.user));

--- a/apps/portal/src/app/core/services/config.service.ts
+++ b/apps/portal/src/app/core/services/config.service.ts
@@ -1,0 +1,42 @@
+import { Injectable, signal } from '@angular/core';
+
+interface AppConfig {
+  apiUrl: string;
+  apiDocsUrl: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class ConfigService {
+  private readonly _config = signal<AppConfig | null>(null);
+  readonly config = this._config.asReadonly();
+
+  async load(): Promise<void> {
+    const res = await fetch('/assets/config.json', { cache: 'no-store' });
+
+    if (!res.ok) {
+      throw new Error(`Failed to load /assets/config.json (${res.status})`);
+    }
+
+    this._config.set((await res.json()) as AppConfig);
+  }
+
+  get apiUrl(): string {
+    const c = this._config();
+
+    if (!c) {
+      throw new Error('ConfigService accessed before load() resolved');
+    }
+
+    return c.apiUrl;
+  }
+
+  get apiDocsUrl(): string {
+    const c = this._config();
+
+    if (!c) {
+      throw new Error('ConfigService accessed before load() resolved');
+    }
+
+    return c.apiDocsUrl;
+  }
+}

--- a/apps/portal/src/app/core/services/config.service.ts
+++ b/apps/portal/src/app/core/services/config.service.ts
@@ -17,7 +17,13 @@ export class ConfigService {
       throw new Error(`Failed to load /assets/config.json (${res.status})`);
     }
 
-    this._config.set((await res.json()) as AppConfig);
+    const parsed = (await res.json()) as Partial<AppConfig>;
+
+    if (typeof parsed?.apiUrl !== 'string' || typeof parsed?.apiDocsUrl !== 'string') {
+      throw new Error('Invalid /assets/config.json: apiUrl and apiDocsUrl must be strings');
+    }
+
+    this._config.set({ apiUrl: parsed.apiUrl, apiDocsUrl: parsed.apiDocsUrl });
   }
 
   get apiUrl(): string {

--- a/apps/portal/src/app/features/api-keys/services/api-keys.service.ts
+++ b/apps/portal/src/app/features/api-keys/services/api-keys.service.ts
@@ -1,13 +1,16 @@
 import { Injectable, inject, signal } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable, tap } from 'rxjs';
-import { environment } from '../../../../environments/environment';
+import { ConfigService } from '../../../core/services/config.service';
 import { ServerApiKey, PaginatedResponse } from '../../../core/models/api.model';
 
 @Injectable({ providedIn: 'root' })
 export class ApiKeysService {
   private readonly http = inject(HttpClient);
-  private readonly apiUrl = `${environment.apiUrl}/api-keys`;
+  private readonly config = inject(ConfigService);
+  private get apiUrl(): string {
+    return `${this.config.apiUrl}/api-keys`;
+  }
 
   private readonly _apiKeys = signal<ServerApiKey[]>([]);
   readonly apiKeys = this._apiKeys.asReadonly();

--- a/apps/portal/src/app/features/applications/services/applications.service.ts
+++ b/apps/portal/src/app/features/applications/services/applications.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, inject, signal } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable, tap } from 'rxjs';
-import { environment } from '../../../../environments/environment';
+import { ConfigService } from '../../../core/services/config.service';
 import {
   Application,
   CreateApplicationInput,
@@ -12,7 +12,10 @@ import {
 @Injectable({ providedIn: 'root' })
 export class ApplicationsService {
   private readonly http = inject(HttpClient);
-  private readonly apiUrl = `${environment.apiUrl}/applications`;
+  private readonly config = inject(ConfigService);
+  private get apiUrl(): string {
+    return `${this.config.apiUrl}/applications`;
+  }
 
   private readonly _applications = signal<Application[]>([]);
   readonly applications = this._applications.asReadonly();

--- a/apps/portal/src/app/features/archived-notifications/services/archived-notifications.service.ts
+++ b/apps/portal/src/app/features/archived-notifications/services/archived-notifications.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, inject, signal } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable, tap } from 'rxjs';
-import { environment } from '../../../../environments/environment';
+import { ConfigService } from '../../../core/services/config.service';
 import { ArchivedNotification, PaginatedResponse } from '../../../core/models/api.model';
 import { NotificationFilters } from '../../../core/models/notification-filters.model';
 
@@ -10,7 +10,10 @@ export type { NotificationFilters };
 @Injectable({ providedIn: 'root' })
 export class ArchivedNotificationsService {
   private readonly http = inject(HttpClient);
-  private readonly apiUrl = `${environment.apiUrl}/archived-notifications`;
+  private readonly config = inject(ConfigService);
+  private get apiUrl(): string {
+    return `${this.config.apiUrl}/archived-notifications`;
+  }
 
   private readonly _archivedNotifications = signal<ArchivedNotification[]>([]);
   readonly archivedNotifications = this._archivedNotifications.asReadonly();

--- a/apps/portal/src/app/features/dashboard/dashboard.service.ts
+++ b/apps/portal/src/app/features/dashboard/dashboard.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, inject, signal, computed } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable, tap } from 'rxjs';
-import { environment } from '../../../environments/environment';
+import { ConfigService } from '../../core/services/config.service';
 import { DashboardStats, DashboardAnalytics } from '../../core/models/api.model';
 
 export type DashboardSource = 'active' | 'archived' | 'both';
@@ -9,7 +9,10 @@ export type DashboardSource = 'active' | 'archived' | 'both';
 @Injectable({ providedIn: 'root' })
 export class DashboardService {
   private readonly http = inject(HttpClient);
-  private readonly apiUrl = `${environment.apiUrl}/dashboard`;
+  private readonly config = inject(ConfigService);
+  private get apiUrl(): string {
+    return `${this.config.apiUrl}/dashboard`;
+  }
 
   private readonly _stats = signal<DashboardStats | null>(null);
   readonly stats = this._stats.asReadonly();

--- a/apps/portal/src/app/features/notifications/services/notifications.service.ts
+++ b/apps/portal/src/app/features/notifications/services/notifications.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, inject, signal } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable, tap } from 'rxjs';
-import { environment } from '../../../../environments/environment';
+import { ConfigService } from '../../../core/services/config.service';
 import { Notification, PaginatedResponse } from '../../../core/models/api.model';
 import { NotificationFilters } from '../../../core/models/notification-filters.model';
 
@@ -10,7 +10,10 @@ export type { NotificationFilters };
 @Injectable({ providedIn: 'root' })
 export class NotificationsService {
   private readonly http = inject(HttpClient);
-  private readonly apiUrl = `${environment.apiUrl}/notifications`;
+  private readonly config = inject(ConfigService);
+  private get apiUrl(): string {
+    return `${this.config.apiUrl}/notifications`;
+  }
 
   private readonly _notifications = signal<Notification[]>([]);
   readonly notifications = this._notifications.asReadonly();

--- a/apps/portal/src/app/features/profile/services/profile.ts
+++ b/apps/portal/src/app/features/profile/services/profile.ts
@@ -1,7 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import { environment } from '../../../../environments/environment';
+import { ConfigService } from '../../../core/services/config.service';
 
 export interface UpdateProfileDto {
   first_name?: string;
@@ -18,7 +18,10 @@ export interface ChangePasswordDto {
 })
 export class ProfileService {
   private readonly http = inject(HttpClient);
-  private readonly apiUrl = `${environment.apiUrl}/users`;
+  private readonly config = inject(ConfigService);
+  private get apiUrl(): string {
+    return `${this.config.apiUrl}/users`;
+  }
 
   updateProfile(data: UpdateProfileDto): Observable<unknown> {
     return this.http.put(`${this.apiUrl}/profile`, data);

--- a/apps/portal/src/app/features/provider-chain-members/services/chain-members.service.ts
+++ b/apps/portal/src/app/features/provider-chain-members/services/chain-members.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, inject, signal } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable, tap } from 'rxjs';
-import { environment } from '../../../../environments/environment';
+import { ConfigService } from '../../../core/services/config.service';
 import {
   ProviderChainMember,
   CreateProviderChainMemberInput,
@@ -13,7 +13,10 @@ import {
 @Injectable({ providedIn: 'root' })
 export class ChainMembersService {
   private readonly http = inject(HttpClient);
-  private readonly apiUrl = `${environment.apiUrl}/provider-chain-members`;
+  private readonly config = inject(ConfigService);
+  private get apiUrl(): string {
+    return `${this.config.apiUrl}/provider-chain-members`;
+  }
 
   private readonly _members = signal<ProviderChainMember[]>([]);
   readonly members = this._members.asReadonly();

--- a/apps/portal/src/app/features/provider-chains/services/provider-chains.service.ts
+++ b/apps/portal/src/app/features/provider-chains/services/provider-chains.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, inject, signal } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable, tap } from 'rxjs';
-import { environment } from '../../../../environments/environment';
+import { ConfigService } from '../../../core/services/config.service';
 import {
   ProviderChain,
   CreateProviderChainInput,
@@ -12,7 +12,10 @@ import {
 @Injectable({ providedIn: 'root' })
 export class ProviderChainsService {
   private readonly http = inject(HttpClient);
-  private readonly apiUrl = `${environment.apiUrl}/provider-chains`;
+  private readonly config = inject(ConfigService);
+  private get apiUrl(): string {
+    return `${this.config.apiUrl}/provider-chains`;
+  }
 
   private readonly _providerChains = signal<ProviderChain[]>([]);
   readonly providerChains = this._providerChains.asReadonly();

--- a/apps/portal/src/app/features/providers/services/master-providers.ts
+++ b/apps/portal/src/app/features/providers/services/master-providers.ts
@@ -1,13 +1,16 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import { environment } from '../../../../environments/environment';
+import { ConfigService } from '../../../core/services/config.service';
 import { MasterProvider } from '../../../core/models/api.model';
 
 @Injectable({ providedIn: 'root' })
 export class MasterProvidersService {
   private readonly http = inject(HttpClient);
-  private readonly apiUrl = `${environment.apiUrl}/master-providers`;
+  private readonly config = inject(ConfigService);
+  private get apiUrl(): string {
+    return `${this.config.apiUrl}/master-providers`;
+  }
 
   list(): Observable<MasterProvider[]> {
     return this.http.get<MasterProvider[]>(this.apiUrl);

--- a/apps/portal/src/app/features/providers/services/providers.service.ts
+++ b/apps/portal/src/app/features/providers/services/providers.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, inject, signal } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable, tap } from 'rxjs';
-import { environment } from '../../../../environments/environment';
+import { ConfigService } from '../../../core/services/config.service';
 import {
   Provider,
   CreateProviderInput,
@@ -12,7 +12,10 @@ import {
 @Injectable({ providedIn: 'root' })
 export class ProvidersService {
   private readonly http = inject(HttpClient);
-  private readonly apiUrl = `${environment.apiUrl}/providers`;
+  private readonly config = inject(ConfigService);
+  private get apiUrl(): string {
+    return `${this.config.apiUrl}/providers`;
+  }
 
   private readonly _providers = signal<Provider[]>([]);
   readonly providers = this._providers.asReadonly();

--- a/apps/portal/src/app/features/super-admin/services/organizations.service.ts
+++ b/apps/portal/src/app/features/super-admin/services/organizations.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, inject, signal } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable, tap } from 'rxjs';
-import { environment } from '../../../../environments/environment';
+import { ConfigService } from '../../../core/services/config.service';
 import {
   Organization,
   CreateOrganizationInput,
@@ -11,7 +11,10 @@ import {
 @Injectable({ providedIn: 'root' })
 export class OrganizationsService {
   private readonly http = inject(HttpClient);
-  private readonly apiUrl = `${environment.apiUrl}/organizations`;
+  private readonly config = inject(ConfigService);
+  private get apiUrl(): string {
+    return `${this.config.apiUrl}/organizations`;
+  }
 
   private readonly _organizations = signal<Organization[]>([]);
   readonly organizations = this._organizations.asReadonly();

--- a/apps/portal/src/app/features/users/services/users.service.ts
+++ b/apps/portal/src/app/features/users/services/users.service.ts
@@ -1,13 +1,16 @@
 import { Injectable, inject, signal } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable, tap } from 'rxjs';
-import { environment } from '../../../../environments/environment';
+import { ConfigService } from '../../../core/services/config.service';
 import { UserResponse, CreateUserInput, UpdateUserInput } from '../../../core/models/api.model';
 
 @Injectable({ providedIn: 'root' })
 export class UsersService {
   private readonly http = inject(HttpClient);
-  private readonly apiUrl = `${environment.apiUrl}/users`;
+  private readonly config = inject(ConfigService);
+  private get apiUrl(): string {
+    return `${this.config.apiUrl}/users`;
+  }
 
   private readonly _users = signal<UserResponse[]>([]);
   readonly users = this._users.asReadonly();

--- a/apps/portal/src/app/features/webhooks/services/webhooks.service.ts
+++ b/apps/portal/src/app/features/webhooks/services/webhooks.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, inject, signal } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable, tap } from 'rxjs';
-import { environment } from '../../../../environments/environment';
+import { ConfigService } from '../../../core/services/config.service';
 import {
   Webhook,
   CreateWebhookInput,
@@ -12,7 +12,10 @@ import {
 @Injectable({ providedIn: 'root' })
 export class WebhooksService {
   private readonly http = inject(HttpClient);
-  private readonly apiUrl = `${environment.apiUrl}/webhooks`;
+  private readonly config = inject(ConfigService);
+  private get apiUrl(): string {
+    return `${this.config.apiUrl}/webhooks`;
+  }
 
   private readonly _webhooks = signal<Webhook[]>([]);
   readonly webhooks = this._webhooks.asReadonly();

--- a/apps/portal/src/assets/config.json
+++ b/apps/portal/src/assets/config.json
@@ -1,0 +1,4 @@
+{
+  "apiUrl": "http://localhost:3000",
+  "apiDocsUrl": "http://localhost:3000/docs"
+}

--- a/apps/portal/src/environments/environment.production.ts
+++ b/apps/portal/src/environments/environment.production.ts
@@ -1,8 +1,0 @@
-// Production environment configuration
-// This file is used when building with --configuration=production
-export const environment = {
-  production: true,
-  // Backend API URL - update this for your production deployment
-  apiUrl: 'http://localhost:3000',
-  apiDocsUrl: 'http://localhost:3000/docs',
-};

--- a/apps/portal/src/environments/environment.ts
+++ b/apps/portal/src/environments/environment.ts
@@ -1,8 +1,0 @@
-// Development environment configuration
-// This file is used by default for development (ng serve)
-export const environment = {
-  production: false,
-  // Backend API URL - localhost for local development
-  apiUrl: 'http://localhost:3000',
-  apiDocsUrl: 'http://localhost:3000/docs',
-};


### PR DESCRIPTION
## Portal PR Checklist

### Task Link

Osmosys Developers must include the Pinestem task link in the PR.

[REST-2319](https://pinestem.com/dashboard.html#/tasks/quick/REST-2319/details/?companyId=453&isPrevNext=1)

### Pre-requisites

- [x] I have gone through the Contributing guidelines for [Submitting a Pull Request (PR)](https://github.com/OsmosysSoftware/osmo-x/blob/main/CONTRIBUTING.md#-submitting-a-pull-request-pr) and ensured that this is not a duplicate PR.
- [x] I have performed unit testing for the new feature added or updated to ensure the new features added are working as expected.
- [x] I have performed preliminary testing to ensure that any existing features are not impacted and any new features are working as expected as a whole.

### PR Details

PR details have been updated as per the given format (see below)

- [x] PR title adheres to the format specified in guidelines (e.g., `feat: add admin login page`)
- [x] Description has been added
- [x] Related changes have been added (optional)
- [ ] Screenshots have been added (optional, may include unit testing screenshots as well)
- [x] Pending actions have been added (optional)
- [x] Any other additional notes have been added (optional)

### Additional Information

- [ ] Appropriate label(s) have been added (`ready for review` should be added if the PR is ready to be reviewed)
- [ ] Assignee(s) and reviewer(s) have been added (optional)

_Note: Reviewer should ensure that the checklist and description have been populated and followed correctly, and the PR should be merged only after resolving all conversations and verifying that CI checks pass._

---

**Description:**

Until now, deploying the portal to a new instance required editing `apps/portal/src/environments/environment.ts` (or `environment.production.ts`) and rebuilding the Docker image, because Angular bakes `environment.apiUrl` into the JS bundle at compile time.

This PR converts the portal to **host-managed runtime configuration**. The compiled JS bundle has zero deploy-specific values; the running container reads `apiUrl` / `apiDocsUrl` at startup from a JSON file bind-mounted from the host. To repoint the portal at a different backend, you edit a single host file — no env vars, no container restart, no rebuild — and nginx serves the new value on the next browser refresh.

**Workflow (single path):**

```
# First-time setup (apps/portal/):
cp .env.example .env
mkdir -p runtime-config
cp runtime-config.example.json runtime-config/config.json
docker compose up -d --build

# Day-to-day:
edit apps/portal/runtime-config/config.json  ← change apiUrl
refresh browser                               ← done. No container restart, no rebuild.
```

The `.env` only carries Docker-level vars (`COMPOSE_PROJECT_NAME`, `SERVER_PORT`). `apiUrl` / `apiDocsUrl` are NOT environment variables — they live in `runtime-config/config.json`.

**Trade-off:** prod deployments require a writable host volume on the Docker host. This fits self-hosted Docker (where the team has filesystem access) but not env-var-only managed runtimes such as Cloud Run, ECS Fargate, or Kubernetes-without-volume-mounts. Acceptable for current deployment targets.

**Related changes:**

- Added `ConfigService` (signal-based, `providedIn: 'root'`) in `apps/portal/src/app/core/services/config.service.ts`. Loads `/assets/config.json` via `provideAppInitializer` before bootstrap and validates that `apiUrl` / `apiDocsUrl` are non-empty strings; throws fail-fast if the payload is malformed.
- Wired `provideAppInitializer(() => inject(ConfigService).load())` in `app.config.ts` so the config is available before the first HTTP call.
- Migrated all 14 portal services that previously imported `environment.apiUrl` to `inject(ConfigService)` with a lazy `apiUrl` getter (auth, dashboard, applications, providers, master-providers, provider-chains, provider-chain-members, notifications, archived-notifications, api-keys, webhooks, users, organizations, profile). Lazy getter is required — a class-field initializer would run before `provideAppInitializer` resolves.
- Added `nginx.conf` alias `/assets/config.json` → `/runtime-config/config.json` so the URL stays the same in dev (`ng serve`) and prod (Docker), while the bind-mountable target lives in a separate directory that doesn't shadow other static assets.
- Added `apps/portal/docker-entrypoint.sh` that verifies the bind-mounted file exists, prints a clear first-time-setup hint if it's missing, then `exec`s nginx.
- `apps/portal/Dockerfile` creates `/runtime-config/` at build time and invokes the entrypoint.
- `apps/portal/docker-compose.yml` declares the bind mount: `./runtime-config:/runtime-config:ro`.
- `apps/portal/runtime-config.example.json` is committed as the template; the actual `runtime-config/` directory is `.gitignore`d (same `.example` → real-file pattern as `.env`).
- Removed `src/environments/environment.ts` and `src/environments/environment.production.ts`. Removed the `fileReplacements` block from `angular.json` since there's nothing left to replace.

**Why a directory bind mount, not a file mount:** file-level bind mounts get severed by editor atomic-writes (VS Code, vim, JetBrains all do temp-file-and-rename, breaking Docker's inode-based mount). Directory mounts survive because Docker tracks the directory inode, not the file's. nginx serves `/assets/config.json` via an `alias` to a path inside the bind-mounted directory.

**Screenshots:**

After first-time setup, curl against the running container returns the host file contents. Editing the host file (no container action) is reflected on the next request — proving live config updates without a rebuild or restart.

**Pending actions:**

- Update production hosts to mount `runtime-config/` and provide a `config.json`.

**Additional notes:**

- `npm test` has pre-existing failures (`zone.js` resolution under zoneless mode, plus auto-generated spec stubs that import non-existent class names). These are present on `main` and unrelated to this change. `npm run lint` and `npm run build:prod` both pass cleanly.
- The `npm run generate:api` script still has a hardcoded `http://localhost:3000` URL (it's a developer-machine script, not a runtime concern). Out of scope for this PR.
- Previous CodeRabbit review feedback addressed in commit `b652d02` (compose default for `API_DOCS_URL`, validation in `ConfigService.load()`); the timeout/AbortController suggestion was respectfully declined as defensive programming for a same-origin static-file fetch that can't realistically hang.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced runtime configuration system allowing backend API endpoints to be specified at container startup via environment variables, eliminating the need to rebuild the Docker image when pointing to different API servers.

* **Chores**
  * Removed compile-time environment configuration files in favor of dynamic runtime setup via Docker entrypoint.

* **Documentation**
  * Updated development and deployment guides to reflect new runtime configuration workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->