### PR TITLE
fix(api): clean up orphaned notification retry records in deletion cron

### DIFF
--- a/apps/api/src/database/migrations/1774000000200-add-retry-notification-created-on-index.ts
+++ b/apps/api/src/database/migrations/1774000000200-add-retry-notification-created-on-index.ts
@@ -1,13 +1,20 @@
-import { MigrationInterface, QueryRunner } from 'typeorm';
+import { MigrationInterface, QueryRunner, TableIndex } from 'typeorm';
 
 export class AddRetryNotificationCreatedOnIndex1774000000200 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(
-      `CREATE INDEX IF NOT EXISTS "IDX_notify_notification_retries_created_on" ON "notify_notification_retries" ("created_on")`,
+    await queryRunner.createIndex(
+      'notify_notification_retries',
+      new TableIndex({
+        name: 'IDX_notify_notification_retries_created_on',
+        columnNames: ['created_on'],
+      }),
     );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_notify_notification_retries_created_on"`);
+    await queryRunner.dropIndex(
+      'notify_notification_retries',
+      'IDX_notify_notification_retries_created_on',
+    );
   }
 }

--- a/apps/api/src/database/migrations/1774000000200-add-retry-notification-created-on-index.ts
+++ b/apps/api/src/database/migrations/1774000000200-add-retry-notification-created-on-index.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddRetryNotificationCreatedOnIndex1774000000200 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_notify_notification_retries_created_on" ON "notify_notification_retries" ("created_on")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_notify_notification_retries_created_on"`,
+    );
+  }
+}

--- a/apps/api/src/database/migrations/1774000000200-add-retry-notification-created-on-index.ts
+++ b/apps/api/src/database/migrations/1774000000200-add-retry-notification-created-on-index.ts
@@ -8,8 +8,6 @@ export class AddRetryNotificationCreatedOnIndex1774000000200 implements Migratio
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(
-      `DROP INDEX IF EXISTS "IDX_notify_notification_retries_created_on"`,
-    );
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_notify_notification_retries_created_on"`);
   }
 }

--- a/apps/api/src/modules/archived-notifications/archived-notifications.service.ts
+++ b/apps/api/src/modules/archived-notifications/archived-notifications.service.ts
@@ -397,22 +397,39 @@ export class ArchivedNotificationsService extends CoreService<ArchivedNotificati
           );
         } while (archivedEntriesBatch.length === batchSize);
 
-        // Retries have no FK to archived_notifications; prior deletion runs leave orphans unreachable by the batch loop above
-        const orphanedRetryResult = await queryRunner.manager
-          .createQueryBuilder()
-          .delete()
-          .from(RetryNotification)
-          .where('created_on < :cutoff', { cutoff: cutoffTimestamp })
-          .andWhere(
-            'NOT EXISTS (SELECT 1 FROM notify_archived_notifications a WHERE a.notification_id = notify_notification_retries.notification_id)',
-          )
-          .execute();
+        // Retries have no FK to archived_notifications; prior deletion runs can
+        // leave orphans that the batch loop above never reaches.
+        // TODO: also exclude retries whose notification_id still exists in notify_notifications
+        // (live notifications not yet archived) to avoid premature deletion
+        let orphanBatchCount: number;
 
-        const orphanedRetryAffected =
-          typeof orphanedRetryResult.affected === 'number' ? orphanedRetryResult.affected : 0;
-        totalDeletedRetries += orphanedRetryAffected;
+        do {
+          const orphanIds = await queryRunner.manager
+            .createQueryBuilder(RetryNotification, 'r')
+            .select('r.id', 'id')
+            .where('r.created_on < :cutoff', { cutoff: cutoffTimestamp })
+            .andWhere(
+              'NOT EXISTS (' +
+                'SELECT 1 FROM notify_archived_notifications a ' +
+                'WHERE a.notification_id = r.notification_id)',
+            )
+            .limit(batchSize)
+            .getRawMany<{ id: number }>();
 
-        this.logger.debug(`Orphaned retry records deleted: ${orphanedRetryAffected}`);
+          orphanBatchCount = orphanIds.length;
+
+          if (orphanBatchCount === 0) {
+            break;
+          }
+
+          await queryRunner.manager.delete(
+            RetryNotification,
+            orphanIds.map((r) => r.id),
+          );
+          totalDeletedRetries += orphanBatchCount;
+
+          this.logger.debug(`Orphaned retry batch deleted: ${orphanBatchCount}`);
+        } while (orphanBatchCount === batchSize);
 
         await queryRunner.commitTransaction();
 

