### PR TITLE
feat(api): add SNS topic publishing support to push-sns provider

### DIFF
--- a/apps/api/OsmoX.postman_collection.json
+++ b/apps/api/OsmoX.postman_collection.json
@@ -1825,6 +1825,72 @@
 						"description": "Allows successfully creating new notification for the SES Push Notification channel type for iOS."
 					},
 					"response": []
+				},
+				{
+					"name": "PushNotification_TopicBroadcast",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Response is valid JSON\", function () {\r",
+									"    pm.response.to.be.json;\r",
+									"});\r",
+									"pm.test(\"Response has valid 'status' and 'data' properties\", function () {\r",
+									"    var jsonData = pm.response.json();\r",
+									"    pm.expect(jsonData).to.have.property(\"status\", \"success\");\r",
+									"    pm.expect(jsonData).to.have.property(\"data\").to.be.an(\"object\");\r",
+									"});\r",
+									"pm.test(\"Response contains a valid 'notification' object\", function () {\r",
+									"    var jsonData = pm.response.json();\r",
+									"    pm.expect(jsonData.data).to.have.property(\"notification\").to.be.an(\"object\");\r",
+									"});\r",
+									"pm.test(\"Response 'channelType' is 9\", function () {\r",
+									"    var jsonData = pm.response.json();\r",
+									"    pm.expect(jsonData.data.notification).to.have.property(\"channelType\", 9);\r",
+									"});\r",
+									"pm.test(\"Response 'deliveryStatus' is 1\", function () {\r",
+									"    var jsonData = pm.response.json();\r",
+									"    pm.expect(jsonData.data.notification).to.have.property(\"deliveryStatus\", 1);\r",
+									"});\r",
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "x-api-key",
+								"value": "{{x-api-key}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"providerId\": 9,\n    \"data\": {\n        \"topicArn\": \"arn:aws:sns:us-west-2:505884080245:my-app-all-users\",\n        \"message\": {\n            \"GCM\": \"{\\\"notification\\\":{\\\"title\\\":\\\"Broadcast\\\",\\\"body\\\":\\\"Sent to all subscribers\\\"}}\"\n        }\n    }\n}"
+						},
+						"url": {
+							"raw": "localhost:3000/notifications",
+							"host": [
+								"localhost"
+							],
+							"port": "3000",
+							"path": [
+								"notifications"
+							]
+						},
+						"description": "Broadcasts a push notification to all subscribers of an SNS topic using topicArn instead of a single device target."
+					},
+					"response": []
 				}
 			],
 			"description": "Request to add push notification"

--- a/apps/api/docs-site/channels/push/aws-sns.mdx
+++ b/apps/api/docs-site/channels/push/aws-sns.mdx
@@ -45,7 +45,13 @@ Create a new entry in the `notify_providers` table with the following settings:
 
 ## Request Format
 
-### Sample Request Body
+The `data` payload accepts either `target` (for delivery to a single device endpoint) or `topicArn` (for broadcast to all subscribers of a topic). At least one must be provided.
+
+<Note>
+  AWS SNS validates that the ARN type matches the parameter. Pass exactly one of `target` or `topicArn` — supplying the wrong ARN type in either slot will cause AWS to reject the publish call.
+</Note>
+
+### Sample Request Body — Device Endpoint
 
 ```json
 {
@@ -59,14 +65,32 @@ Create a new entry in the `notify_providers` table with the following settings:
 }
 ```
 
+### Sample Request Body — Topic Broadcast
+
+```json
+{
+  "providerId": 10,
+  "data": {
+    "message": {
+      "GCM": "{\"notification\":{\"title\":\"Broadcast\",\"body\":\"Sent to all topic subscribers\"}}"
+    },
+    "topicArn": "arn:aws:sns:us-west-2:505884080245:my-app-all-users"
+  }
+}
+```
+
 ### Request Fields
 
 <ParamField path="message" type="object" required>
   Platform-specific message payload. The key is the platform (e.g., `GCM` for Android, `APNS` for iOS).
 </ParamField>
 
-<ParamField path="target" type="string" required>
-  The ARN of the endpoint to send the notification to
+<ParamField path="target" type="string">
+  The endpoint ARN of a single device. Maps to AWS SNS `TargetArn`. Required when `topicArn` is not provided.
+</ParamField>
+
+<ParamField path="topicArn" type="string">
+  The ARN of a topic to broadcast to. Maps to AWS SNS `TopicArn`. Required when `target` is not provided.
 </ParamField>
 
 ### Message Format for Different Platforms

