### PR TITLE
feat: remove non-whitelisted recipients from email provider request body

### DIFF
--- a/apps/api/src/common/constants/notifications.ts
+++ b/apps/api/src/common/constants/notifications.ts
@@ -82,9 +82,3 @@ export const RecipientKeyForChannelType = {
 };
 
 export const AllRecipientsWhitelistedExpression = '*';
-
-export const ChannelTypesThatUseEmailProviderType = [
-  ChannelType.SMTP,
-  ChannelType.MAILGUN,
-  ChannelType.AWS_SES,
-];

--- a/apps/api/src/common/constants/notifications.ts
+++ b/apps/api/src/common/constants/notifications.ts
@@ -82,3 +82,9 @@ export const RecipientKeyForChannelType = {
 };
 
 export const AllRecipientsWhitelistedExpression = '*';
+
+export const ChannelTypesThatUseEmailProviderType = [
+  ChannelType.SMTP,
+  ChannelType.MAILGUN,
+  ChannelType.AWS_SES,
+];

--- a/apps/api/src/modules/notifications/notifications.service.ts
+++ b/apps/api/src/modules/notifications/notifications.service.ts
@@ -14,6 +14,7 @@ import {
   QueueAction,
   RecipientKeyForChannelType,
   AllRecipientsWhitelistedExpression,
+  ChannelTypesThatUseEmailProviderType,
 } from 'src/common/constants/notifications';
 import { NotificationQueueProducer } from 'src/jobs/producers/notifications/notifications.job.producer';
 import { IsEnabledStatus, Status } from 'src/common/constants/database';
@@ -168,6 +169,11 @@ export class NotificationsService extends CoreService<Notification> {
         notification.result = TEST_MODE_RESULT_JSON;
       } else {
         this.logger.log('Recipient is whitelisted. Notification will be prepared for processing.');
+        const cleanedNotificationData = await this.keepOnlyWhitelistedRecipients(
+          notification,
+          applicationEntry,
+        );
+        notification.data = cleanedNotificationData;
       }
     }
 
@@ -331,6 +337,96 @@ export class NotificationsService extends CoreService<Notification> {
       this.logger.log(`Error checking if recipient is whitelisted: ${error.message}`);
       throw error;
     }
