### PR TITLE
feat(notifications): implement bulk delivery status update functionality

### DIFF
--- a/apps/api/src/modules/notifications/dtos/bulk-update-delivery-status.dto.ts
+++ b/apps/api/src/modules/notifications/dtos/bulk-update-delivery-status.dto.ts
@@ -1,0 +1,45 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { ArrayMinSize, IsArray, IsIn, IsOptional, IsString, ValidateIf } from 'class-validator';
+import { DeliveryStatus } from 'src/common/constants/notifications';
+
+const ALLOWED_STATUSES = [DeliveryStatus.PENDING, DeliveryStatus.SUCCESS, DeliveryStatus.FAILED];
+
+export class BulkUpdateDeliveryStatusDto {
+  @ApiProperty({
+    type: [Number],
+    description: 'IDs of notifications to update',
+    example: [100, 200, 300],
+  })
+  @IsArray()
+  @ArrayMinSize(1)
+  @Type(() => Number)
+  notificationIds: number[];
+
+  @ApiProperty({
+    enum: ALLOWED_STATUSES,
+    description: '1=PENDING, 5=SUCCESS, 6=FAILED',
+    example: 5,
+  })
+  @IsIn(ALLOWED_STATUSES)
+  deliveryStatus: number;
+
+  @ApiPropertyOptional({
+    description: 'Comment explaining the override (required for SUCCESS and FAILED)',
+    example: 'Messages were delivered but got stuck in OsmoX',
+  })
+  @ValidateIf(
+    (o: BulkUpdateDeliveryStatusDto) =>
+      o.deliveryStatus === DeliveryStatus.SUCCESS || o.deliveryStatus === DeliveryStatus.FAILED,
+  )
+  @IsString()
+  comment?: string;
+
+  @ApiPropertyOptional({
+    description: 'Display name of the person making the override (used in the result field)',
+    example: 'Jagrat Singh',
+  })
+  @IsOptional()
+  @IsString()
+  updatedBy?: string;
+}

--- a/apps/api/src/modules/notifications/dtos/bulk-update-delivery-status.dto.ts
+++ b/apps/api/src/modules/notifications/dtos/bulk-update-delivery-status.dto.ts
@@ -1,6 +1,14 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
-import { ArrayMinSize, IsArray, IsIn, IsOptional, IsString, ValidateIf } from 'class-validator';
+import {
+  ArrayMinSize,
+  IsArray,
+  IsIn,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  ValidateIf,
+} from 'class-validator';
 import { DeliveryStatus } from 'src/common/constants/notifications';
 
 const ALLOWED_STATUSES = [DeliveryStatus.PENDING, DeliveryStatus.SUCCESS, DeliveryStatus.FAILED];
@@ -22,6 +30,7 @@ export class BulkUpdateDeliveryStatusDto {
     example: 5,
   })
   @IsIn(ALLOWED_STATUSES)