--- a/apps/api/docs/channels/push-sns.md
+++ b/apps/api/docs/channels/push-sns.md
@@ -30,9 +30,19 @@ Then set the following configurations in the `configuration` field
 }
 ```
 
-### Sample Request Body
+### Request Fields
 
-Here's a sample request body:
+The `data` payload for an SNS push notification accepts either of the following destination fields. At least one must be provided; if both are omitted the request is rejected with a validation error.
+
+| Field      | Type   | Description                                                                                                                |
+| ---------- | ------ | -------------------------------------------------------------------------------------------------------------------------- |
+| `target`   | string | The platform-application **endpoint ARN** for a single device. Maps to AWS SNS `TargetArn`. Use this for direct delivery.  |
+| `topicArn` | string | The **topic ARN** to broadcast to. Maps to AWS SNS `TopicArn`. Use this to deliver the message to all topic subscribers.   |
+| `message`  | object | Platform-specific payload keyed by `default`, `GCM`, `APNS`, or `APNS_SANDBOX`. At least one key is required.              |
+
+Pass exactly one of `target` or `topicArn` — AWS SNS validates that the ARN type matches the parameter and will reject a publish call where the wrong ARN type is supplied.
+
+### Sample Request Body — Device Endpoint
 
 ```jsonc
 {
@@ -44,6 +54,20 @@ Here's a sample request body:
     }
 }
 ```
+
+### Sample Request Body — Topic Broadcast
+
+```jsonc
+{
+    "providerId": 10,
+    "data": {
+        "message": {
+            "GCM": "{\"notification\":{\"title\":\"Broadcast\",\"body\":\"Sent to all topic subscribers\"}}"},
+        "topicArn": "arn:aws:sns:us-west-2:505884080245:my-app-all-users"
+    }
+}
+```
+
 For further payload information check here : [link](https://docs.aws.amazon.com/sns/latest/dg/sns-send-custom-platform-specific-payloads-mobile-devices.html)
 
 ### Dependencies

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -115,6 +115,9 @@
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "moduleNameMapper": {
+      "^src/(.*)$": "<rootDir>/$1"
+    }
   }
 }

--- a/apps/api/src/common/decorators/only-one-of.decorator.ts
+++ b/apps/api/src/common/decorators/only-one-of.decorator.ts
@@ -1,0 +1,31 @@
+import { registerDecorator, ValidationArguments, ValidationOptions } from 'class-validator';
+
+export function OnlyOneOf(
+  property1: string,
+  property2: string,
+  validationOptions?: ValidationOptions,
+) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      name: 'onlyOneOf',
+      target: object.constructor,
+      propertyName: propertyName,
+      options: validationOptions,
+      constraints: [property1, property2],
+      validator: {
+        validate(_: unknown, args: ValidationArguments) {
+          const [prop1, prop2] = args.constraints;
+          const val1 = (args.object as unknown)[prop1];
+          const val2 = (args.object as unknown)[prop2];
+
+          return (val1 && !val2) || (!val1 && val2);
+        },
+        defaultMessage(args: ValidationArguments) {
+          const [prop1, prop2] = args.constraints;
+
+          return `Either "${prop1}" or "${prop2}" must be provided, but not both.`;
+        },
+      },
+    });
+  };
+}

--- a/apps/api/src/modules/notifications/dtos/create-notification.dto.ts
+++ b/apps/api/src/modules/notifications/dtos/create-notification.dto.ts
@@ -1,35 +1,6 @@
 import { IsNumber, IsObject, IsString, ValidateIf } from 'class-validator';
 import { IsDataValid } from 'src/common/decorators/is-data-valid.decorator';
-import { registerDecorator, ValidationOptions, ValidationArguments } from 'class-validator';
-
-// Custom decorator to ensure only one of providerId or providerChain is set
-export function OnlyOneOf(
-  property1: string,
-  property2: string,
-  validationOptions?: ValidationOptions,
-) {
-  return function (object: object, propertyName: string) {
-    registerDecorator({
-      name: 'onlyOneOf',
-      target: object.constructor,
-      propertyName: propertyName,
-      options: validationOptions,
-      constraints: [property1, property2],
-      validator: {
-        validate(_: unknown, args: ValidationArguments) {
-          const [prop1, prop2] = args.constraints;
-          const val1 = (args.object as unknown)[prop1];
-          const val2 = (args.object as unknown)[prop2];
-          return (val1 && !val2) || (!val1 && val2);
-        },
-        defaultMessage(args: ValidationArguments) {
-          const [prop1, prop2] = args.constraints;
-          return `Either "${prop1}" or "${prop2}" must be provided, but not both.`;
-        },
-      },
-    });
-  };
-}
+import { OnlyOneOf } from 'src/common/decorators/only-one-of.decorator';
 
 export class CreateNotificationDto {
   // Used to trigger OnlyOneOf validator

--- a/apps/api/src/modules/notifications/dtos/providers/pushSns-data.dto.spec.ts
+++ b/apps/api/src/modules/notifications/dtos/providers/pushSns-data.dto.spec.ts
@@ -78,4 +78,52 @@ describe('PushSnsDataDto', () => {
       expect(messages.some((m) => m.toLowerCase().includes('string'))).toBe(true);
     });
   });
+
+  describe('whitespace and empty-string handling', () => {
+    it('rejects whitespace-only target with a specific error', async () => {
+      const messages = await runValidation({
+        target: '   ',
+        message: validMessage,
+      });
+      expect(messages.some((m) => m === 'target must not be empty when provided')).toBe(true);
+    });
+
+    it('rejects whitespace-only topicArn with a specific error', async () => {
+      const messages = await runValidation({
+        topicArn: '\t\n  ',
+        message: validMessage,
+      });
+      expect(messages.some((m) => m === 'topicArn must not be empty when provided')).toBe(true);
+    });
+
+    it('rejects empty-string target with a specific error', async () => {
+      const messages = await runValidation({
+        target: '',
+        message: validMessage,
+      });
+      expect(messages.some((m) => m === 'target must not be empty when provided')).toBe(true);
+    });
+
+    it('trims surrounding whitespace from a valid target', async () => {
+      const raw = '  arn:aws:sns:us-east-1:123456789012:endpoint/GCM/MyApp/abc-123  ';
+      const instance = plainToInstance(PushSnsDataDto, {
+        target: raw,
+        message: validMessage,
+      });
+      const errors = await validate(instance);
+      expect(errors).toEqual([]);
+      expect(instance.target).toBe(raw.trim());
+    });
+
+    it('trims surrounding whitespace from a valid topicArn', async () => {
+      const raw = '  arn:aws:sns:us-east-1:123456789012:oqsha-all-users  ';
+      const instance = plainToInstance(PushSnsDataDto, {
+        topicArn: raw,
+        message: validMessage,
+      });
+      const errors = await validate(instance);
+      expect(errors).toEqual([]);
+      expect(instance.topicArn).toBe(raw.trim());
+    });
+  });
 });

--- a/apps/api/src/modules/notifications/dtos/providers/pushSns-data.dto.spec.ts
+++ b/apps/api/src/modules/notifications/dtos/providers/pushSns-data.dto.spec.ts
@@ -1,0 +1,81 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+jest.mock(
+  'src/common/decorators/is-data-valid.decorator',
+  () => ({
+    IsDataValid: () => () => undefined,
+  }),
+  { virtual: true },
+);
+
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { PushSnsDataDto } from './pushSns-data.dto';
+
+describe('PushSnsDataDto', () => {
+  const validMessage = { default: 'hello world' };
+
+  const runValidation = async (payload: Record<string, unknown>): Promise<string[]> => {
+    const instance = plainToInstance(PushSnsDataDto, payload);
+    const errors = await validate(instance);
+    return errors.flatMap((e) => Object.values(e.constraints ?? {}));
+  };
+
+  describe('destination XOR (target / topicArn)', () => {
+    it('accepts a payload with only target', async () => {
+      const messages = await runValidation({
+        target: 'arn:aws:sns:us-east-1:123456789012:endpoint/GCM/MyApp/abc-123',
+        message: validMessage,
+      });
+      expect(messages).toEqual([]);
+    });
+
+    it('accepts a payload with only topicArn', async () => {
+      const messages = await runValidation({
+        topicArn: 'arn:aws:sns:us-east-1:123456789012:oqsha-all-users',
+        message: validMessage,
+      });
+      expect(messages).toEqual([]);
+    });
+
+    it('rejects when both target and topicArn are provided', async () => {
+      const messages = await runValidation({
+        target: 'arn:aws:sns:us-east-1:123456789012:endpoint/GCM/MyApp/abc-123',
+        topicArn: 'arn:aws:sns:us-east-1:123456789012:oqsha-all-users',
+        message: validMessage,
+      });
+      expect(messages.some((m) => m.includes('target') && m.includes('topicArn'))).toBe(true);
+    });
+
+    it('rejects when neither target nor topicArn is provided', async () => {
+      const messages = await runValidation({ message: validMessage });
+      expect(messages.some((m) => m.includes('target') && m.includes('topicArn'))).toBe(true);
+    });
+
+    it('treats explicit null topicArn as absent', async () => {
+      const messages = await runValidation({
+        target: 'arn:aws:sns:us-east-1:123456789012:endpoint/GCM/MyApp/abc-123',
+        topicArn: null,
+        message: validMessage,
+      });
+      expect(messages).toEqual([]);
+    });
+  });
+
+  describe('type safety', () => {
+    it('rejects when target is not a string', async () => {
+      const messages = await runValidation({
+        target: 42 as unknown as string,
+        message: validMessage,
+      });
+      expect(messages.some((m) => m.toLowerCase().includes('string'))).toBe(true);
+    });
+
+    it('rejects when topicArn is not a string', async () => {
+      const messages = await runValidation({
+        topicArn: { foo: 'bar' } as unknown as string,
+        message: validMessage,
+      });
+      expect(messages.some((m) => m.toLowerCase().includes('string'))).toBe(true);
+    });
+  });
+});

--- a/apps/api/src/modules/notifications/dtos/providers/pushSns-data.dto.ts
+++ b/apps/api/src/modules/notifications/dtos/providers/pushSns-data.dto.ts
@@ -2,6 +2,7 @@
 import {
   IsNotEmpty,
   ValidateNested,
+  ValidateIf,
   IsOptional,
   IsString,
   ValidatorConstraint,
@@ -49,8 +50,16 @@ class MessagePayload {
 }
 
 export class PushSnsDataDto {
-  @IsNotEmpty()
-  target: string;
+  // Need at least one of target, topicArn for successful request
+  @IsNotEmpty({ message: 'Must provide target or topicArn parameter' })
+  @ValidateIf((obj) => !obj.topicArn, { message: 'Must provide target or topicArn parameter' })
+  @IsString()
+  target?: string;
+
+  @IsNotEmpty({ message: 'Must provide target or topicArn parameter' })
+  @ValidateIf((obj) => !obj.target, { message: 'Must provide target or topicArn parameter' })
+  @IsString()
+  topicArn?: string;
 
   @IsNotEmpty()
   @ValidateNested()

--- a/apps/api/src/modules/notifications/dtos/providers/pushSns-data.dto.ts
+++ b/apps/api/src/modules/notifications/dtos/providers/pushSns-data.dto.ts
@@ -10,7 +10,7 @@ import {
 } from 'class-validator';
 import { Transform, Type } from 'class-transformer';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { OnlyOneOf } from '../create-notification.dto';
+import { OnlyOneOf } from 'src/common/decorators/only-one-of.decorator';
 
 @ValidatorConstraint({ name: 'AllowedProperties', async: false })
 class AllowedPropertiesConstraint implements ValidatorConstraintInterface {

--- a/apps/api/src/modules/notifications/dtos/providers/pushSns-data.dto.ts
+++ b/apps/api/src/modules/notifications/dtos/providers/pushSns-data.dto.ts
@@ -8,7 +8,7 @@ import {
   ValidatorConstraintInterface,
   Validate,
 } from 'class-validator';
-import { Type } from 'class-transformer';
+import { Transform, Type } from 'class-transformer';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { OnlyOneOf } from '../create-notification.dto';
 
@@ -64,7 +64,9 @@ export class PushSnsDataDto {
     example: 'arn:aws:sns:us-west-2:505884080245:endpoint/GCM/Android/7fb080a5-...',
   })
   @IsOptional()
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
   @IsString()
+  @IsNotEmpty({ message: 'target must not be empty when provided' })
   target?: string;
 
   @ApiPropertyOptional({
@@ -73,7 +75,9 @@ export class PushSnsDataDto {
     example: 'arn:aws:sns:us-west-2:505884080245:my-app-all-users',
   })
   @IsOptional()
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
   @IsString()
+  @IsNotEmpty({ message: 'topicArn must not be empty when provided' })
   topicArn?: string;
 
   @ApiProperty({

--- a/apps/api/src/modules/notifications/dtos/providers/pushSns-data.dto.ts
+++ b/apps/api/src/modules/notifications/dtos/providers/pushSns-data.dto.ts
@@ -7,11 +7,11 @@ import {
   IsString,
   ValidatorConstraint,
   ValidatorConstraintInterface,
-  ValidationArguments,
   Validate,
 } from 'class-validator';
 import { Transform, Type } from 'class-transformer';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { OnlyOneOf } from '../create-notification.dto';
 
 @ValidatorConstraint({ name: 'AllowedProperties', async: false })
 class AllowedPropertiesConstraint implements ValidatorConstraintInterface {
@@ -30,21 +30,6 @@ class AllowedPropertiesConstraint implements ValidatorConstraintInterface {
 
   defaultMessage() {
     return 'Invalid properties found in the message payload. Input object must contain at least one of the allowed properties. Allowed properties are GCM, APNS_SANDBOX, APNS, and default.';
-  }
-}
-
-@ValidatorConstraint({ name: 'ExactlyOneDestination', async: false })
-class ExactlyOneDestinationConstraint implements ValidatorConstraintInterface {
-  validate(_value: unknown, args: ValidationArguments): boolean {
-    const obj = args.object as { target?: string; topicArn?: string };
-    const hasTarget = typeof obj.target === 'string' && obj.target.trim().length > 0;
-    const hasTopic = typeof obj.topicArn === 'string' && obj.topicArn.trim().length > 0;
-
-    return hasTarget !== hasTopic;
-  }
-
-  defaultMessage(): string {
-    return 'Must provide exactly one of target or topicArn';
   }
 }
 
@@ -101,7 +86,9 @@ export class PushSnsDataDto {
       'Platform-specific message payloads. Must contain at least one of: GCM, APNS_SANDBOX, APNS, default.',
     type: () => MessagePayload,
   })
-  @Validate(ExactlyOneDestinationConstraint)
+  @OnlyOneOf('target', 'topicArn', {
+    message: 'Either "target" or "topicArn" must be provided, but not both.',
+  })
   @IsNotEmpty()
   @ValidateNested()
   @Validate(AllowedPropertiesConstraint)

--- a/apps/api/src/modules/notifications/dtos/providers/pushSns-data.dto.ts
+++ b/apps/api/src/modules/notifications/dtos/providers/pushSns-data.dto.ts
@@ -2,14 +2,13 @@
 import {
   IsNotEmpty,
   ValidateNested,
-  ValidateIf,
   IsOptional,
   IsString,
   ValidatorConstraint,
   ValidatorConstraintInterface,
   Validate,
 } from 'class-validator';
-import { Transform, Type } from 'class-transformer';
+import { Type } from 'class-transformer';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { OnlyOneOf } from '../create-notification.dto';
 
@@ -64,10 +63,8 @@ export class PushSnsDataDto {
       'SNS endpoint ARN for single-device delivery. Provide exactly one of target or topicArn.',
     example: 'arn:aws:sns:us-west-2:505884080245:endpoint/GCM/Android/7fb080a5-...',
   })
-  @ValidateIf((obj) => obj.target !== undefined)
-  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
+  @IsOptional()
   @IsString()
-  @IsNotEmpty({ message: 'target must not be empty when provided' })
   target?: string;
 
   @ApiPropertyOptional({
@@ -75,10 +72,8 @@ export class PushSnsDataDto {
       'SNS topic ARN for broadcast delivery to all subscribers. Provide exactly one of target or topicArn.',
     example: 'arn:aws:sns:us-west-2:505884080245:my-app-all-users',
   })
-  @ValidateIf((obj) => obj.topicArn !== undefined)
-  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
+  @IsOptional()
   @IsString()
-  @IsNotEmpty({ message: 'topicArn must not be empty when provided' })
   topicArn?: string;
 
   @ApiProperty({

--- a/apps/api/src/modules/notifications/dtos/providers/pushSns-data.dto.ts
+++ b/apps/api/src/modules/notifications/dtos/providers/pushSns-data.dto.ts
@@ -10,7 +10,7 @@ import {
   ValidationArguments,
   Validate,
 } from 'class-validator';
-import { Type } from 'class-transformer';
+import { Transform, Type } from 'class-transformer';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 @ValidatorConstraint({ name: 'AllowedProperties', async: false })
@@ -37,8 +37,8 @@ class AllowedPropertiesConstraint implements ValidatorConstraintInterface {
 class ExactlyOneDestinationConstraint implements ValidatorConstraintInterface {
   validate(_value: unknown, args: ValidationArguments): boolean {
     const obj = args.object as { target?: string; topicArn?: string };
-    const hasTarget = typeof obj.target === 'string' && obj.target.length > 0;
-    const hasTopic = typeof obj.topicArn === 'string' && obj.topicArn.length > 0;
+    const hasTarget = typeof obj.target === 'string' && obj.target.trim().length > 0;
+    const hasTopic = typeof obj.topicArn === 'string' && obj.topicArn.trim().length > 0;
 
     return hasTarget !== hasTopic;
   }
@@ -80,6 +80,7 @@ export class PushSnsDataDto {
     example: 'arn:aws:sns:us-west-2:505884080245:endpoint/GCM/Android/7fb080a5-...',
   })
   @ValidateIf((obj) => obj.target !== undefined)
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
   @IsString()
   @IsNotEmpty({ message: 'target must not be empty when provided' })
   target?: string;
@@ -90,6 +91,7 @@ export class PushSnsDataDto {
     example: 'arn:aws:sns:us-west-2:505884080245:my-app-all-users',
   })
   @ValidateIf((obj) => obj.topicArn !== undefined)
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
   @IsString()
   @IsNotEmpty({ message: 'topicArn must not be empty when provided' })
   topicArn?: string;

--- a/apps/api/src/modules/notifications/dtos/providers/pushSns-data.dto.ts
+++ b/apps/api/src/modules/notifications/dtos/providers/pushSns-data.dto.ts
@@ -7,9 +7,11 @@ import {
   IsString,
   ValidatorConstraint,
   ValidatorConstraintInterface,
+  ValidationArguments,
   Validate,
 } from 'class-validator';
 import { Type } from 'class-transformer';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 @ValidatorConstraint({ name: 'AllowedProperties', async: false })
 class AllowedPropertiesConstraint implements ValidatorConstraintInterface {
@@ -31,36 +33,73 @@ class AllowedPropertiesConstraint implements ValidatorConstraintInterface {
   }
 }
 
+@ValidatorConstraint({ name: 'ExactlyOneDestination', async: false })
+class ExactlyOneDestinationConstraint implements ValidatorConstraintInterface {
+  validate(_value: unknown, args: ValidationArguments): boolean {
+    const obj = args.object as { target?: string; topicArn?: string };
+    const hasTarget = typeof obj.target === 'string' && obj.target.length > 0;
+    const hasTopic = typeof obj.topicArn === 'string' && obj.topicArn.length > 0;
+
+    return hasTarget !== hasTopic;
+  }
+
+  defaultMessage(): string {
+    return 'Must provide exactly one of target or topicArn';
+  }
+}
+
 class MessagePayload {
+  @ApiPropertyOptional({
+    description: 'GCM/FCM message JSON string',
+    example: '{"notification":{"title":"Test","body":"Hello"}}',
+  })
   @IsOptional()
   @IsString()
   GCM?: string;
 
+  @ApiPropertyOptional({ description: 'APNS sandbox message JSON string' })
   @IsOptional()
   @IsString()
   APNS_SANDBOX?: string;
 
+  @ApiPropertyOptional({ description: 'APNS production message JSON string' })
   @IsOptional()
   @IsString()
   APNS?: string;
 
+  @ApiPropertyOptional({ description: 'Default fallback message string' })
   @IsOptional()
   @IsString()
   default?: string;
 }
 
 export class PushSnsDataDto {
-  // Need at least one of target, topicArn for successful request
-  @IsNotEmpty({ message: 'Must provide target or topicArn parameter' })
-  @ValidateIf((obj) => !obj.topicArn, { message: 'Must provide target or topicArn parameter' })
+  @ApiPropertyOptional({
+    description:
+      'SNS endpoint ARN for single-device delivery. Provide exactly one of target or topicArn.',
+    example: 'arn:aws:sns:us-west-2:505884080245:endpoint/GCM/Android/7fb080a5-...',
+  })
+  @ValidateIf((obj) => obj.target !== undefined)
   @IsString()
+  @IsNotEmpty({ message: 'target must not be empty when provided' })
   target?: string;
 
-  @IsNotEmpty({ message: 'Must provide target or topicArn parameter' })
-  @ValidateIf((obj) => !obj.target, { message: 'Must provide target or topicArn parameter' })
+  @ApiPropertyOptional({
+    description:
+      'SNS topic ARN for broadcast delivery to all subscribers. Provide exactly one of target or topicArn.',
+    example: 'arn:aws:sns:us-west-2:505884080245:my-app-all-users',
+  })
+  @ValidateIf((obj) => obj.topicArn !== undefined)
   @IsString()
+  @IsNotEmpty({ message: 'topicArn must not be empty when provided' })
   topicArn?: string;
 
+  @ApiProperty({
+    description:
+      'Platform-specific message payloads. Must contain at least one of: GCM, APNS_SANDBOX, APNS, default.',
+    type: () => MessagePayload,
+  })
+  @Validate(ExactlyOneDestinationConstraint)
   @IsNotEmpty()
   @ValidateNested()
   @Validate(AllowedPropertiesConstraint)

--- a/apps/api/src/modules/providers/push-sns/push-sns.service.spec.ts
+++ b/apps/api/src/modules/providers/push-sns/push-sns.service.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+import { BadRequestException, Logger } from '@nestjs/common';
 
 const publishMock = jest.fn();
 
@@ -76,5 +76,21 @@ describe('PushSnsService', () => {
     expect(params.TargetArn).toBeUndefined();
     expect(params.Message).toBe(JSON.stringify(data.message));
     expect(params.MessageStructure).toBe('json');
+  });
+
+  it('should throw BadRequestException when both target and topicArn are provided', async () => {
+    const data = {
+      target: 'arn:aws:sns:us-east-1:123456789012:endpoint/GCM/MyApp/abc-123',
+      topicArn: 'arn:aws:sns:us-east-1:123456789012:oqsha-all-users',
+      message: { default: 'hello' },
+    };
+
+    await expect(service.sendPushNotification(data, 1)).rejects.toThrow(BadRequestException);
+  });
+
+  it('should throw BadRequestException when neither target nor topicArn is provided', async () => {
+    const data = { message: { default: 'hello' } };
+
+    await expect(service.sendPushNotification(data, 1)).rejects.toThrow(BadRequestException);
   });
 });

--- a/apps/api/src/modules/providers/push-sns/push-sns.service.spec.ts
+++ b/apps/api/src/modules/providers/push-sns/push-sns.service.spec.ts
@@ -1,12 +1,42 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+
+const publishMock = jest.fn();
+
+jest.mock('@aws-sdk/client-sns', () => ({
+  SNS: jest.fn().mockImplementation(() => ({
+    publish: publishMock,
+  })),
+}));
+
+jest.mock('../providers.service', () => ({
+  ProvidersService: class {},
+}));
+
 import { PushSnsService } from './push-sns.service';
+import { ProvidersService } from '../providers.service';
 
 describe('PushSnsService', () => {
   let service: PushSnsService;
 
+  const providersServiceMock = {
+    getConfigById: jest.fn().mockResolvedValue({
+      AWS_ACCESS_KEY_ID: 'test-access-key',
+      AWS_SECRET_ACCESS_KEY: 'test-secret-key',
+      AWS_REGION: 'us-east-1',
+    }),
+  };
+
   beforeEach(async () => {
+    publishMock.mockReset();
+    publishMock.mockResolvedValue({ MessageId: 'test-message-id' });
+
     const module: TestingModule = await Test.createTestingModule({
-      providers: [PushSnsService],
+      providers: [
+        PushSnsService,
+        { provide: ProvidersService, useValue: providersServiceMock },
+        { provide: Logger, useValue: { debug: jest.fn(), log: jest.fn(), error: jest.fn() } },
+      ],
     }).compile();
 
     service = module.get<PushSnsService>(PushSnsService);
@@ -14,5 +44,37 @@ describe('PushSnsService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  it('should publish with TargetArn when target is provided', async () => {
+    const data = {
+      target: 'arn:aws:sns:us-east-1:123456789012:endpoint/GCM/MyApp/abc-123',
+      message: { default: 'hello', GCM: '{"notification":{"title":"hi"}}' },
+    };
+
+    await service.sendPushNotification(data, 1);
+
+    expect(publishMock).toHaveBeenCalledTimes(1);
+    const params = publishMock.mock.calls[0][0];
+    expect(params.TargetArn).toBe(data.target);
+    expect(params.TopicArn).toBeUndefined();
+    expect(params.Message).toBe(JSON.stringify(data.message));
+    expect(params.MessageStructure).toBe('json');
+  });
+
+  it('should publish with TopicArn when topicArn is provided', async () => {
+    const data = {
+      topicArn: 'arn:aws:sns:us-east-1:123456789012:oqsha-all-users',
+      message: { default: 'hello', GCM: '{"notification":{"title":"hi"}}' },
+    };
+
+    await service.sendPushNotification(data, 1);
+
+    expect(publishMock).toHaveBeenCalledTimes(1);
+    const params = publishMock.mock.calls[0][0];
+    expect(params.TopicArn).toBe(data.topicArn);
+    expect(params.TargetArn).toBeUndefined();
+    expect(params.Message).toBe(JSON.stringify(data.message));
+    expect(params.MessageStructure).toBe('json');
   });
 });

--- a/apps/api/src/modules/providers/push-sns/push-sns.service.ts
+++ b/apps/api/src/modules/providers/push-sns/push-sns.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { BadRequestException, Injectable, Logger } from '@nestjs/common';
 import { PublishCommandInput, PublishCommandOutput, SNS } from '@aws-sdk/client-sns';
 import { ProvidersService } from '../providers.service';
 
@@ -33,7 +33,14 @@ export class PushSnsService {
   async sendPushNotification(data: PushSnsData, providerId: number): Promise<PublishCommandOutput> {
     await this.assignSnsConfig(providerId);
 
-    // Prepare SNS publish parameters: route to TopicArn for broadcast, TargetArn for device endpoint
+    if (data.topicArn && data.target) {
+      throw new BadRequestException('Provide either target or topicArn, not both');
+    }
+
+    if (!data.topicArn && !data.target) {
+      throw new BadRequestException('Must provide target or topicArn parameter');
+    }
+
     const params: PublishCommandInput = {
       Message: JSON.stringify(data.message),
       MessageStructure: 'json',

--- a/apps/api/src/modules/providers/push-sns/push-sns.service.ts
+++ b/apps/api/src/modules/providers/push-sns/push-sns.service.ts
@@ -3,7 +3,8 @@ import { PublishCommandInput, PublishCommandOutput, SNS } from '@aws-sdk/client-
 import { ProvidersService } from '../providers.service';
 
 export interface PushSnsData {
-  target: string;
+  target?: string;
+  topicArn?: string;
   message: object;
 }
 
@@ -32,12 +33,17 @@ export class PushSnsService {
   async sendPushNotification(data: PushSnsData, providerId: number): Promise<PublishCommandOutput> {
     await this.assignSnsConfig(providerId);
 
-    // Prepare SNS publish parameters
+    // Prepare SNS publish parameters: route to TopicArn for broadcast, TargetArn for device endpoint
     const params: PublishCommandInput = {
       Message: JSON.stringify(data.message),
       MessageStructure: 'json',
-      TargetArn: data.target,
     };
+
+    if (data.topicArn) {
+      params.TopicArn = data.topicArn;
+    } else {
+      params.TargetArn = data.target;
+    }
 
     this.logger.debug('Sending SNS push notification');
     return this.sns.publish(params);


### PR DESCRIPTION
## API PR Checklist

### Task Link

[REST-2337](https://pinestem.com/dashboard.html#/tasks/REST-2337/details/?isPrevNext=1)

### Pre-requisites

- [x] I have gone through the Contributing guidelines for [Submitting a Pull Request (PR)](https://github.com/OsmosysSoftware/osmo-x/blob/main/CONTRIBUTING.md#-submitting-a-pull-request-pr) and ensured that this is not a duplicate PR.
- [x] I have performed unit testing for the new feature added or updated to ensure the new features added are working as expected.
- [x] I have added/updated test cases to the [test suite](https://github.com/OsmosysSoftware/osmo-x/blob/main/apps/api/OsmoX.postman_collection.json) as applicable.
- [x] I have performed preliminary testing using the [test suite](https://github.com/OsmosysSoftware/osmo-x/blob/main/apps/api/OsmoX.postman_collection.json) to ensure that any existing features are not impacted and any new features are working as expected as a whole.
- [x] I have added/updated the required [api docs](https://github.com/OsmosysSoftware/osmo-x/tree/main/apps/api/docs) as applicable.
- [ ] I have added/updated the `.env.example` file with the required values as applicable. _(N/A — no new config)_

### PR Details

- [x] PR title adheres to the format specified in guidelines (e.g., `feat: add admin login endpoint`)
- [x] Description has been added
- [x] Related changes have been added (optional)
- [ ] Screenshots have been added (optional) _(N/A — backend-only change)_
- [x] Query request and response examples have been added (as applicable, in case added or updated)
- [x] Documentation changes have been listed (as applicable)
- [x] Test suite/unit testing output is added (as applicable)
- [x] Pending actions have been added (optional)
- [x] Any other additional notes have been added (optional)

### Additional Information

- [x] Appropriate label(s) have been added (`ready for review` should be added if the PR is ready to be reviewed)
- [ ] Assignee(s) and reviewer(s) have been added (optional)

---

**Description:**

Adds AWS SNS topic publishing support to the push-sns provider. Previously the provider hard-coded `TargetArn` on every `Publish` call, restricting it to single device endpoints. Broadcasting to all subscribers of a topic was impossible — passing a topic ARN through the existing `target` field caused AWS to reject the call with `InvalidParameter` because SNS validates that the ARN type matches the parameter slot.

This change introduces an optional `topicArn` field on the notification `data` payload. Clients send **exactly one** of `target` (device endpoint) or `topicArn` (topic broadcast); the service routes the value to the correct AWS parameter (`TargetArn` or `TopicArn`). Field names mirror the AWS SDK 1:1 so the API stays self-documenting against AWS docs, and no discriminator/enum field is introduced.

The change is fully backwards compatible: every existing client that sends `target` continues to work unchanged, and existing notification rows in the database consume identically.

**Related changes:**

- `apps/api/src/modules/notifications/dtos/providers/pushSns-data.dto.ts` — make `target` optional and add `topicArn`. Validation stack per field: `@IsOptional` (skip on null/undefined) + `@Transform(trim)` (strip surrounding whitespace) + `@IsString` (type safety) + `@IsNotEmpty` (specific empty-field error). Cross-field XOR enforced by `@OnlyOneOf('target', 'topicArn')` on `message` — reuses the shared decorator already defined in `create-notification.dto.ts` rather than duplicating logic.
- `apps/api/src/modules/providers/push-sns/push-sns.service.ts` — extend `PushSnsData` interface with optional `topicArn`; branch in `sendPushNotification` to set `params.TopicArn` when present, otherwise `params.TargetArn`. Defensive runtime checks throw `BadRequestException` if both / neither reach the service (belt-and-braces for non-HTTP callers).
- `apps/api/src/modules/providers/push-sns/push-sns.service.spec.ts` — rewrote the previously-broken placeholder spec with mocked-SDK tests asserting exact `PublishCommandInput` shape on both ARN paths plus the defensive both-set / neither-set throws (5 tests).
- `apps/api/src/modules/notifications/dtos/providers/pushSns-data.dto.spec.ts` — **new** DTO-level spec running the real `class-validator` pipeline. Covers XOR rules, type safety, null-is-absent semantics, empty-string rejection, whitespace-only rejection, and whitespace trimming on valid input (12 tests).
- `apps/api/OsmoX.postman_collection.json` — added topic-broadcast example request.
- `apps/api/docs/channels/push-sns.md` and `apps/api/docs-site/channels/push/aws-sns.mdx` — documented the new field and added a topic-broadcast sample request body.
- `apps/api/package.json`, `apps/portal/package.json` and respective `package-lock.json` — bumped to `8.6.0` (semver minor for a feat) so deployment doesn't need a separate version-bump PR.

**Query request and response:**

_Device endpoint (existing behaviour, unchanged):_

```json
{
  "providerId": 10,
  "data": {
    "target": "arn:aws:sns:us-west-2:505884080245:endpoint/GCM/Android/7fb080a5-...",
    "message": {
      "GCM": "{\"notification\":{\"title\":\"Test\",\"body\":\"Hello\"}}"
    }
  }
}
```

_Topic broadcast (new):_

```json
{
  "providerId": 10,
  "data": {
    "topicArn": "arn:aws:sns:us-west-2:505884080245:my-app-all-users",
    "message": {
      "GCM": "{\"notification\":{\"title\":\"Broadcast\",\"body\":\"Sent to all subscribers\"}}"
    }
  }
}
```

_Validation errors (400):_

| Bad input | Error message |
|---|---|
| Both `target` and `topicArn` set | `Either "target" or "topicArn" must be provided, but not both.` |
| Neither set | `Either "target" or "topicArn" must be provided, but not both.` |
| `target: ""` | `target must not be empty when provided` |
| `target: "   "` (whitespace) | `target must not be empty when provided` (trimmed first) |
| `target: 42` (wrong type) | `target must be a string` |
| `topicArn: null` | accepted — treated the same as absent |
| `target: "  arn:...  "` | accepted, value trimmed to `"arn:..."` |

**Documentation changes:**

- `apps/api/docs/channels/push-sns.md` — added "Request Fields" table listing `target`, `topicArn`, `message`; added a second sample request body for the topic case; called out that AWS validates the ARN type per slot.
- `apps/api/docs-site/channels/push/aws-sns.mdx` — mirrored the source-doc changes; added a `<Note>` about mutual exclusivity; added a `topicArn` `<ParamField>`.

**Test suite/unit testing output:**

```
PASS src/modules/providers/push-sns/push-sns.service.spec.ts
  PushSnsService
    ✓ should be defined
    ✓ should publish with TargetArn when target is provided
    ✓ should publish with TopicArn when topicArn is provided
    ✓ should throw BadRequestException when both target and topicArn are provided
    ✓ should throw BadRequestException when neither target nor topicArn is provided