--- a/apps/api/src/modules/archived-notifications/archived-notifications.service.ts
+++ b/apps/api/src/modules/archived-notifications/archived-notifications.service.ts
@@ -12,7 +12,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { CoreService } from 'src/common/graphql/services/core.service';
 import { PaginationQueryDto } from 'src/common/dto/pagination-query.dto';
 import { PaginationMeta, PaginationHelper } from 'src/common/utils/pagination.helper';
-import ms from 'ms';
+import ms = require('ms');
 import { ArchivedNotificationResponseDto } from './dto/archived-notification-response.dto';
 import { ApplicationsService } from '../applications/applications.service';
 import { NotificationDataFilterHelper } from '../notifications/helpers/notification-data-filter.helper';

--- a/apps/api/src/modules/archived-notifications/archived-notifications.service.ts
+++ b/apps/api/src/modules/archived-notifications/archived-notifications.service.ts
@@ -346,108 +346,125 @@ export class ArchivedNotificationsService extends CoreService<ArchivedNotificati
 
       const queryRunner = this.dataSource.createQueryRunner();
       await queryRunner.connect();
-      await queryRunner.startTransaction();
 
       try {
-        let archivedEntriesBatch: ArchivedNotification[] = [];
+        // Phase 1: archive deletion in a single transaction
+        await queryRunner.startTransaction();
 
-        do {
-          // Fetch archived entries to delete
-          archivedEntriesBatch = await queryRunner.manager.find(ArchivedNotification, {
-            where: {
-              createdOn: LessThan(cutoffTimestamp),
-              status: Status.ACTIVE,
-            },
-            order: {
-              createdOn: 'ASC',
-            },
-            take: batchSize,
-          });
+        try {
+          let archivedEntriesBatch: ArchivedNotification[] = [];
 
-          this.logger.debug(
-            `Query found ${archivedEntriesBatch.length} records. First record: ${archivedEntriesBatch.length > 0 ? JSON.stringify({ id: archivedEntriesBatch[0].id, notificationId: archivedEntriesBatch[0].notificationId, createdOn: archivedEntriesBatch[0].createdOn }) : 'None'}`,
-          );
+          do {
+            // Fetch archived entries to delete
+            archivedEntriesBatch = await queryRunner.manager.find(ArchivedNotification, {
+              where: {
+                createdOn: LessThan(cutoffTimestamp),
+                status: Status.ACTIVE,
+              },
+              order: {
+                createdOn: 'ASC',
+              },
+              take: batchSize,
+            });
 
-          if (archivedEntriesBatch.length === 0) {
             this.logger.debug(
-              `No more archived entries older than ${cutoffTimestamp} left to delete`,
+              `Query found ${archivedEntriesBatch.length} records. First record: ${archivedEntriesBatch.length > 0 ? JSON.stringify({ id: archivedEntriesBatch[0].id, notificationId: archivedEntriesBatch[0].notificationId, createdOn: archivedEntriesBatch[0].createdOn }) : 'None'}`,
             );
-            break;
-          }
 
-          // Get notification IDs for deleting related retry records
-          const notificationIds = archivedEntriesBatch.map((entry) => entry.notificationId);
+            if (archivedEntriesBatch.length === 0) {
+              this.logger.debug(
+                `No more archived entries older than ${cutoffTimestamp} left to delete`,
+              );
+              break;
+            }
 
-          // Delete retry entries first (foreign key constraint)
-          const retryDeleteResult = await queryRunner.manager.delete(RetryNotification, {
-            notification_id: In(notificationIds),
-          });
+            // Get notification IDs for deleting related retry records
+            const notificationIds = archivedEntriesBatch.map((entry) => entry.notificationId);
 
-          const retryAffected =
-            typeof retryDeleteResult.affected === 'number' ? retryDeleteResult.affected : 0;
-          totalDeletedRetries += retryAffected;
+            // Delete retry entries first (foreign key constraint)
+            const retryDeleteResult = await queryRunner.manager.delete(RetryNotification, {
+              notification_id: In(notificationIds),
+            });
 
-          // Delete archived notifications
-          const archivedIds = archivedEntriesBatch.map((entry) => entry.id);
-          await queryRunner.manager.delete(ArchivedNotification, archivedIds);
-          totalDeletedArchived += archivedEntriesBatch.length;
+            const retryAffected =
+              typeof retryDeleteResult.affected === 'number' ? retryDeleteResult.affected : 0;
+            totalDeletedRetries += retryAffected;
 
-          this.logger.debug(
-            `Batch processed: ${archivedEntriesBatch.length} archived notifications, ${retryAffected} retry records deleted`,
+            // Delete archived notifications
+            const archivedIds = archivedEntriesBatch.map((entry) => entry.id);
+            await queryRunner.manager.delete(ArchivedNotification, archivedIds);
+            totalDeletedArchived += archivedEntriesBatch.length;
+
+            this.logger.debug(
+              `Batch processed: ${archivedEntriesBatch.length} archived notifications, ${retryAffected} retry records deleted`,
+            );
+          } while (archivedEntriesBatch.length === batchSize);
+
+          await queryRunner.commitTransaction();
+        } catch (error) {
+          await queryRunner.rollbackTransaction();
+          this.logger.error(
+            'Error during archive deletion. Transaction rolled back.',
+            (error as Error).stack,
           );
-        } while (archivedEntriesBatch.length === batchSize);
+          throw error;
+        }
 
+        // Phase 2: orphan retry cleanup in independent per-batch transactions.
         // Retries have no FK to archived_notifications; prior deletion runs can
         // leave orphans that the batch loop above never reaches.
-        let orphanBatchCount: number;
+        let orphanBatchCount = 0;
 
         do {
-          const orphanIds = await queryRunner.manager
-            .createQueryBuilder(RetryNotification, 'r')
-            .select('r.id', 'id')
-            .where('r.created_on < :cutoff', { cutoff: cutoffTimestamp })
-            .andWhere(
-              `NOT EXISTS (
-                SELECT 1 FROM notify_archived_notifications a
-                WHERE a.notification_id = r.notification_id
-              )`,
-            )
-            .andWhere(
-              `NOT EXISTS (
-                SELECT 1 FROM notify_notifications n
-                WHERE n.id = r.notification_id
-              )`,
-            )
-            .limit(batchSize)
-            .getRawMany<{ id: number }>();
+          await queryRunner.startTransaction();
 
-          orphanBatchCount = orphanIds.length;
+          try {
+            const orphanIds = await queryRunner.manager
+              .createQueryBuilder(RetryNotification, 'r')
+              .select('r.id', 'id')
+              .where('r.created_on < :cutoff', { cutoff: cutoffTimestamp })
+              .andWhere(
+                `NOT EXISTS (
+                  SELECT 1 FROM notify_archived_notifications a
+                  WHERE a.notification_id = r.notification_id
+                )`,
+              )
+              .andWhere(
+                `NOT EXISTS (
+                  SELECT 1 FROM notify_notifications n
+                  WHERE n.id = r.notification_id
+                )`,
+              )
+              .limit(batchSize)
+              .getRawMany<{ id: number }>();
 
-          if (orphanBatchCount === 0) {
-            break;
+            orphanBatchCount = orphanIds.length;
+
+            if (orphanBatchCount === 0) {
+              await queryRunner.rollbackTransaction();
+              break;
+            }
+
+            await queryRunner.manager.delete(
+              RetryNotification,
+              orphanIds.map((r) => r.id),
+            );
+            totalDeletedRetries += orphanBatchCount;
+            await queryRunner.commitTransaction();
+            this.logger.debug(`Orphaned retry batch deleted: ${orphanBatchCount}`);
+          } catch (error) {
+            await queryRunner.rollbackTransaction();
+            this.logger.error(
+              'Error during orphan retry cleanup. Transaction rolled back.',
+              (error as Error).stack,
+            );
+            throw error;
           }
-
-          await queryRunner.manager.delete(
-            RetryNotification,
-            orphanIds.map((r) => r.id),
-          );
-          totalDeletedRetries += orphanBatchCount;
-
-          this.logger.debug(`Orphaned retry batch deleted: ${orphanBatchCount}`);
         } while (orphanBatchCount === batchSize);
-
-        await queryRunner.commitTransaction();
 
         this.logger.log(
           `Successfully deleted ${totalDeletedArchived} archived notifications and ${totalDeletedRetries} retry records older than ${cutoffTimestamp.toISOString()}`,
         );
-      } catch (error) {
-        await queryRunner.rollbackTransaction();
-        this.logger.error(
-          'Error during deletion. Transaction rolled back.',
-          (error as Error).stack,
-        );
-        throw error;
       } finally {
         await queryRunner.release();
       }

--- a/apps/api/src/modules/archived-notifications/archived-notifications.service.ts
+++ b/apps/api/src/modules/archived-notifications/archived-notifications.service.ts
@@ -352,6 +352,7 @@ export class ArchivedNotificationsService extends CoreService<ArchivedNotificati
         // partial failure rolls back all batches atomically. Trade-off: long
         // backlogs hold locks for the full run. Move commit inside the loop
         // (matching Phase 2) only if lock contention becomes a problem.
+        this.logger.log('Phase 1: deleting archived notifications');
         await queryRunner.startTransaction();
 
         try {
@@ -425,6 +426,7 @@ export class ArchivedNotificationsService extends CoreService<ArchivedNotificati
         // Phase 2: orphan retry cleanup in independent per-batch transactions.
         // Retries have no FK to archived_notifications; prior deletion runs can
         // leave orphans that the batch loop above never reaches.
+        this.logger.log('Phase 2: deleting orphaned retries');
         let orphanBatchCount = 0;
 
         do {

--- a/apps/api/src/modules/archived-notifications/archived-notifications.service.ts
+++ b/apps/api/src/modules/archived-notifications/archived-notifications.service.ts
@@ -12,7 +12,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { CoreService } from 'src/common/graphql/services/core.service';
 import { PaginationQueryDto } from 'src/common/dto/pagination-query.dto';
 import { PaginationMeta, PaginationHelper } from 'src/common/utils/pagination.helper';
-import ms = require('ms');
+import ms from 'ms';
 import { ArchivedNotificationResponseDto } from './dto/archived-notification-response.dto';
 import { ApplicationsService } from '../applications/applications.service';
 import { NotificationDataFilterHelper } from '../notifications/helpers/notification-data-filter.helper';
@@ -111,7 +111,7 @@ export class ArchivedNotificationsService extends CoreService<ArchivedNotificati
         await queryRunner.release();
       }
     } catch (error) {
-      this.logger.error(`Failed to archive notifications: ${error.message}`);
+      this.logger.error(`Failed to archive notifications: ${(error as Error).message}`);
       throw error;
     }
   }
@@ -122,7 +122,7 @@ export class ArchivedNotificationsService extends CoreService<ArchivedNotificati
       await this.moveCompletedNotificationsToArchiveTable();
       this.logger.log(`Archive notifications cron task completed`);
     } catch (error) {
-      this.logger.error(`Cron job failed: ${error.message}`, error.stack);
+      this.logger.error(`Cron job failed: ${(error as Error).message}`, (error as Error).stack);
       throw error;
     }
   }