+  }
+
+  async keepOnlyWhitelistedRecipients(
+    notificationEntry: Notification,
+    applicationEntry: Application,
+  ): Promise<Record<string, unknown>> {
+    try {
+      const { channelType, providerId, data } = notificationEntry;
+
+      // 1. Only process if the channelType uses email provider logic
+      if (!ChannelTypesThatUseEmailProviderType.includes(channelType)) {
+        return data;
+      }
+
+      // 2. Extract and normalize whitelist values for the current provider
+      const whitelistRecipientValues =
+        applicationEntry.whitelistRecipients?.[providerId.toString()] || [];
+
+      const normalizedWhitelistRecipientValues = (whitelistRecipientValues as unknown[]).map(
+        (val) => (typeof val === 'string' ? val.toLowerCase().trim() : val),
+      );
+
+      // 3. Bypass check: If wildcard rule exists, return object as-is
+      if (
+        normalizedWhitelistRecipientValues.length === 1 &&
+        normalizedWhitelistRecipientValues[0] === AllRecipientsWhitelistedExpression
+      ) {
+        return data;
+      }
+
+      // Build a Set for O(1) lowercase lookups
+      const whitelistSet = new Set<string>(
+        normalizedWhitelistRecipientValues
+          .filter((val): val is string => typeof val === 'string')
+          .map((val) => val.toLowerCase().trim()),
+      );
+
+      const updatedData: Record<string, unknown> = { ...data };
+      const emailFields = [RecipientKeyForChannelType[notificationEntry.channelType], 'cc', 'bcc'];
+
+      // 4. Process each email field if present in payload
+      for (const field of emailFields) {
+        if (field in updatedData && updatedData[field] != null) {
+          updatedData[field] = this.filterRecipients(updatedData[field], whitelistSet);
+        }
+      }
+
+      this.logger.log(
+        `Updated notification data. Removed all non-whitelisted recipients from the request.`,
+      );
+
+      return updatedData;
+    } catch (error) {
+      this.logger.log(
+        `Error while keeping only whitelisted recipients in notification: ${(error as Error).message}`,
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Filters recipient inputs against a whitelist set.
+   * Handles:
+   *  - Simple string: "user@domain.com"
+   *  - Comma-separated string: "user1@domain.com, user2@domain.com"
+   *  - Array of strings: ["user1@domain.com", "user2@domain.com"] (including mixed comma-separated items)
+   */
+  private filterRecipients(rawRecipients: unknown, whitelistSet: Set<string>): string | string[] {
+    const isStringInput = typeof rawRecipients === 'string';
+    let parsedRecipients: string[] = [];
+
+    if (typeof rawRecipients === 'string') {
+      // Handles single string and comma-separated string
+      parsedRecipients = rawRecipients.split(',').map((r) => r.trim());
+    } else if (Array.isArray(rawRecipients)) {
+      // Handles array of strings (and flattens any comma-separated strings inside array elements)
+      parsedRecipients = rawRecipients.flatMap((item) =>
+        typeof item === 'string' ? item.split(',').map((r) => r.trim()) : [String(item).trim()],
+      );
+    } else if (rawRecipients != null) {
+      parsedRecipients = [String(rawRecipients).trim()];
+    }
+
+    // Filter out empty strings and non-whitelisted recipients
+    const filtered = parsedRecipients.filter(
+      (recipient) => recipient.length > 0 && whitelistSet.has(recipient.toLowerCase()),
+    );
+
+    // Maintain original type structure
+    return isStringInput ? filtered.join(', ') : filtered;
   }
 
   async addNotificationsToQueue(): Promise<void> {

--- a/apps/api/src/modules/notifications/notifications.service.ts
+++ b/apps/api/src/modules/notifications/notifications.service.ts
@@ -287,18 +287,7 @@ export class NotificationsService extends CoreService<Notification> {
 
           // Create a list of recipient(s) added in request body
           const notificationRecipientRaw = notificationEntry.data[ChannelTypeRecipientKey];
-          const notificationRecipientsArray =
-            typeof notificationRecipientRaw === 'string'
-              ? notificationRecipientRaw.split(',').map((recipient) => recipient.trim())
-              : Array.isArray(notificationRecipientRaw)
-                ? notificationRecipientRaw.flatMap((item) =>
-                    typeof item === 'string'
-                      ? item.split(',').map((recipient) => recipient.trim())
-                      : [String(item).trim()],
-                  )
-                : notificationRecipientRaw != null
-                  ? [String(notificationRecipientRaw).trim()]
-                  : [];
+          const notificationRecipientsArray = this.parseRawRecipients(notificationRecipientRaw);
           this.logger.debug(`Notification recipient list: ${notificationRecipientsArray}`);
 
           // Confirm if a whitelisted recipient is in request body (Case insensitive)
@@ -344,6 +333,34 @@ export class NotificationsService extends CoreService<Notification> {
       this.logger.log(`Error checking if recipient is whitelisted: ${(error as Error).message}`);
       throw error;
     }
+  }
+
+  /**
+   * Recursively parses and flattens recipient inputs (strings, arrays, scalars) into clean string arrays.
+   * Safely drops nullish entries (null, undefined) BEFORE string coercion.
+   */
+  private parseRawRecipients(raw: unknown): string[] {
+    // 1. Drop null & undefined values strictly before any processing
+    if (raw === null || raw === undefined) {
+      return [];
+    }
+
+    // 2. Handle string & comma-separated string inputs
+    if (typeof raw === 'string') {
+      return raw
+        .split(',')
+        .map((item) => item.trim())
+        .filter((item) => item.length > 0);
+    }
+
+    // 3. Handle arrays recursively (flattens nested arrays & comma-separated entries)
+    if (Array.isArray(raw)) {
+      return raw.flatMap((item) => this.parseRawRecipients(item));
+    }
+
+    // 4. Handle remaining non-nullish scalar values (e.g. numbers)
+    const trimmed = String(raw).trim();
+    return trimmed.length > 0 ? [trimmed] : [];
   }
 
   /**

--- a/apps/api/src/modules/notifications/notifications.service.ts
+++ b/apps/api/src/modules/notifications/notifications.service.ts
@@ -14,7 +14,7 @@ import {
   QueueAction,
   RecipientKeyForChannelType,
   AllRecipientsWhitelistedExpression,
-  ChannelTypesThatUseEmailProviderType,
+  ChannelType,
 } from 'src/common/constants/notifications';
 import { NotificationQueueProducer } from 'src/jobs/producers/notifications/notifications.job.producer';
 import { IsEnabledStatus, Status } from 'src/common/constants/database';
@@ -339,19 +339,17 @@ export class NotificationsService extends CoreService<Notification> {
     }
   }
 
+  /**
+   * Filters recipients in notification data based on channelType and application whitelist configuration.
+   */
   async keepOnlyWhitelistedRecipients(
     notificationEntry: Notification,
     applicationEntry: Application,
   ): Promise<Record<string, unknown>> {
     try {
-      const { channelType, providerId, data } = notificationEntry;
+      const { channelType: inputChannelType, providerId, data } = notificationEntry;
 
-      // 1. Only process if the channelType uses email provider logic
-      if (!ChannelTypesThatUseEmailProviderType.includes(channelType)) {
-        return data;
-      }
-
-      // 2. Extract and normalize whitelist values for the current provider
+      // 1. Extract whitelist values for current providerId
       const whitelistRecipientValues =
         applicationEntry.whitelistRecipients?.[providerId.toString()] || [];
 
@@ -359,7 +357,7 @@ export class NotificationsService extends CoreService<Notification> {
         (val) => (typeof val === 'string' ? val.toLowerCase().trim() : val),
       );
 
-      // 3. Bypass check: If wildcard rule exists, return object as-is
+      // 2. Wildcard check: If wildcard rule exists, return payload unmodified
       if (
         normalizedWhitelistRecipientValues.length === 1 &&
         normalizedWhitelistRecipientValues[0] === AllRecipientsWhitelistedExpression
@@ -367,20 +365,40 @@ export class NotificationsService extends CoreService<Notification> {
         return data;
       }
 
-      // Build a Set for O(1) lowercase lookups
+      // Build Set for O(1) case-insensitive lookups
       const whitelistSet = new Set<string>(
         normalizedWhitelistRecipientValues
           .filter((val): val is string => typeof val === 'string')
           .map((val) => val.toLowerCase().trim()),
       );
 
-      const updatedData: Record<string, unknown> = { ...data };
-      const emailFields = [RecipientKeyForChannelType[notificationEntry.channelType], 'cc', 'bcc'];
+      // 3. Directly assign target recipient fields based on channelType
+      let recipientKeys: string[] = [];
 
-      // 4. Process each email field if present in payload
-      for (const field of emailFields) {
-        if (field in updatedData && updatedData[field] != null) {
-          updatedData[field] = this.filterRecipients(updatedData[field], whitelistSet);
+      switch (inputChannelType) {
+        // Channel types that process email
+        case ChannelType.SMTP:
+        case ChannelType.MAILGUN:
+        case ChannelType.AWS_SES:
+          recipientKeys = [RecipientKeyForChannelType[inputChannelType], 'cc', 'bcc'];
+          break;
+
+        // Add future channel type mappings here as needed
+
+        default:
+          // Passthrough for unhandled channel types
+          this.logger.debug(
+            `Unhandled channelType [${inputChannelType}]. Passthrough mode activated.`,
+          );
+          return data;
+      }
+
+      // 4. Update payload fields with whitelisted recipients
+      const updatedData: Record<string, unknown> = { ...data };
+
+      for (const key of recipientKeys) {
+        if (key in updatedData && updatedData[key] != null) {
+          updatedData[key] = this.filterRecipients(updatedData[key], whitelistSet);
         }
       }
 

--- a/apps/api/src/modules/notifications/notifications.service.ts
+++ b/apps/api/src/modules/notifications/notifications.service.ts
@@ -291,8 +291,14 @@ export class NotificationsService extends CoreService<Notification> {
             typeof notificationRecipientRaw === 'string'
               ? notificationRecipientRaw.split(',').map((recipient) => recipient.trim())
               : Array.isArray(notificationRecipientRaw)
-                ? notificationRecipientRaw
-                : [notificationRecipientRaw];
+                ? notificationRecipientRaw.flatMap((item) =>
+                    typeof item === 'string'
+                      ? item.split(',').map((recipient) => recipient.trim())
+                      : [String(item).trim()],
+                  )
+                : notificationRecipientRaw != null
+                  ? [String(notificationRecipientRaw).trim()]
+                  : [];
           this.logger.debug(`Notification recipient list: ${notificationRecipientsArray}`);
 
           // Confirm if a whitelisted recipient is in request body (Case insensitive)
@@ -324,8 +330,9 @@ export class NotificationsService extends CoreService<Notification> {
             return true;
           }
 
-          const exists = normalizedWhitelistRecipientValues.some((item) =>
-            normalizeNotificationRecipientsArray.includes(item),
+          const exists = normalizedWhitelistRecipientValues.some(
+            (item) =>
+              typeof item === 'string' && normalizeNotificationRecipientsArray.includes(item),
           );
           return exists;
         }
@@ -334,7 +341,7 @@ export class NotificationsService extends CoreService<Notification> {
       this.logger.debug('Notification provider does not have whitelisted recipient(s)');
       return false;
     } catch (error) {
-      this.logger.log(`Error checking if recipient is whitelisted: ${error.message}`);
+      this.logger.log(`Error checking if recipient is whitelisted: ${(error as Error).message}`);
       throw error;
     }
   }

--- a/apps/api/src/modules/notifications/notifications.service.ts
+++ b/apps/api/src/modules/notifications/notifications.service.ts
@@ -264,15 +264,12 @@ export class NotificationsService extends CoreService<Notification> {
     applicationEntry: Application,
   ): Promise<boolean> {
     try {
-      if (
-        applicationEntry.whitelistRecipients &&
-        applicationEntry.whitelistRecipients[notificationEntry.providerId.toString()]
-      ) {
-        this.logger.debug(`Whitelist exists for provider ${notificationEntry.providerId}`);
+      const providerIdStr = notificationEntry.providerId.toString();
+      // Fetch whitelist whitelist recipients from db
+      const whitelistRecipientValues = applicationEntry.whitelistRecipients?.[providerIdStr];
 
-        // Fetch whitelist whitelist recipients from db
-        const whitelistRecipientValues =
-          applicationEntry.whitelistRecipients[notificationEntry.providerId.toString()];
+      if (whitelistRecipientValues) {
+        this.logger.debug(`Whitelist exists for provider ${notificationEntry.providerId}`);
         this.logger.debug(
           `Whitelist recipient values: ${JSON.stringify(whitelistRecipientValues)}`,
         );
@@ -291,16 +288,16 @@ export class NotificationsService extends CoreService<Notification> {
           this.logger.debug(`Notification recipient list: ${notificationRecipientsArray}`);
 
           // Confirm if a whitelisted recipient is in request body (Case insensitive)
-          const normalizedWhitelistRecipientValues = (whitelistRecipientValues as unknown[]).map(
-            (val) => (typeof val === 'string' ? val.toLowerCase().trim() : val),
-          );
+          const normalizedWhitelistRecipientValues = this.parseRawRecipients(
+            whitelistRecipientValues,
+          ).map((val) => val.toLowerCase());
 
           this.logger.debug(
             `Normalized whitelist recipient values: ${JSON.stringify(normalizedWhitelistRecipientValues)}`,
           );
 
           const normalizeNotificationRecipientsArray = notificationRecipientsArray.map((val) =>
-            typeof val === 'string' ? val.toLowerCase().trim() : val,
+            val.toLowerCase(),
           );
 
           this.logger.debug(
@@ -319,11 +316,9 @@ export class NotificationsService extends CoreService<Notification> {
             return true;
           }
 
-          const exists = normalizedWhitelistRecipientValues.some(
-            (item) =>
-              typeof item === 'string' && normalizeNotificationRecipientsArray.includes(item),
+          return normalizedWhitelistRecipientValues.some((item) =>
+            normalizeNotificationRecipientsArray.includes(item),
           );
-          return exists;
         }
       }
 
@@ -373,13 +368,13 @@ export class NotificationsService extends CoreService<Notification> {
     try {
       const { channelType: inputChannelType, providerId, data } = notificationEntry;
 
-      // 1. Extract whitelist values for current providerId
+      // 1. Extract & normalize whitelist values using parseRawRecipients
       const whitelistRecipientValues =
-        applicationEntry.whitelistRecipients?.[providerId.toString()] || [];
+        applicationEntry.whitelistRecipients?.[providerId.toString()];
 
-      const normalizedWhitelistRecipientValues = (whitelistRecipientValues as unknown[]).map(
-        (val) => (typeof val === 'string' ? val.toLowerCase().trim() : val),
-      );
+      const normalizedWhitelistRecipientValues = this.parseRawRecipients(
+        whitelistRecipientValues,
+      ).map((val) => val.toLowerCase());
 
       // 2. Wildcard check: If wildcard rule exists, return payload unmodified
       if (
@@ -389,12 +384,8 @@ export class NotificationsService extends CoreService<Notification> {
         return data;
       }
 
-      // Build Set for O(1) case-insensitive lookups
-      const whitelistSet = new Set<string>(
-        normalizedWhitelistRecipientValues
-          .filter((val): val is string => typeof val === 'string')
-          .map((val) => val.toLowerCase().trim()),
-      );
+      // Build Set for O(1) case-insensitive lookups directly from normalized string[]
+      const whitelistSet = new Set<string>(normalizedWhitelistRecipientValues);
 
       // 3. Directly assign target recipient fields based on channelType
       let recipientKeys: string[] = [];
@@ -448,23 +439,12 @@ export class NotificationsService extends CoreService<Notification> {
    */
   private filterRecipients(rawRecipients: unknown, whitelistSet: Set<string>): string | string[] {
     const isStringInput = typeof rawRecipients === 'string';
-    let parsedRecipients: string[] = [];
 
-    if (typeof rawRecipients === 'string') {
-      // Handles single string and comma-separated string
-      parsedRecipients = rawRecipients.split(',').map((r) => r.trim());
-    } else if (Array.isArray(rawRecipients)) {
-      // Handles array of strings (and flattens any comma-separated strings inside array elements)
-      parsedRecipients = rawRecipients.flatMap((item) =>
-        typeof item === 'string' ? item.split(',').map((r) => r.trim()) : [String(item).trim()],
-      );
-    } else if (rawRecipients != null) {
-      parsedRecipients = [String(rawRecipients).trim()];
-    }
+    const parsedRecipients = this.parseRawRecipients(rawRecipients);
 
-    // Filter out empty strings and non-whitelisted recipients
-    const filtered = parsedRecipients.filter(
-      (recipient) => recipient.length > 0 && whitelistSet.has(recipient.toLowerCase()),
+    // Filter out non-whitelisted recipients
+    const filtered = parsedRecipients.filter((recipient) =>
+      whitelistSet.has(recipient.toLowerCase()),
     );
 
     // Maintain original type structure

--- a/apps/api/src/modules/notifications/notifications.service.ts
+++ b/apps/api/src/modules/notifications/notifications.service.ts
@@ -303,7 +303,7 @@ export class NotificationsService extends CoreService<Notification> {
 
           // Confirm if a whitelisted recipient is in request body (Case insensitive)
           const normalizedWhitelistRecipientValues = (whitelistRecipientValues as unknown[]).map(
-            (val) => (typeof val === 'string' ? val.toLowerCase() : val),
+            (val) => (typeof val === 'string' ? val.toLowerCase().trim() : val),
           );
 
           this.logger.debug(
@@ -311,7 +311,7 @@ export class NotificationsService extends CoreService<Notification> {
           );
 
           const normalizeNotificationRecipientsArray = notificationRecipientsArray.map((val) =>
-            typeof val === 'string' ? val.toLowerCase() : val,
+            typeof val === 'string' ? val.toLowerCase().trim() : val,
           );
 
           this.logger.debug(


### PR DESCRIPTION
## API PR Checklist

### Task Link

Osmosys Developers must include the Pinestem task link in the PR.

[OSXT-2142](https://pinestem.com/dashboard.html#/tasks/REST-2412/details/?companyId=453&isPrevNext=1)

### Pre-requisites

- [x] I have gone through the Contributing guidelines for [Submitting a Pull Request (PR)](https://github.com/OsmosysSoftware/osmo-x/blob/main/CONTRIBUTING.md#-submitting-a-pull-request-pr) and ensured that this is not a duplicate PR.
- [x] I have performed unit testing for the new feature added or updated to ensure the new features added are working as expected.
- [ ] I have added/updated test cases to the [test suite](https://github.com/OsmosysSoftware/osmo-x/blob/main/apps/api/OsmoX.postman_collection.json) as applicable.
- [ ] I have performed preliminary testing using the [test suite](https://github.com/OsmosysSoftware/osmo-x/blob/main/apps/api/OsmoX.postman_collection.json) to ensure that any existing features are not impacted and any new features are working as expected as a whole.
- [ ] I have added/updated the required [api docs](https://github.com/OsmosysSoftware/osmo-x/tree/main/apps/api/docs) as applicable.
- [ ] I have added/updated the `.env.example` file with the required values as applicable.

### PR Details

PR details have been updated as per the given format (see below)

- [x] PR title adheres to the format specified in guidelines (e.g., `feat: add admin login endpoint`)
- [x] Description has been added
- [x] Related changes have been added (optional)
- [x] Screenshots have been added (optional)
- [x] Query request and response examples have been added (as applicable, in case added or updated)
- [ ] Documentation changes have been listed (as applicable)
- [x] Test suite/unit testing output is added (as applicable)
- [x] Pending actions have been added (optional)
- [x] Any other additional notes have been added (optional)

### Additional Information

- [x] Appropriate label(s) have been added (`ready for review` should be added if the PR is ready to be reviewed)
- [x] Assignee(s) and reviewer(s) have been added (optional)

_Note: Reviewer should ensure that the checklist and description have been populated and followed correctly, and the PR should be merged only after resolving all conversations and verifying that CI checks pass._

---

**Description:**

Remove non-whitelisted recipients from email provider request body
Add switch case to simplify adding more channel types for whitelist verification

**Related changes:**

1. Control Flow & Strategy
* **Wildcard Short-Circuit:** Immediately returns the original `data` unmodified if the provider's whitelist contains `AllRecipientsWhitelistedExpression` (`*`).
* **Dynamic Recipient Mapping:** Routes on `inputChannelType` using `ChannelType` enums and resolves primary target fields via `RecipientKeyForChannelType`, adding standard email fields (`cc`, `bcc`).
* **Fail-Open Passthrough (`default` case):** Logs a `debug` message for unhandled channel types and returns `data` untouched (`return data;`), preventing system blockages for unmapped channels.
* **Immutability:** Operates on a shallow copy (`{ ...data }`) to ensure incoming request payload references are not directly mutated.

2. Efficiency & Data Normalization
* **$O(1)$ Lookup Performance:** Converts raw whitelist entries into a `Set<string>` of lowercased, trimmed values for instant, case-insensitive evaluation.
* **Format Preservation:** The output type matches the input type per field—returning clean comma-separated strings for string inputs, and clean arrays for array inputs.

3. Recipient Parsing & Sanitization (`filterRecipients`)
* **Multi-Format Support:** Correctly processes:
  * Single email strings (`"user@domain.com"`)
  * Comma-separated strings (`"user1@domain.com, user2@domain.com"`)
  * String arrays (`["user1@domain.com", "user2@domain.com"]`)
* **Flattening & Cleaning:** Uses `flatMap` on array inputs to handle nested comma-separated string elements, trimming whitespace and ignoring blank entries from duplicate or trailing commas.

---

FIX BUG: code does not split comma separated recipients from an array element

Use flatMap() to unpack and split any comma-separated strings inside array elements
Now if a user has whitelisted email say "abc@org.com" and tries to pass request

```json
{
  "to": [
    "abc@org.com, def@org.com",
    "ghi@org.com"
  ]
}
```

The code will still consider that the request contains a whitelisted recipient and process accordingly

---

REFACTOR

Create new data parser that returns a string array. Refactor the code and reuse the parser to avoid repeating of code

**Pending actions:**

I checked the code and dtos for rest of the channel types and these are the channel types that do not have a max length set, so these can use comma separated numbers as recipient- though I have not yet tested it

- WaTwilioDataDto
- WaTwilioBusinessDataDto
- PushSnsDataDto
- VcTwilioDataDto

**Additional notes:**

- Deployed on DEV server
- Known limitation or whitelisted recipients is that it does not work with provider chains as provider chains feature itself is in progress.
- This PR will therefore also face same issues that provider chain requests had faced with whitelists.

**Test cases:**

https://pinestem.com/dashboard.html#/tasks/REST-2412/details/?companyId=453&isPrevNext=1&cmntID=1228879

**Screenshots:**

Only one recipient
<img width="758" height="383" alt="image" src="https://github.com/user-attachments/assets/a67d91eb-2618-4c26-8155-7e41a81d0941" />

**Query request and response:**

1. Mailgun
```curl
curl --request POST \
  --url http://localhost:3300/notifications \
  --header 'content-type: application/json' \
  --header 'x-api-key: my-secret-key' \
  --data '{
  // Assuming providerId 34 is part of test mode and has whitelisted email whitelisted.user@osmosys.co
  "providerId": 34,
  "data": {
    "cc": "nonwhitelisted.2@osmosys.co, nonwhitelisted.3@osmosys.co",
    "to": "whitelisted.user@osmosys.co",
    "bcc": "nonwhitelisted.1@osmosys.co",
    "from": "postmaster@mg.com",
    "html": "<b>Testing the whitelist recipients bug 3</b>",
    "text": "This is a test notification",
    "subject": "Testing the whitelist recipients bug 3"
  }
}'
```

Response
```json
{
  "provider_id": 34,
  "data": {
    "cc": "",
    "to": "whitelisted.user@osmosys.co",
    "bcc": "",
    "from": "postmaster@mg.com",
    "html": "<b>Testing the whitelist recipients bug 3</b>",
    "text": "This is a test notification",
    "subject": "Testing the whitelist recipients bug 3"
  },
  "application_id": 13,
  "created_by": "DUMMY-APPLICATION-FOR-TESTING",
  "updated_by": "DUMMY-APPLICATION-FOR-TESTING",
  "channel_type": 2,
  "result": null,
  "notification_sent_on": null,
  "provider_chain_id": null,
  "id": 820155,
  "delivery_status": 1,
  "created_on": "2026-07-30T12:47:01.130Z",
  "updated_on": "2026-07-30T12:47:01.130Z",
  "status": 1,
  "retry_count": 0
}
```

2. SMTP
```curl
curl --request POST \
  --url http://localhost:3300/notifications \
  --header 'content-type: application/json' \
  --header 'x-api-key: my-api-key' \
  --data '{
  "providerId": 25,
  "data": {
    "to": [
      "nonwhitelisted.1@osmosys.co",
      "whitelisted.user1@osmosys.co",
      "nonwhitelisted.2@osmosys.co, nonwhitelisted.3@osmosys.co, whitelisted.user2@osmosys.co"
    ],
    "cc": "whitelisted.user2@osmosys.co, nonwhitelisted.3@osmosys.co",
    "bcc": "whitelisted.user1@osmosys.co",
    "from": "postmaster@mg.com",
    "html": "<h1>Testing 2 Please Ignore</h1><hr>\n            <p>Hello,</p>\n\n            <p>\n                Please find attached the <strong>GitLab Merge Requests</strong> report for all users\n                covering the period from <strong>2026-06-14</strong> to <strong>2026-06-21</strong>.\n            </p>\n\n            <p>\n                This report includes details of merge requests submitted, reviewed, and merged during this timeframe.\n            </p>\n\n            <p>\n                Let us know if you need any further insights or clarification.\n            </p>\n\n            <p>Best regards,<br>nonwhitelisted.1@osmosys.co</p>\n        ",
    "subject": "Testing 2 PR #546 please ignore",
    "attachments": [
      {
        "content": "content-string",
        "encoding": "base64",
        "filename": "2026-06-14_2026-06-21_mr_report.xlsx"
      }
    ]
  }
}'
```

Response
```json
{
  "provider_id": 25,
  "data": {
    "to": [
      "whitelisted.user1@osmosys.co",
      "whitelisted.user2@osmosys.co"
    ],
    "cc": "whitelisted.user2@osmosys.co",
    "bcc": "whitelisted.user1@osmosys.co",
    "from": "postmaster@mg.com",
    "html": "<h1>Testing 2 Please Ignore</h1><hr>\n            <p>Hello,</p>\n\n            <p>\n                Please find attached the <strong>GitLab Merge Requests</strong> report for all users\n                covering the period from <strong>2026-06-14</strong> to <strong>2026-06-21</strong>.\n            </p>\n\n            <p>\n                This report includes details of merge requests submitted, reviewed, and merged during this timeframe.\n            </p>\n\n            <p>\n                Let us know if you need any further insights or clarification.\n            </p>\n\n",
    "subject": "Testing 2 PR #546 please ignore",
    "attachments": [
      {
        "content": "content-string",
        "encoding": "base64",
        "filename": "2026-06-14_2026-06-21_mr_report.xlsx"
      }
    ]
  },
  "application_id": 12,
  "created_by": "R&D applications",
  "updated_by": "R&D applications",
  "channel_type": 1,
  "result": null,
  "notification_sent_on": null,
  "provider_chain_id": null,
  "id": 820156,
  "delivery_status": 1,
  "created_on": "2026-07-31T08:15:12.410Z",
  "updated_on": "2026-07-31T08:15:12.410Z",
  "status": 1,
  "retry_count": 0
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test-mode notification safety by limiting delivery to approved recipients.
  * Added consistent handling for single, multiple, comma-separated, nested, and mixed recipient formats.
  * Added case-insensitive recipient matching while preserving wildcard and unsupported-channel behavior.
  * Added error handling and logging when recipient filtering fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->