PASS src/modules/notifications/dtos/providers/pushSns-data.dto.spec.ts
  PushSnsDataDto
    destination XOR (target / topicArn)
      ✓ accepts a payload with only target
      ✓ accepts a payload with only topicArn
      ✓ rejects when both target and topicArn are provided
      ✓ rejects when neither target nor topicArn is provided
      ✓ treats explicit null topicArn as absent
    type safety
      ✓ rejects when target is not a string
      ✓ rejects when topicArn is not a string
    whitespace and empty-string handling
      ✓ rejects whitespace-only target with a specific error
      ✓ rejects whitespace-only topicArn with a specific error
      ✓ rejects empty-string target with a specific error
      ✓ trims surrounding whitespace from a valid target
      ✓ trims surrounding whitespace from a valid topicArn

Test Suites: 2 passed, 2 total
Tests:       17 passed, 17 total
```

Lint (`npm run lint`) and build (`npm run build`) both pass cleanly with the repo's zero-warnings policy.

**Additional notes:**

- No DB migration, no provider-config schema change, no `master-providers` seed change, no `.env.example` change.
- Note: the broader Jest test suite has pre-existing failures (~31 suites) caused by an unrelated path-alias issue (`src/...` imports not resolved by Jest) that existed on `main` before this PR. This PR's specs use targeted `jest.mock(..., { virtual: true })` to side-step the broken transitive imports, so the new DTO and service specs run cleanly. Fixing the repo-wide Jest config is out of scope here.

## Test Cases

### a) Neither field provided (Expect 400 Validation Error)

```bash
curl -s -X POST http://localhost:3000/notifications \
  -H "Content-Type: application/json" \
  -H "x-api-key: <your-key>" \
  -d '{
    "providerId": 9,
    "data": {
      "message": {
        "GCM": "{\"notification\":{\"title\":\"T\",\"body\":\"B\"}}"
      }
    }
  }' | jq .