@@ -309,7 +309,7 @@ export class ArchivedNotificationsService extends CoreService<ArchivedNotificati
         this.logger.log('Archived Notification Deletion Cron is disabled');
       }
     } catch (error) {
-      this.logger.error(`Cron job failed: ${error.message}`, error.stack);
+      this.logger.error(`Cron job failed: ${(error as Error).message}`, (error as Error).stack);
       throw error;
     }
   }
@@ -397,6 +397,23 @@ export class ArchivedNotificationsService extends CoreService<ArchivedNotificati
           );
         } while (archivedEntriesBatch.length === batchSize);
 
+        // Retries have no FK to archived_notifications; prior deletion runs leave orphans unreachable by the batch loop above
+        const orphanedRetryResult = await queryRunner.manager
+          .createQueryBuilder()
+          .delete()
+          .from(RetryNotification)
+          .where('created_on < :cutoff', { cutoff: cutoffTimestamp })
+          .andWhere(
+            'NOT EXISTS (SELECT 1 FROM notify_archived_notifications a WHERE a.notification_id = notify_notification_retries.notification_id)',
+          )
+          .execute();
+
+        const orphanedRetryAffected =
+          typeof orphanedRetryResult.affected === 'number' ? orphanedRetryResult.affected : 0;
+        totalDeletedRetries += orphanedRetryAffected;
+
+        this.logger.debug(`Orphaned retry records deleted: ${orphanedRetryAffected}`);
+
         await queryRunner.commitTransaction();
 
         this.logger.log(
@@ -404,13 +421,19 @@ export class ArchivedNotificationsService extends CoreService<ArchivedNotificati
         );
       } catch (error) {
         await queryRunner.rollbackTransaction();
-        this.logger.error('Error during deletion. Transaction rolled back.', error.stack);
+        this.logger.error(
+          'Error during deletion. Transaction rolled back.',
+          (error as Error).stack,
+        );
         throw error;
       } finally {
         await queryRunner.release();
       }
     } catch (error) {
-      this.logger.error(`Failed to delete archived notifications: ${error.message}`, error.stack);
+      this.logger.error(
+        `Failed to delete archived notifications: ${(error as Error).message}`,
+        (error as Error).stack,
+      );
       throw error;
     }
   }