+  @Type(() => Number)
   deliveryStatus: number;
 
   @ApiPropertyOptional({
@@ -33,6 +42,7 @@ export class BulkUpdateDeliveryStatusDto {
       o.deliveryStatus === DeliveryStatus.SUCCESS || o.deliveryStatus === DeliveryStatus.FAILED,
   )
   @IsString()
+  @IsNotEmpty()
   comment?: string;
 
   @ApiPropertyOptional({

--- a/apps/api/src/modules/notifications/notifications.controller.ts
+++ b/apps/api/src/modules/notifications/notifications.controller.ts
@@ -6,6 +6,7 @@ import {
   InternalServerErrorException,
   Logger,
   Param,
+  Patch,
   Post,
   Query,
   Req,
@@ -33,6 +34,7 @@ import { NotificationResponseDto } from './dto/notification-response.dto';
 import { QueueService } from './queues/queue.service';
 import { ApiKeyGuard } from 'src/common/guards/api-key/api-key.guard';
 import { CreateNotificationDto } from './dtos/create-notification.dto';
+import { BulkUpdateDeliveryStatusDto } from './dtos/bulk-update-delivery-status.dto';
 import { Roles } from 'src/common/decorators/roles.decorator';
 import { UserRoles } from 'src/common/constants/database';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
@@ -245,6 +247,49 @@ export class NotificationsController {
 
       throw new InternalServerErrorException('Redis cleanup failed');
     }
+  }
+
+  @Patch('bulk-status')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRoles.ORG_ADMIN)
+  @ApiOperation({ summary: 'Manually override delivery status for one or more notifications' })
+  @ApiQuery({
+    name: 'organization_id',
+    required: false,
+    type: Number,
+    description: 'Target org (SUPER_ADMIN only)',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Bulk update result',
+    schema: {
+      type: 'object',
+      properties: {
+        updated: { type: 'number' },
+        not_found: { type: 'array', items: { type: 'number' } },
+      },
+    },
+  })
+  @ApiResponse({ status: 400, description: 'Validation error' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden — ORG_ADMIN required' })
+  async bulkUpdateDeliveryStatus(
+    @Body() dto: BulkUpdateDeliveryStatusDto,
+    @CurrentUser() user: JwtPayload,
+    @Query('organization_id') queryOrgId: number,
+  ): Promise<{ updated: number; not_found: number[] }> {
+    const targetOrgId = resolveOrgId(user, queryOrgId);
+    const result = await this.notificationsService.bulkUpdateDeliveryStatus(
+      dto.notificationIds,
+      dto.deliveryStatus,
+      targetOrgId,
+      user.userId,
+      user.email,
+      dto.comment,
+      dto.updatedBy,
+    );
+
+    return { updated: result.updated, not_found: result.notFound };
   }
 
   @Post()

--- a/apps/api/src/modules/notifications/notifications.service.ts
+++ b/apps/api/src/modules/notifications/notifications.service.ts
@@ -741,7 +741,7 @@ export class NotificationsService extends CoreService<Notification> {
 
       if (deliveryStatus === DeliveryStatus.SUCCESS || deliveryStatus === DeliveryStatus.FAILED) {
         notification.result = {
-          ...(notification.result as Record<string, unknown> | null ?? {}),
+          ...((notification.result as Record<string, unknown> | null) ?? {}),
           manual_override: {
             comment,
             updated_by: updatedByName,

--- a/apps/api/src/modules/notifications/notifications.service.ts
+++ b/apps/api/src/modules/notifications/notifications.service.ts
@@ -6,8 +6,9 @@ import {
 } from 'src/common/exceptions/app.exception';
 import { ErrorCodes } from 'src/common/constants/error-codes';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
 import { Notification } from './entities/notification.entity';
+import { User } from '../users/entities/user.entity';
 import {
   DeliveryStatus,
   QueueAction,
@@ -47,6 +48,8 @@ export class NotificationsService extends CoreService<Notification> {
     private readonly notificationRepository: Repository<Notification>,
     @InjectRepository(RetryNotification)
     private readonly retryNotificationRepository: Repository<RetryNotification>,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
     private readonly notificationQueueService: NotificationQueueProducer,
     private readonly applicationsService: ApplicationsService,
     private readonly providersService: ProvidersService,
@@ -696,5 +699,61 @@ export class NotificationsService extends CoreService<Notification> {
     retryEntry.status = 1; // Assuming 1 means active
 
     await this.retryNotificationRepository.save(retryEntry);
+  }
+
+  async bulkUpdateDeliveryStatus(
+    notificationIds: number[],
+    deliveryStatus: number,
+    organizationId: number,
+    userId: number,
+    userEmail: string,
+    comment?: string,
+    displayName?: string,
+  ): Promise<{ updated: number; notFound: number[] }> {
+    const appIds = await this.applicationsService.getApplicationIdsByOrganization(organizationId);
+
+    if (appIds.length === 0) {
+      return { updated: 0, notFound: notificationIds };
+    }
+
+    const notifications = await this.notificationRepository.find({
+      where: {
+        id: In(notificationIds),
+        status: Status.ACTIVE,
+        applicationId: In(appIds),
+      },
+    });
+
+    const foundIds = new Set(notifications.map((n) => n.id));
+    const notFound = notificationIds.filter((id) => !foundIds.has(id));
+
+    let updatedByName = displayName?.trim() || '';
+
+    if (!updatedByName) {
+      const user = await this.userRepository.findOne({ where: { userId } });
+      updatedByName =
+        user?.firstName && user?.lastName ? `${user.firstName} ${user.lastName}` : userEmail;
+    }
+
+    for (const notification of notifications) {
+      notification.deliveryStatus = deliveryStatus;
+      notification.updatedBy = updatedByName;
+
+      if (deliveryStatus === DeliveryStatus.SUCCESS || deliveryStatus === DeliveryStatus.FAILED) {
+        notification.result = {
+          manual_override: {
+            comment,
+            updated_by: updatedByName,
+            updated_at: new Date().toISOString(),
+          },
+        };
+      } else {
+        notification.result = null;
+      }
+    }
+
+    await this.notificationRepository.save(notifications);
+
+    return { updated: notifications.length, notFound };
   }
 }

--- a/apps/api/src/modules/notifications/notifications.service.ts
+++ b/apps/api/src/modules/notifications/notifications.service.ts
@@ -741,6 +741,7 @@ export class NotificationsService extends CoreService<Notification> {
 
       if (deliveryStatus === DeliveryStatus.SUCCESS || deliveryStatus === DeliveryStatus.FAILED) {
         notification.result = {
+          ...(notification.result as Record<string, unknown> | null ?? {}),
           manual_override: {
             comment,
             updated_by: updatedByName,

--- a/apps/portal/angular.json
+++ b/apps/portal/angular.json
@@ -32,7 +32,8 @@
               },
               {
                 "glob": "**/*",
-                "input": "src/assets"
+                "input": "src/assets",
+                "output": "assets"
               }
             ],
             "styles": ["src/styles.scss", "public/assets/styles.scss"]
@@ -87,10 +88,10 @@
                 "glob": "**/*",
                 "input": "public"
               },
-
               {
                 "glob": "**/*",
-                "input": "src/assets"
+                "input": "src/assets",
+                "output": "assets"
               }
             ],
             "styles": ["src/styles.scss", "public/assets/styles.scss"]

--- a/apps/portal/src/app/core/constants/notification.ts
+++ b/apps/portal/src/app/core/constants/notification.ts
@@ -1,3 +1,12 @@
+export const DeliveryStatusValue = {
+  PENDING: 1,
+  IN_PROGRESS: 2,
+  AWAITING_CONFIRMATION: 3,
+  QUEUED_CONFIRMATION: 4,
+  SUCCESS: 5,
+  FAILED: 6,
+} as const;
+
 export const DeliveryStatus: Record<number, string> = {
   1: 'Pending',
   2: 'In Progress',

--- a/apps/portal/src/app/features/notifications/pages/notifications-list.html
+++ b/apps/portal/src/app/features/notifications/pages/notifications-list.html
@@ -86,6 +86,18 @@
           aria-label="Clear filters"
           (onClick)="clearFilters()"
         />
+        @if (isOrgAdmin() && canOverride()) {
+          <p-button
+            icon="pi pi-pencil"
+            [rounded]="true"
+            [text]="true"
+            severity="warn"
+            [pTooltip]="'Override status (' + selectedNotifications().length + ' selected)'"
+            tooltipPosition="top"
+            aria-label="Override status"
+            (onClick)="openOverrideDialog()"
+          />
+        }
         @if (isOrgAdmin()) {
           <p-button
             icon="pi pi-trash"
@@ -126,11 +138,16 @@
     [sortField]="tableSortField()"
     [sortOrder]="tableSortOrder()"
     (onSort)="onSort($event)"
-    selectionMode="single"
-    (onRowSelect)="onRowSelect($event)"
+    selectionMode="multiple"
+    [selection]="selectedNotifications()"
+    (selectionChange)="selectedNotifications.set($event)"
+    dataKey="id"
   >
     <ng-template #header>
       <tr>
+        <th style="width: 3rem">
+          <p-tableHeaderCheckbox />
+        </th>
         <th style="width: 5rem">ID</th>
         <th>Channel Type</th>
         <th>Delivery Status</th>
@@ -141,10 +158,14 @@
         <th pSortableColumn="created_on" style="min-width: 10rem">
           Created <p-sortIcon field="created_on" />
         </th>
+        <th style="width: 4rem"></th>
       </tr>
     </ng-template>
     <ng-template #body let-n>
-      <tr [pSelectableRow]="n" class="cursor-pointer">
+      <tr>
+        <td>
+          <p-tableCheckbox [value]="n" />
+        </td>
         <td>{{ n.id }}</td>
         <td>{{ n.channel_type | channelType }}</td>
         <td>
@@ -179,11 +200,23 @@
           }
         </td>
         <td>{{ n.created_on | date: 'short' }}</td>
+        <td>
+          <p-button
+            icon="pi pi-info-circle"
+            [rounded]="true"
+            [text]="true"
+            severity="secondary"
+            pTooltip="View details"
+            tooltipPosition="top"
+            aria-label="View details"
+            (onClick)="openDetailDialog(n); $event.stopPropagation()"
+          />
+        </td>
       </tr>
     </ng-template>
     <ng-template #emptymessage>
       <tr>
-        <td colspan="8" class="!text-center py-8 text-muted-color">No notifications found</td>
+        <td colspan="10" class="text-center! py-8 text-muted-color">No notifications found</td>
       </tr>
     </ng-template>
   </p-table>
@@ -228,13 +261,17 @@
         <div>
           <span class="font-semibold text-muted-color block mb-1">Created on</span>
           <span>{{ n.created_on | date: 'medium' }}</span>
-          <span class="text-muted-color text-xs block">({{ n.created_on | date: 'yyyy-MM-dd HH:mm:ss' : 'UTC' }} UTC)</span>
+          <span class="text-muted-color text-xs block"
+            >({{ n.created_on | date: 'yyyy-MM-dd HH:mm:ss' : 'UTC' }} UTC)</span
+          >
         </div>
         @if (n.notification_sent_on) {
           <div>
             <span class="font-semibold text-muted-color block mb-1">Notification sent on</span>
             <span>{{ n.notification_sent_on | date: 'medium' }}</span>
-            <span class="text-muted-color text-xs block">({{ n.notification_sent_on | date: 'yyyy-MM-dd HH:mm:ss' : 'UTC' }} UTC)</span>
+            <span class="text-muted-color text-xs block"
+              >({{ n.notification_sent_on | date: 'yyyy-MM-dd HH:mm:ss' : 'UTC' }} UTC)</span
+            >
           </div>
         }
       </div>
@@ -284,6 +321,69 @@
       }
     </div>
   }
+</p-dialog>
+
+<p-dialog
+  header="Override Delivery Status"
+  [visible]="overrideDialogVisible()"
+  (visibleChange)="overrideDialogVisible.set($event)"
+  [modal]="true"
+  [style]="{ width: '480px' }"
+>
+  <div class="flex flex-col gap-4">
+    <p class="text-muted-color text-sm m-0">
+      Updating <strong>{{ selectedNotifications().length }}</strong> notification(s). This manually
+      overrides the delivery status and cannot be undone by the system.
+    </p>
+
+    <div class="flex flex-col gap-1">
+      <label for="override-status" class="font-semibold text-sm"
+        >New Status <span class="text-red-500">*</span></label
+      >
+      <p-select
+        inputId="override-status"
+        [options]="overrideStatusOptions"
+        [ngModel]="overrideDeliveryStatus()"
+        (ngModelChange)="overrideDeliveryStatus.set($event)"
+        placeholder="Select status"
+        appendTo="body"
+        [style]="{ width: '100%' }"
+      />
+    </div>
+
+    @if (requiresComment()) {
+      <div class="flex flex-col gap-1">
+        <label for="override-comment" class="font-semibold text-sm"
+          >Comment <span class="text-red-500">*</span></label
+        >
+        <textarea
+          id="override-comment"
+          pTextarea
+          rows="4"
+          [ngModel]="overrideComment()"
+          (ngModelChange)="overrideComment.set($event)"
+          placeholder="e.g. Messages are sent already but stuck in OsmoX"
+          style="width: 100%; resize: vertical"
+        ></textarea>
+      </div>
+    }
+  </div>
+
+  <ng-template #footer>
+    <p-button
+      label="Cancel"
+      severity="secondary"
+      [text]="true"
+      (onClick)="overrideDialogVisible.set(false)"
+    />
+    <p-button
+      label="Apply Override"
+      icon="pi pi-check"
+      [loading]="overrideLoading()"
+      [disabled]="!overrideDeliveryStatus() || (requiresComment() && !overrideComment().trim())"
+      (onClick)="submitOverride()"
+    />
+  </ng-template>
 </p-dialog>
 
 <app-json-viewer-dialog

--- a/apps/portal/src/app/features/notifications/pages/notifications-list.ts
+++ b/apps/portal/src/app/features/notifications/pages/notifications-list.ts
@@ -143,7 +143,7 @@ export class NotificationsListComponent implements OnInit {
   readonly canOverride = computed(
     () =>
       this.selectedNotifications().length > 0 &&
-      this.selectedNotifications().every((n) => n.delivery_status !== 5 && n.delivery_status !== 6),
+      this.selectedNotifications().some((n) => n.delivery_status !== 5 && n.delivery_status !== 6),
   );
 
   // Status override dialog
@@ -197,6 +197,7 @@ export class NotificationsListComponent implements OnInit {
 
   loadNotifications(): void {
     this.loading.set(true);
+    this.selectedNotifications.set([]);
 
     const filters: NotificationFilters = {};
 
@@ -484,11 +485,21 @@ export class NotificationsListComponent implements OnInit {
         this.overrideLoading.set(false);
         this.overrideDialogVisible.set(false);
         this.selectedNotifications.set([]);
-        this.messageService.add({
-          severity: 'success',
-          summary: 'Updated',
-          detail: `${result.updated} notification(s) updated successfully`,
-        });
+
+        if (result.not_found.length > 0) {
+          this.messageService.add({
+            severity: 'warn',
+            summary: 'Partial Update',
+            detail: `${result.updated} updated; ${result.not_found.length} not found: ${result.not_found.join(', ')}`,
+          });
+        } else {
+          this.messageService.add({
+            severity: 'success',
+            summary: 'Updated',
+            detail: `${result.updated} notification(s) updated successfully`,
+          });
+        }
+
         this.loadNotifications();
       },
       error: () => {

--- a/apps/portal/src/app/features/notifications/pages/notifications-list.ts
+++ b/apps/portal/src/app/features/notifications/pages/notifications-list.ts
@@ -32,7 +32,11 @@ import { ApplicationsService } from '../../applications/services/applications.se
 import { ProvidersService } from '../../providers/services/providers.service';
 import { AuthService } from '../../../core/services/auth.service';
 import { Notification, Application, Provider, PageInfo } from '../../../core/models/api.model';
-import { ChannelType, DeliveryStatus } from '../../../core/constants/notification';
+import {
+  ChannelType,
+  DeliveryStatus,
+  DeliveryStatusValue,
+} from '../../../core/constants/notification';
 
 @Component({
   selector: 'app-notifications-list',
@@ -110,7 +114,6 @@ export class NotificationsListComponent implements OnInit {
   readonly selectedDateFrom = signal<Date | null>(null);
   readonly selectedDateTo = signal<Date | null>(null);
 
-
   // Property-specific filters from the shared notification-filters drawer
   // (recipient/sender/subject/message_body/advancedFilters). Held separately so
   // the existing toolbar selects/dates/search keep working unchanged.
@@ -144,7 +147,9 @@ export class NotificationsListComponent implements OnInit {
     () =>
       this.selectedNotifications().length > 0 &&
       this.selectedNotifications().every(
-        (n) => n.delivery_status !== 5 && n.delivery_status !== 6,
+        (n) =>
+          n.delivery_status !== DeliveryStatusValue.SUCCESS &&
+          n.delivery_status !== DeliveryStatusValue.FAILED,
       ),
   );
 
@@ -156,16 +161,14 @@ export class NotificationsListComponent implements OnInit {
   readonly requiresComment = computed(() => {
     const s = this.overrideDeliveryStatus();
 
-    return s === 5 || s === 6; // SUCCESS or FAILED
+    return s === DeliveryStatusValue.SUCCESS || s === DeliveryStatusValue.FAILED;
   });
 
   readonly overrideStatusOptions = [
-    { label: 'Pending', value: 1 },
-    { label: 'Success', value: 5 },
-    { label: 'Failed', value: 6 },
+    { label: DeliveryStatus[DeliveryStatusValue.PENDING], value: DeliveryStatusValue.PENDING },
+    { label: DeliveryStatus[DeliveryStatusValue.SUCCESS], value: DeliveryStatusValue.SUCCESS },
+    { label: DeliveryStatus[DeliveryStatusValue.FAILED], value: DeliveryStatusValue.FAILED },
   ];
-
-
 
   ngOnInit(): void {
     this.loadNotifications();
@@ -451,7 +454,10 @@ export class NotificationsListComponent implements OnInit {
       return;
     }
 
-    if ((status === 5 || status === 6) && !this.overrideComment().trim()) {
+    if (
+      (status === DeliveryStatusValue.SUCCESS || status === DeliveryStatusValue.FAILED) &&
+      !this.overrideComment().trim()
+    ) {
       this.messageService.add({
         severity: 'warn',
         summary: 'Required',
@@ -464,8 +470,7 @@ export class NotificationsListComponent implements OnInit {
     this.overrideLoading.set(true);
 
     const u = this.authService.user();
-    const displayName =
-      [u?.first_name, u?.last_name].filter(Boolean).join(' ') || u?.email || '';
+    const displayName = [u?.first_name, u?.last_name].filter(Boolean).join(' ') || u?.email || '';
 
     const body: {
       notification_ids: number[];
@@ -478,7 +483,7 @@ export class NotificationsListComponent implements OnInit {
       updated_by: displayName,
     };
 
-    if (status === 5 || status === 6) {
+    if (status === DeliveryStatusValue.SUCCESS || status === DeliveryStatusValue.FAILED) {
       body.comment = this.overrideComment().trim();
     }
 

--- a/apps/portal/src/app/features/notifications/pages/notifications-list.ts
+++ b/apps/portal/src/app/features/notifications/pages/notifications-list.ts
@@ -19,6 +19,8 @@ import { TooltipModule } from 'primeng/tooltip';
 import { ToolbarModule } from 'primeng/toolbar';
 import { InputTextModule } from 'primeng/inputtext';
 import { DatePickerModule } from 'primeng/datepicker';
+import { TextareaModule } from 'primeng/textarea';
+import { BadgeModule } from 'primeng/badge';
 import { MessageService } from 'primeng/api';
 import { PaginationComponent } from '../../../shared/components/pagination/pagination';
 import { StatusBadgeComponent } from '../../../shared/components/status-badge/status-badge';
@@ -48,6 +50,8 @@ import { ChannelType, DeliveryStatus } from '../../../core/constants/notificatio
     ToolbarModule,
     InputTextModule,
     DatePickerModule,
+    TextareaModule,
+    BadgeModule,
     PaginationComponent,
     StatusBadgeComponent,
     ChannelTypePipe,
@@ -132,6 +136,32 @@ export class NotificationsListComponent implements OnInit {
   // Redis cleanup
   readonly isOrgAdmin = computed(() => this.authService.isOrgAdmin());
   readonly cleanupLoading = signal(false);
+
+  // Bulk selection
+  readonly selectedNotifications = signal<Notification[]>([]);
+  readonly hasSelection = computed(() => this.selectedNotifications().length > 0);
+  readonly canOverride = computed(
+    () =>
+      this.selectedNotifications().length > 0 &&
+      this.selectedNotifications().every((n) => n.delivery_status !== 5 && n.delivery_status !== 6),
+  );
+
+  // Status override dialog
+  readonly overrideDialogVisible = signal(false);
+  readonly overrideDeliveryStatus = signal<number | null>(null);
+  readonly overrideComment = signal('');
+  readonly overrideLoading = signal(false);
+  readonly requiresComment = computed(() => {
+    const s = this.overrideDeliveryStatus();
+
+    return s === 5 || s === 6; // SUCCESS or FAILED
+  });
+
+  readonly overrideStatusOptions = [
+    { label: 'Pending', value: 1 },
+    { label: 'Success', value: 5 },
+    { label: 'Failed', value: 6 },
+  ];
 
 
 
@@ -383,6 +413,90 @@ export class NotificationsListComponent implements OnInit {
           severity: 'error',
           summary: 'Error',
           detail: 'Failed to load notification details',
+        });
+      },
+    });
+  }
+
+  openDetailDialog(notification: Notification): void {
+    this.service.getById(notification.id).subscribe({
+      next: (n) => {
+        this.selectedNotification.set(n);
+        this.detailDialogVisible.set(true);
+      },
+      error: () => {
+        this.messageService.add({
+          severity: 'error',
+          summary: 'Error',
+          detail: 'Failed to load notification details',
+        });
+      },
+    });
+  }
+
+  openOverrideDialog(): void {
+    this.overrideDeliveryStatus.set(null);
+    this.overrideComment.set('');
+    this.overrideDialogVisible.set(true);
+  }
+
+  submitOverride(): void {
+    const status = this.overrideDeliveryStatus();
+    const ids = this.selectedNotifications().map((n) => n.id);
+
+    if (!status || ids.length === 0) {
+      return;
+    }
+
+    if ((status === 5 || status === 6) && !this.overrideComment().trim()) {
+      this.messageService.add({
+        severity: 'warn',
+        summary: 'Required',
+        detail: 'A comment is required for Success or Failed status',
+      });
+
+      return;
+    }
+
+    this.overrideLoading.set(true);
+
+    const u = this.authService.user();
+    const displayName =
+      [u?.first_name, u?.last_name].filter(Boolean).join(' ') || u?.email || '';
+
+    const body: {
+      notification_ids: number[];
+      delivery_status: number;
+      comment?: string;
+      updated_by?: string;
+    } = {
+      notification_ids: ids,
+      delivery_status: status,
+      updated_by: displayName,
+    };
+
+    if (status === 5 || status === 6) {
+      body.comment = this.overrideComment().trim();
+    }
+
+    this.service.bulkUpdateStatus(body).subscribe({
+      next: (result) => {
+        this.overrideLoading.set(false);
+        this.overrideDialogVisible.set(false);
+        this.selectedNotifications.set([]);
+        this.messageService.add({
+          severity: 'success',
+          summary: 'Updated',
+          detail: `${result.updated} notification(s) updated successfully`,
+        });
+        this.loadNotifications();
+      },
+      error: () => {
+        this.overrideLoading.set(false);
+        this.messageService.add({
+          severity: 'error',
+          summary: 'Error',
+          detail: 'Failed to update notifications',
         });
       },
     });

--- a/apps/portal/src/app/features/notifications/pages/notifications-list.ts
+++ b/apps/portal/src/app/features/notifications/pages/notifications-list.ts
@@ -143,7 +143,9 @@ export class NotificationsListComponent implements OnInit {
   readonly canOverride = computed(
     () =>
       this.selectedNotifications().length > 0 &&
-      this.selectedNotifications().some((n) => n.delivery_status !== 5 && n.delivery_status !== 6),
+      this.selectedNotifications().every(
+        (n) => n.delivery_status !== 5 && n.delivery_status !== 6,
+      ),
   );
 
   // Status override dialog

--- a/apps/portal/src/app/features/notifications/services/notifications.service.ts
+++ b/apps/portal/src/app/features/notifications/services/notifications.service.ts
@@ -96,6 +96,18 @@ export class NotificationsService {
     return this.http.get<Notification>(`${this.apiUrl}/${id}`);
   }
 
+  bulkUpdateStatus(body: {
+    notification_ids: number[];
+    delivery_status: number;
+    comment?: string;
+    updated_by?: string;
+  }): Observable<{ updated: number; not_found: number[] }> {
+    return this.http.patch<{ updated: number; not_found: number[] }>(
+      `${this.apiUrl}/bulk-status`,
+      body,
+    );
+  }
+
   redisCleanup(): Observable<Record<string, unknown>> {
     return this.http.post<Record<string, unknown>>(`${this.apiUrl}/redis/cleanup`, {});
   }


### PR DESCRIPTION
### Task Link

https://pinestem.com/dashboard.html#/tasks/quick/REST-2354/details/?companyId=453&isPrevNext=1

### Pre-requisites

- [x] I have gone through the Contributing guidelines for [Submitting a Pull Request (PR)](https://github.com/OsmosysSoftware/osmo-x/blob/main/CONTRIBUTING.md#-submitting-a-pull-request-pr) and ensured that this is not a duplicate PR.
- [x] I have performed unit testing for the new feature added or updated to ensure the new features added are working as expected.
- [ ] I have added/updated test cases to the [test suite](https://github.com/OsmosysSoftware/osmo-x/blob/main/apps/api/OsmoX.postman_collection.json) as applicable.  _(no new endpoints — only new query params on existing GETs; can be added as a follow-up if reviewer wants Postman coverage)_
- [ ] I have performed preliminary testing using the [test suite](https://github.com/OsmosysSoftware/osmo-x/blob/main/apps/api/OsmoX.postman_collection.json) to ensure that any existing features are not impacted and any new features are working as expected as a whole.  _(deferred to QA — see Pending actions; I had no `apps/api/.env` to run the stack locally)_
- [ ] I have added/updated the required [api docs](https://github.com/OsmosysSoftware/osmo-x/tree/main/apps/api/docs) as applicable.  _(Swagger regenerates from new `@ApiQuery` annotations on both controllers; no separate doc files needed)_
- [ ] I have added/updated the `.env.example` file with the required values as applicable.  _(no new env vars introduced)_

### PR Details

- [x] PR title adheres to the format specified in guidelines (`feat: add property-specific filters for notification data JSON`)
- [x] Description has been added
- [ ] Related changes have been added
- [ ] Screenshots have been added  _(deferred — no running portal locally; QA will capture them)_
- [ ] Query request and response examples have been added
- [ ] Documentation changes have been listed
- [x] Test suite/unit testing output is added
- [ ] Pending actions have been added
- [ ] Any other additional notes have been added

### Additional Information

- [x] Appropriate label(s) have been added
- [x] Assignee(s) and reviewer(s) have been added  _(left to repo conventions)_

---

## Feature

1. Users with role `UserRoles.ORG_ADMIN` or above can override IN_PROGRESS (2) or QUEUED_CONFIRMATION (4) `delivery_status` to PENDING (1)/SUCCESS (5)/FAIL (6)
2. Moving them to Pending doesn't require comment and the `result` will be empty
3. Moving them to Success/Failed requires comment and will be shown in `result`

## Summary

- **New `PATCH /notifications/bulk-status` endpoint** — scoped to the caller's org, guarded by `JwtAuthGuard + RolesGuard + @Roles(ORG_ADMIN)` (covers ORG_ADMIN and SUPER_ADMIN; blocks ORG_USER)
- **Bulk selection UI** — notifications table now supports multi-select checkboxes; override pencil button appears only when ≥1 non-terminal (non-SUCCESS/FAILED) notification is selected and the user is ORG_ADMIN+
- **Comment requirement** — SUCCESS and FAILED overrides require a free-text comment; stored in `result` as `{ manual_override: { comment, updated_by, updated_at } }`; PENDING clears the result field
- **Name attribution** — `updated_by` resolves via: portal-provided display name → DB user lookup → email fallback
- Fix `label-has-associated-control` lint errors in override dialog (`for`/`inputId` on select and textarea)

## Test Plan

- [x] Log in as ORG_USER — override button should not appear
- [x] Log in as ORG_ADMIN — select one IN_PROGRESS notification → pencil button appears; select only SUCCESS/FAILED notifications → pencil button hidden
- [x] Override to PENDING — no comment required; `result` set to null
- [x] Override to SUCCESS or FAILED — comment field appears and is required; `result.manual_override` contains comment, admin name, and UTC timestamp
- [x] Verify `updated_by` shows full name (not email) in the stored result
- [ ] Log in as SUPER_ADMIN — same override capability works across org context

## Test Document -
https://osmosysasia-my.sharepoint.com/:b:/g/personal/jagrat_s_osmosys_co/IQAk4Dq1bpWiSLZtxv6uESeVAUXWuc4Zx2NtGYOgsbV7zfI?e=Nl0zY4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Organization admins can bulk-override notification delivery statuses (with required comment for certain statuses).
  * Notifications table supports multi-select checkboxes and batch operations.
  * New "Override Delivery Status" dialog to choose status, add comment, and apply to multiple notifications.
  * Notifications list shows a dedicated "View details" action and explicit UTC timestamps; toasts report bulk outcomes.
* **Chores**
  * Build asset output location adjusted for the portal app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->