```

**Expected Result:**
`400 Bad Request` :

```json
{
    "type": "http://localhost:3010/problems/validation-failed",
    "title": "Validation Failed",
    "status": 400,
    "detail": "Validation failed",
    "instance": "/notifications",
    "validation_errors": [
        "Either \"target\" or \"topicArn\" must be provided, but not both."
    ],
    "error_code": "VALIDATION_FAILED",
    "timestamp": "2026-05-21T08:55:43.115Z"
}
```

---

### b) Both fields provided (Expect 400 Validation Error)

```bash
curl -s -X POST http://localhost:3000/notifications \
  -H "Content-Type: application/json" \
  -H "x-api-key: <your-key>" \
  -d '{
    "providerId": 9,
    "data": {
      "target": "arn:aws:sns:us-east-1:123:endpoint/GCM/App/abc",
      "topicArn": "arn:aws:sns:us-east-1:123:my-topic",
      "message": {
        "GCM": "{\"notification\":{\"title\":\"T\",\"body\":\"B\"}}"
      }
    }
  }' | jq .
```

**Expected Result:**
`400 Bad Request` :

```json
{
    "type": "http://localhost:3010/problems/validation-failed",
    "title": "Validation Failed",
    "status": 400,
    "detail": "Validation failed",
    "instance": "/notifications",
    "validation_errors": [
        "Either \"target\" or \"topicArn\" must be provided, but not both."
    ],
    "error_code": "VALIDATION_FAILED",
    "timestamp": "2026-05-21T08:56:17.353Z"
}
```

---

### c) Provided field contains empty string (Expect 400 Validation Error)

```bash
curl -s -X POST http://localhost:3000/notifications \
  -H "Content-Type: application/json" \
  -H "x-api-key: <your-key>" \
  -d '{
    "providerId": 9,
    "data": {
      "target": "",
      "message": {
        "GCM": "{\"notification\":{\"title\":\"T\",\"body\":\"B\"}}"
      }
    }
  }' | jq .