--- a/apps/api/src/modules/archived-notifications/archived-notifications.service.ts
+++ b/apps/api/src/modules/archived-notifications/archived-notifications.service.ts
@@ -399,8 +399,6 @@ export class ArchivedNotificationsService extends CoreService<ArchivedNotificati
 
         // Retries have no FK to archived_notifications; prior deletion runs can
         // leave orphans that the batch loop above never reaches.
-        // TODO: also exclude retries whose notification_id still exists in notify_notifications
-        // (live notifications not yet archived) to avoid premature deletion
         let orphanBatchCount: number;
 
         do {
@@ -409,9 +407,16 @@ export class ArchivedNotificationsService extends CoreService<ArchivedNotificati
             .select('r.id', 'id')
             .where('r.created_on < :cutoff', { cutoff: cutoffTimestamp })
             .andWhere(
-              'NOT EXISTS (' +
-                'SELECT 1 FROM notify_archived_notifications a ' +
-                'WHERE a.notification_id = r.notification_id)',
+              `NOT EXISTS (
+                SELECT 1 FROM notify_archived_notifications a
+                WHERE a.notification_id = r.notification_id
+              )`,
+            )
+            .andWhere(
+              `NOT EXISTS (
+                SELECT 1 FROM notify_notifications n
+                WHERE n.id = r.notification_id
+              )`,
             )
             .limit(batchSize)
             .getRawMany<{ id: number }>();

--- a/apps/api/src/modules/archived-notifications/archived-notifications.service.ts
+++ b/apps/api/src/modules/archived-notifications/archived-notifications.service.ts
@@ -348,7 +348,10 @@ export class ArchivedNotificationsService extends CoreService<ArchivedNotificati
       await queryRunner.connect();
 
       try {
-        // Phase 1: archive deletion in a single transaction
+        // Phase 1: archive deletion wrapped in a single transaction so a
+        // partial failure rolls back all batches atomically. Trade-off: long
+        // backlogs hold locks for the full run. Move commit inside the loop
+        // (matching Phase 2) only if lock contention becomes a problem.
         await queryRunner.startTransaction();
 
         try {
@@ -367,8 +370,16 @@ export class ArchivedNotificationsService extends CoreService<ArchivedNotificati
               take: batchSize,
             });
 
+            const firstRecord =
+              archivedEntriesBatch.length > 0
+                ? JSON.stringify({
+                    id: archivedEntriesBatch[0].id,
+                    notificationId: archivedEntriesBatch[0].notificationId,
+                    createdOn: archivedEntriesBatch[0].createdOn,
+                  })
+                : 'None';
             this.logger.debug(
-              `Query found ${archivedEntriesBatch.length} records. First record: ${archivedEntriesBatch.length > 0 ? JSON.stringify({ id: archivedEntriesBatch[0].id, notificationId: archivedEntriesBatch[0].notificationId, createdOn: archivedEntriesBatch[0].createdOn }) : 'None'}`,
+              `Query found ${archivedEntriesBatch.length} records. First record: ${firstRecord}`,
             );
 
             if (archivedEntriesBatch.length === 0) {
@@ -396,7 +407,8 @@ export class ArchivedNotificationsService extends CoreService<ArchivedNotificati
             totalDeletedArchived += archivedEntriesBatch.length;
 
             this.logger.debug(
-              `Batch processed: ${archivedEntriesBatch.length} archived notifications, ${retryAffected} retry records deleted`,
+              `Batch processed: ${archivedEntriesBatch.length} archived notifications, ` +
+                `${retryAffected} retry records deleted`,
             );
           } while (archivedEntriesBatch.length === batchSize);
 

--- a/apps/api/src/modules/notifications/entities/retry-notification.entity.ts
+++ b/apps/api/src/modules/notifications/entities/retry-notification.entity.ts
@@ -12,6 +12,7 @@ import { Notification } from './notification.entity';
 
 @Entity('notify_notification_retries')
 @Index('IDX_notify_notification_retries_notification_id', ['notification_id'])
+@Index('IDX_notify_notification_retries_created_on', ['createdOn'])
 export class RetryNotification {
   @PrimaryGeneratedColumn()
   id: number;


### PR DESCRIPTION
## Task Link

https://pinestem.com/dashboard.html#/tasks/REST-2370/details/?companyId=453&isPrevNext=1

### Pre-requisites

- [x] I have gone through the Contributing guidelines for [Submitting a Pull Request (PR)](https://github.com/OsmosysSoftware/osmo-x/blob/main/CONTRIBUTING.md#-submitting-a-pull-request-pr) and ensured that this is not a duplicate PR.
- [x] I have performed unit testing for the new feature added or updated to ensure the new features added are working as expected.
- [ ] I have added/updated test cases to the [test suite](https://github.com/OsmosysSoftware/osmo-x/blob/main/apps/api/OsmoX.postman_collection.json) as applicable.
- [ ] I have performed preliminary testing using the [test suite](https://github.com/OsmosysSoftware/osmo-x/blob/main/apps/api/OsmoX.postman_collection.json) to ensure that any existing features are not impacted and any new features are working as expected as a whole.
- [ ] I have added/updated the required [api docs](https://github.com/OsmosysSoftware/osmo-x/tree/main/apps/api/docs) as applicable.
- [ ] I have added/updated the `.env.example` file with the required values as applicable.

### PR Details

PR details have been updated as per the given format (see below)

- [x] PR title adheres to the format specified in guidelines (e.g., `feat: add admin login endpoint`)
- [x] Description has been added
- [ ] Related changes have been added (optional)
- [ ] Screenshots have been added (optional)
- [ ] Query request and response examples have been added (as applicable, in case added or updated)
- [ ] Documentation changes have been listed (as applicable)
- [ ] Test suite/unit testing output is added (as applicable)
- [ ] Pending actions have been added (optional)
- [ ] Any other additional notes have been added (optional)

### Additional Information

- [x] Appropriate label(s) have been added (`ready for review` should be added if the PR is ready to be reviewed)
- [x] Assignee(s) and reviewer(s) have been added (optional)

_Note: Reviewer should ensure that the checklist and description have been populated and followed correctly, and the PR should be merged only after resolving all conversations and verifying that CI checks pass._

---

**Description:**

- Retry records have no FK to notify_archived_notifications (the FK was removed), so records whose archived counterpart was already deleted in a prior deletion run become permanent orphans unreachable by the existing batch loop.
- Adds a second DELETE pass after the main loop that removes retry records older than the retention cutoff that have no matching notification_id in notify_archived_notifications.
- Also fixes pre-existing TypeScript errors: error in catch blocks typed as unknown required (error as Error) casts, and converts the ms require() import to a default import.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retention cleanup for archived notifications by also removing orphaned retry records that no longer map to any notification.
  * Refined archival/deletion job error logging to provide clearer message and stack details.
* **Performance**
  * Added an index on retry-notification creation time to speed up retention cleanup queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->