### PR TITLE
fix: prevent docker from auto-creating portal runtime-config as root

### DIFF
--- a/apps/portal/.env.example
+++ b/apps/portal/.env.example
@@ -4,7 +4,6 @@ SERVER_PORT=4200
 # Portal runtime config (apiUrl, apiDocsUrl) is NOT set here.
 # It lives in ./runtime-config/config.json — see runtime-config.example.json.
 # First-time setup:
-#   mkdir -p runtime-config
 #   cp runtime-config.example.json runtime-config/config.json
 #   docker compose up -d --build
 # Day-to-day: edit runtime-config/config.json on the host, refresh the browser.

--- a/apps/portal/.gitignore
+++ b/apps/portal/.gitignore
@@ -45,4 +45,7 @@ Thumbs.db
 
 # Host-managed runtime config (only used when SKIP_RUNTIME_CONFIG_GENERATION=true
 # in docker-compose.yml). See runtime-config.example.json for the template.
-runtime-config/
+# The directory is tracked via .gitkeep so Docker doesn't auto-create it as root
+# when the bind mount initializes.
+runtime-config/*
+!runtime-config/.gitkeep

--- a/apps/portal/CLAUDE.md
+++ b/apps/portal/CLAUDE.md
@@ -295,7 +295,6 @@ There is no `environment.ts` file — those were removed and `fileReplacements` 
    ```bash
    cd apps/portal
    cp .env.example .env
-   mkdir -p runtime-config
    cp runtime-config.example.json runtime-config/config.json
    docker compose up -d --build
    ```

--- a/apps/portal/docker-entrypoint.sh
+++ b/apps/portal/docker-entrypoint.sh
@@ -14,7 +14,6 @@ if [ ! -f "$CONFIG_PATH" ]; then
   echo "ERROR: $CONFIG_PATH is missing." >&2
   echo "" >&2
   echo "First-time setup (run from apps/portal/):" >&2
-  echo "  mkdir -p runtime-config" >&2
   echo "  cp runtime-config.example.json runtime-config/config.json" >&2
   echo "" >&2
   echo "Then re-run: docker compose up -d" >&2


### PR DESCRIPTION
## Portal PR Checklist

### Task Link

_No Pinestem task — fix discovered while bringing the portal up on the R&D server (`docker-user` could not write `config.json` into the auto-created bind-mount source)._

### Pre-requisites

- [x] I have gone through the Contributing guidelines for [Submitting a Pull Request (PR)](https://github.com/OsmosysSoftware/osmo-x/blob/main/CONTRIBUTING.md#-submitting-a-pull-request-pr) and ensured that this is not a duplicate PR.
- [x] I have performed preliminary testing to ensure that any existing features are not impacted and any new features are working as expected as a whole.

### PR Details

- [x] PR title adheres to the conventional-commits format
- [x] Description has been added
- [x] Related changes have been added
- [ ] Screenshots have been added — N/A, no UI changes
- [x] Pending actions have been added
- [x] Additional notes have been added

### Additional Information

- [ ] Appropriate label(s) to be added by maintainer
- [ ] Assignee(s) and reviewer(s) to be added by maintainer

---

**Description:**

When `docker compose up` runs on a host where `apps/portal/runtime-config/` does not yet exist, the Docker daemon auto-creates the bind-mount source directory as `root:root`. The deploy user (which owns the rest of the checkout) then cannot `cp runtime-config.example.json runtime-config/config.json` without `sudo` — which on shared servers without sudo access (e.g. our R&D box, where `docker-user` has no sudoers entry) bricks first-time setup. The user is left chowning the directory through a throwaway root container as a workaround.

This PR tracks `apps/portal/runtime-config/` in git via an empty `.gitkeep`, so the directory exists at clone time with the cloning user's ownership. Docker uses the existing directory rather than auto-creating it, and the trap disappears for every future deploy. The now-redundant `mkdir -p runtime-config` step is dropped from the three places it was referenced (env example, CLAUDE.md, and the entrypoint's error message).

**Related changes:**

- `apps/portal/.gitignore` — switched `runtime-config/` to `runtime-config/*` + `!runtime-config/.gitkeep`, so the directory is tracked but `config.json` (and anything else inside) stays ignored.
- `apps/portal/runtime-config/.gitkeep` — empty marker file to make git track the directory.
- `apps/portal/.env.example` — removed stale `mkdir -p runtime-config` line from the setup comment block.
- `apps/portal/CLAUDE.md` — removed `mkdir -p runtime-config` from the documented first-time-setup workflow.
- `apps/portal/docker-entrypoint.sh` — removed `mkdir -p runtime-config` from the error message printed when `runtime-config/config.json` is missing.

**Screenshots:**

N/A — config / docs / gitignore only, no UI changes.

**Pending actions:**

- _On existing deploys where the root-owned directory has already been auto-created (e.g. R&D server):_ chown it back to the deploy user via a throwaway root container, no sudo needed:
  ```bash
  cd apps/portal
  docker run --rm -v "$(pwd)/runtime-config:/target" alpine \
    chown -R "$(id -u):$(id -g)" /target
  ```
  Fresh clones after this PR merges do not need this step.

**Additional notes:**

- The bind mount remains a **directory** mount (not a file mount) per the existing rationale in `CLAUDE.md` (atomic-write safety from editors). Runtime behavior is unchanged.
- Spotted a separate issue while committing this: `.husky/pre-commit` is not marked executable on at least one developer machine, so `npx lint-staged` is being silently skipped on commits. This PR's diff has no `.ts` files so the skip is harmless here, but it is worth a follow-up commit (`chmod +x .husky/pre-commit` + a one-line tracking change) to make sure future TS commits actually run lint-staged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the container startup error message when the required runtime config is missing, including clearer “copy the example config” guidance and the next command to run.
  * Updated repository ignore rules so the runtime-config directory is handled correctly while keeping the placeholder file tracked.
* **Documentation**
  * Simplified first-time setup instructions by removing the unnecessary directory-creation step, while keeping the remaining configuration and startup steps unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->