```

**Expected Result:**
`400 Bad Request` :

```json
{
    "type": "http://localhost:3010/problems/validation-failed",
    "title": "Validation Failed",
    "status": 400,
    "detail": "Validation failed",
    "instance": "/notifications",
    "validation_errors": [
        "target must not be empty when provided",
        "Either \"target\" or \"topicArn\" must be provided, but not both."
    ],
    "error_code": "VALIDATION_FAILED",
    "timestamp": "2026-05-21T08:52:58.055Z"
}
```

---

### d) Whitespace-only → 400 (verifies the trim fix)

```bash
curl -s -X POST http://localhost:3010/notifications \
  -H "Content-Type: application/json" \
  -H "x-api-key: 9f37b5082e2949a50fc84a0b207ba3a4f86f553bb55bd7ca2fdaf56d36ee1743" \
  -d '{"providerId":14,"data":{"target":"   ","message":{"GCM":"{\"notification\":{\"title\":\"T\",\"body\":\"B\"}}"}}}' | jq .
```

**Expected Result:**
`400 Bad Request` :

```json
{
    "type": "http://localhost:3010/problems/validation-failed",
    "title": "Validation Failed",
    "status": 400,
    "detail": "Validation failed",
    "instance": "/notifications",
    "validation_errors": [
        "target must not be empty when provided",
        "Either \"target\" or \"topicArn\" must be provided, but not both."
    ],
    "error_code": "VALIDATION_FAILED",
    "timestamp": "2026-05-21T08:57:50.155Z"
}
```

---


### e) Only `target` provided (Expect 201 Happy Path — Existing Behavior)

```bash
curl -s -X POST http://localhost:3000/notifications \
  -H "Content-Type: application/json" \
  -H "x-api-key: <your-key>" \
  -d '{
    "providerId": 9,
    "data": {
      "target": "arn:aws:sns:us-west-2:505884080245:endpoint/GCM/OQSHA-Android/7fb080a5-a5e9-38f0-98fe-ebd0396e0076",
      "message": {
        "GCM": "{\"notification\":{\"title\":\"Test\",\"body\":\"Hello\"}}"
      }
    }
  }' | jq .
```

**Expected Result:**
`201 Created`

```json
{
  "status": "success"
}
```

---

### f) Only `topicArn` provided (Expect 201 Happy Path — New Behavior)

```bash
curl -s -X POST http://localhost:3000/notifications \
  -H "Content-Type: application/json" \
  -H "x-api-key: <your-key>" \
  -d '{
    "providerId": 9,
    "data": {
      "topicArn": "arn:aws:sns:us-west-2:505884080245:my-app-all-users",
      "message": {
        "GCM": "{\"notification\":{\"title\":\"Broadcast\",\"body\":\"Sent to all subscribers\"}}"
      }
    }
  }' | jq .
```

**Expected Result:**
`201 Created`

```json
{
  "status": "success"
}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AWS SNS push notifications now support topic-based broadcasting in addition to targeted endpoint delivery.

* **Documentation**
  * Updated AWS SNS push notification guides with clarified payload requirements, including new broadcast examples and validation rules for endpoint vs. topic parameters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OsmosysSoftware/osmo-x/pull/534?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
