### PR TITLE
feat: allow x-api-key auth on notification GET endpoints

### DIFF
--- a/apps/api/docs-site/api-reference/overview.mdx
+++ b/apps/api/docs-site/api-reference/overview.mdx
@@ -188,7 +188,7 @@ Retrieve a paginated, filterable list of notifications.
   Accepts **either** a Bearer token **or** an `x-api-key` header for authorization. With a Bearer token, results are scoped to the caller's organization (or a target org via `organization_id`, `SUPER_ADMIN` only). With `x-api-key`, results are scoped strictly to the application the key belongs to — `application_id` is ignored in this mode.
 </Note>
 
-**Endpoint:** `GET /notifications`
+**Endpoint:** `GET /api/notifications`
 
 **Query Parameters:**
 
@@ -205,12 +205,12 @@ Retrieve a paginated, filterable list of notifications.
 
 <CodeGroup>
 ```bash Bearer token
-curl --location 'http://localhost:3000/notifications?limit=5&application_id=1' \
+curl --location 'http://localhost:3000/api/notifications?limit=5&application_id=1' \
 --header 'Authorization: Bearer mysecuretoken'
 ```
 
 ```bash x-api-key
-curl --location 'http://localhost:3000/notifications?limit=5' \
+curl --location 'http://localhost:3000/api/notifications?limit=5' \
 --header 'x-api-key: mysecureserverapikey'
 ```
 </CodeGroup>
@@ -234,11 +234,11 @@ curl --location 'http://localhost:3000/notifications?limit=5' \
       "updated_on": "2024-02-12T07:24:21.000Z"
     }
   ],
-  "self": "http://localhost:3000/notifications?page=1&limit=5",
-  "first": "http://localhost:3000/notifications?page=1&limit=5",
+  "self": "http://localhost:3000/api/notifications?page=1&limit=5",
+  "first": "http://localhost:3000/api/notifications?page=1&limit=5",
   "next": null,
   "prev": null,
-  "last": "http://localhost:3000/notifications?page=1&limit=5",
+  "last": "http://localhost:3000/api/notifications?page=1&limit=5",
   "page_info": {
     "page": 1,
     "limit": 5,
@@ -254,7 +254,7 @@ curl --location 'http://localhost:3000/notifications?limit=5' \
 
 Retrieve a single notification by its `id`. Accepts the same Bearer token / `x-api-key` authorization and scoping rules as [Fetch All Notifications (REST)](#fetch-all-notifications-rest). Returns `404` if the notification doesn't exist, or isn't visible to the caller's org/application.
 
-**Endpoint:** `GET /notifications/:id`
+**Endpoint:** `GET /api/notifications/:id`
 
 **Query Parameters:**
 
@@ -264,12 +264,12 @@ Retrieve a single notification by its `id`. Accepts the same Bearer token / `x-a
 
 <CodeGroup>
 ```bash Bearer token
-curl --location 'http://localhost:3000/notifications/92' \
+curl --location 'http://localhost:3000/api/notifications/92' \
 --header 'Authorization: Bearer mysecuretoken'
 ```
 
 ```bash x-api-key
-curl --location 'http://localhost:3000/notifications/92' \
+curl --location 'http://localhost:3000/api/notifications/92' \
 --header 'x-api-key: mysecureserverapikey'
 ```
 </CodeGroup>

--- a/apps/api/docs-site/api-reference/overview.mdx
+++ b/apps/api/docs-site/api-reference/overview.mdx
@@ -180,7 +180,119 @@ curl --location 'http://localhost:3000/notifications' \
 }
 ```
 
-### Fetch All Notifications
+### Fetch All Notifications (REST)
+
+Retrieve a paginated, filterable list of notifications.
+
+<Note>
+  Accepts **either** a Bearer token **or** an `x-api-key` header for authorization. With a Bearer token, results are scoped to the caller's organization (or a target org via `organization_id`, `SUPER_ADMIN` only). With `x-api-key`, results are scoped strictly to the application the key belongs to — `application_id` is ignored in this mode.
+</Note>
+
+**Endpoint:** `GET /notifications`
+
+**Query Parameters:**
+
+| Parameter | Description |
+|-----------|-------------|
+| `page` / `limit` | Pagination controls (`limit` max `1000`, default `20`) |
+| `sort` / `order` | Sort field (snake_case, e.g. `created_on`) and direction (`asc`/`desc`) |
+| `organization_id` | Target org — Bearer auth only, `SUPER_ADMIN` only |
+| `application_id` | Filter by application — Bearer auth only (ignored for `x-api-key` auth) |
+| `channel_type`, `delivery_status`, `provider_id` | Filter by the respective numeric fields |
+| `date_from` / `date_to` | Filter by `created_on` range (ISO 8601) |
+| `recipient`, `sender`, `subject`, `message_body`, `template_name` | Free-text filters matched against `data` fields (3+ characters recommended) |
+| `data_filter[key]=value` | Match top-level `data` JSON key/value pairs (repeatable, AND-combined) |
+
+<CodeGroup>
+```bash Bearer token
+curl --location 'http://localhost:3000/notifications?limit=5&application_id=1' \
+--header 'Authorization: Bearer mysecuretoken'
+```
+
+```bash x-api-key
+curl --location 'http://localhost:3000/notifications?limit=5' \
+--header 'x-api-key: mysecureserverapikey'
+```
+</CodeGroup>
+
+**Response:**
+```json
+{
+  "items": [
+    {
+      "id": 92,
+      "provider_id": 1,
+      "channel_type": 1,
+      "data": {
+        "from": "sender@email.com",
+        "to": "receiver@email.com",
+        "subject": "Test subject"
+      },
+      "delivery_status": 5,
+      "application_id": 2,
+      "created_on": "2024-02-12T07:24:21.000Z",
+      "updated_on": "2024-02-12T07:24:21.000Z"
+    }
+  ],
+  "self": "http://localhost:3000/notifications?page=1&limit=5",
+  "first": "http://localhost:3000/notifications?page=1&limit=5",
+  "next": null,
+  "prev": null,
+  "last": "http://localhost:3000/notifications?page=1&limit=5",
+  "page_info": {
+    "page": 1,
+    "limit": 5,
+    "total_items": 1,
+    "total_pages": 1,
+    "has_next": false,
+    "has_prev": false
+  }
+}
+```
+
+### Get Notification by ID (REST)
+
+Retrieve a single notification by its `id`. Accepts the same Bearer token / `x-api-key` authorization and scoping rules as [Fetch All Notifications (REST)](#fetch-all-notifications-rest). Returns `404` if the notification doesn't exist, or isn't visible to the caller's org/application.
+
+**Endpoint:** `GET /notifications/:id`
+
+**Query Parameters:**
+
+| Parameter | Description |
+|-----------|-------------|
+| `organization_id` | Target org — Bearer auth only, `SUPER_ADMIN` only |
+
+<CodeGroup>
+```bash Bearer token
+curl --location 'http://localhost:3000/notifications/92' \
+--header 'Authorization: Bearer mysecuretoken'
+```
+
+```bash x-api-key
+curl --location 'http://localhost:3000/notifications/92' \
+--header 'x-api-key: mysecureserverapikey'
+```
+</CodeGroup>
+
+**Response:**
+```json
+{
+  "id": 92,
+  "provider_id": 1,
+  "channel_type": 1,
+  "data": {
+    "from": "sender@email.com",
+    "to": "receiver@email.com",
+    "subject": "Test subject"
+  },
+  "delivery_status": 5,
+  "application_id": 2,
+  "created_on": "2024-02-12T07:24:21.000Z",
+  "updated_on": "2024-02-12T07:24:21.000Z"
+}
+```
+
+### Fetch All Notifications (GraphQL)
 
 Retrieve notifications with filtering, sorting, and pagination.
 
@@ -248,7 +360,7 @@ curl --location 'localhost:3000/graphql' \
 ```
 </CodeGroup>
 
-### Fetch Notification by ID
+### Fetch Notification by ID (GraphQL)
 
 Retrieve a single notification from either active or archived tables.
 

--- a/apps/api/docs/api-documentation.md
+++ b/apps/api/docs/api-documentation.md
@@ -180,7 +180,124 @@ curl --location 'http://localhost:3000/notifications' \
 }
 ```
 
-### Fetch All Notifications
+### Fetch All Notifications (REST)
+
+Allows fetching a paginated, filterable list of notifications. Accepts **either** a Bearer token **or** an `x-api-key` header for authorization:
+
+- **Bearer token:** Results are scoped to the caller's organization (or a target org via `organization_id`, `SUPER_ADMIN` only).
+- **`x-api-key`:** Results are scoped strictly to the application the key belongs to — `application_id` is ignored in this mode.
+
+**Endpoint:** `http://localhost:3000/notifications`
+
+**Method:** `GET`
+
+**Query Parameters:**
+
+- `page` / `limit:` Pagination controls (`limit` max `1000`, default `20`)
+- `sort` / `order:` Sort field (snake_case, e.g. `created_on`) and direction (`asc`/`desc`)
+- `organization_id:` Target org — Bearer auth only, `SUPER_ADMIN` only
+- `application_id:` Filter by application — Bearer auth only (ignored for `x-api-key` auth, which is already application-scoped)
+- `channel_type`, `delivery_status`, `provider_id:` Filter by the respective numeric fields
+- `date_from` / `date_to:` Filter by `created_on` range (ISO 8601)
+- `recipient`, `sender`, `subject`, `message_body`, `template_name:` Free-text filters matched against `data` fields (3+ characters recommended)
+- `data_filter[key]=value:` Match top-level `data` JSON key/value pairs (repeatable, AND-combined)
+
+**cURL (Bearer token)**
+
+```sh
+curl --location 'http://localhost:3000/notifications?limit=5&application_id=1' \
+--header 'Authorization: Bearer mysecuretoken'
+```
+
+**cURL (x-api-key)**
+
+```sh
+curl --location 'http://localhost:3000/notifications?limit=5' \
+--header 'x-api-key: mysecureserverapikey'
+```
+
+**Sample response**
+
+```json
+{
+  "items": [
+    {
+      "id": 92,
+      "provider_id": 1,
+      "channel_type": 1,
+      "data": {
+        "from": "sender@email.com",
+        "to": "receiver@email.com",
+        "subject": "Test subject"
+      },
+      "delivery_status": 5,
+      "application_id": 2,
+      "created_on": "2024-02-12T07:24:21.000Z",
+      "updated_on": "2024-02-12T07:24:21.000Z"
+    }
+  ],
+  "self": "http://localhost:3000/notifications?page=1&limit=5",
+  "first": "http://localhost:3000/notifications?page=1&limit=5",
+  "next": null,
+  "prev": null,
+  "last": "http://localhost:3000/notifications?page=1&limit=5",
+  "page_info": {
+    "page": 1,
+    "limit": 5,
+    "total_items": 1,
+    "total_pages": 1,
+    "has_next": false,
+    "has_prev": false
+  }
+}
+```
+
+### Get Notification by ID (REST)
+
+Allows fetching a single notification by its `id`. Accepts **either** a Bearer token **or** an `x-api-key` header for authorization, with the same scoping rules as [Fetch All Notifications (REST)](#fetch-all-notifications-rest). Returns `404` if the notification doesn't exist, or isn't visible to the caller's org/application.
+
+**Endpoint:** `http://localhost:3000/notifications/:id`
+
+**Method:** `GET`
+
+**Query Parameters:**
+
+- `organization_id:` Target org — Bearer auth only, `SUPER_ADMIN` only
+
+**cURL (Bearer token)**
+
+```sh
+curl --location 'http://localhost:3000/notifications/92' \
+--header 'Authorization: Bearer mysecuretoken'
+```
+
+**cURL (x-api-key)**
+
+```sh
+curl --location 'http://localhost:3000/notifications/92' \
+--header 'x-api-key: mysecureserverapikey'
+```
+
+**Sample response**
+
+```json
+{
+  "id": 92,
+  "provider_id": 1,
+  "channel_type": 1,
+  "data": {
+    "from": "sender@email.com",
+    "to": "receiver@email.com",
+    "subject": "Test subject"
+  },
+  "delivery_status": 5,
+  "application_id": 2,
+  "created_on": "2024-02-12T07:24:21.000Z",
+  "updated_on": "2024-02-12T07:24:21.000Z"
+}
+```
+
+### Fetch All Notifications (GraphQL)
 
 Allows the user to fetch all notifications based on the passed query parameters. Requires passing bearer token for authorization.
 
@@ -310,7 +427,7 @@ curl --location 'YOUR_BASE_URL/graphql' \
 }
 ```
 
-### Fetch active or archived Notification by Id
+### Fetch active or archived Notification by Id (GraphQL)
 
 Allows the user to fetch a single notification present in either `notify_notifications` or `notify_archived_notifications` table by passing notificationId. Requires passing bearer token for authorization.
 

--- a/apps/api/docs/api-documentation.md
+++ b/apps/api/docs/api-documentation.md
@@ -187,7 +187,7 @@ Allows fetching a paginated, filterable list of notifications. Accepts **either*
 - **Bearer token:** Results are scoped to the caller's organization (or a target org via `organization_id`, `SUPER_ADMIN` only).
 - **`x-api-key`:** Results are scoped strictly to the application the key belongs to — `application_id` is ignored in this mode.
 
-**Endpoint:** `http://localhost:3000/notifications`
+**Endpoint:** `http://localhost:3000/api/notifications`
 
 **Method:** `GET`
 
@@ -205,14 +205,14 @@ Allows fetching a paginated, filterable list of notifications. Accepts **either*
 **cURL (Bearer token)**
 
 ```sh
-curl --location 'http://localhost:3000/notifications?limit=5&application_id=1' \
+curl --location 'http://localhost:3000/api/notifications?limit=5&application_id=1' \
 --header 'Authorization: Bearer mysecuretoken'
 ```
 
 **cURL (x-api-key)**
 
 ```sh
-curl --location 'http://localhost:3000/notifications?limit=5' \
+curl --location 'http://localhost:3000/api/notifications?limit=5' \
 --header 'x-api-key: mysecureserverapikey'
 ```
 
@@ -236,11 +236,11 @@ curl --location 'http://localhost:3000/notifications?limit=5' \
       "updated_on": "2024-02-12T07:24:21.000Z"
     }
   ],
-  "self": "http://localhost:3000/notifications?page=1&limit=5",
-  "first": "http://localhost:3000/notifications?page=1&limit=5",
+  "self": "http://localhost:3000/api/notifications?page=1&limit=5",
+  "first": "http://localhost:3000/api/notifications?page=1&limit=5",
   "next": null,
   "prev": null,
-  "last": "http://localhost:3000/notifications?page=1&limit=5",
+  "last": "http://localhost:3000/api/notifications?page=1&limit=5",
   "page_info": {
     "page": 1,
     "limit": 5,
@@ -256,7 +256,7 @@ curl --location 'http://localhost:3000/notifications?limit=5' \
 
 Allows fetching a single notification by its `id`. Accepts **either** a Bearer token **or** an `x-api-key` header for authorization, with the same scoping rules as [Fetch All Notifications (REST)](#fetch-all-notifications-rest). Returns `404` if the notification doesn't exist, or isn't visible to the caller's org/application.
 
-**Endpoint:** `http://localhost:3000/notifications/:id`
+**Endpoint:** `http://localhost:3000/api/notifications/:id`
 
 **Method:** `GET`
 
@@ -267,14 +267,14 @@ Allows fetching a single notification by its `id`. Accepts **either** a Bearer t
 **cURL (Bearer token)**
 
 ```sh
-curl --location 'http://localhost:3000/notifications/92' \
+curl --location 'http://localhost:3000/api/notifications/92' \
 --header 'Authorization: Bearer mysecuretoken'
 ```
 
 **cURL (x-api-key)**
 
 ```sh
-curl --location 'http://localhost:3000/notifications/92' \
+curl --location 'http://localhost:3000/api/notifications/92' \
 --header 'x-api-key: mysecureserverapikey'
 ```
 

--- a/apps/api/src/common/guards/jwt-or-api-key/jwt-or-api-key.guard.spec.ts
+++ b/apps/api/src/common/guards/jwt-or-api-key/jwt-or-api-key.guard.spec.ts
@@ -1,0 +1,77 @@
+import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import { JwtOrApiKeyGuard, RequestWithApiKeyAuth } from './jwt-or-api-key.guard';
+import { JwtAuthGuard } from 'src/modules/auth/guards/jwt-auth.guard';
+import { RolesGuard } from 'src/common/guards/role.guard';
+import { ServerApiKeysService } from 'src/modules/server-api-keys/server-api-keys.service';
+
+describe('JwtOrApiKeyGuard', () => {
+  let guard: JwtOrApiKeyGuard;
+  let jwtAuthGuard: { canActivate: jest.Mock };
+  let rolesGuard: { canActivate: jest.Mock };
+  let serverApiKeysService: { findApplicationIdByRawApiKey: jest.Mock };
+
+  const buildContext = (headers: Record<string, string | string[]>): ExecutionContext => {
+    const request = { headers } as RequestWithApiKeyAuth;
+
+    return {
+      switchToHttp: () => ({
+        getRequest: () => request,
+      }),
+    } as unknown as ExecutionContext;
+  };
+
+  beforeEach(() => {
+    jwtAuthGuard = { canActivate: jest.fn() };
+    rolesGuard = { canActivate: jest.fn() };
+    serverApiKeysService = { findApplicationIdByRawApiKey: jest.fn() };
+    guard = new JwtOrApiKeyGuard(
+      jwtAuthGuard as unknown as JwtAuthGuard,
+      rolesGuard as unknown as RolesGuard,
+      serverApiKeysService as unknown as ServerApiKeysService,
+    );
+  });
+
+  it('authenticates via x-api-key and stamps apiKeyApplicationId on the request', async () => {
+    serverApiKeysService.findApplicationIdByRawApiKey.mockResolvedValue(7);
+    const context = buildContext({ 'x-api-key': 'raw-key' });
+
+    await expect(guard.canActivate(context)).resolves.toBe(true);
+    expect(serverApiKeysService.findApplicationIdByRawApiKey).toHaveBeenCalledWith('raw-key');
+    expect(jwtAuthGuard.canActivate).not.toHaveBeenCalled();
+    expect(context.switchToHttp().getRequest<RequestWithApiKeyAuth>().apiKeyApplicationId).toBe(7);
+  });
+
+  it('rejects an unrecognized x-api-key', async () => {
+    serverApiKeysService.findApplicationIdByRawApiKey.mockResolvedValue(undefined);
+    const context = buildContext({ 'x-api-key': 'bad-key' });
+
+    await expect(guard.canActivate(context)).rejects.toThrow(UnauthorizedException);
+  });
+
+  it('uses the first value when x-api-key is sent as multiple headers', async () => {
+    serverApiKeysService.findApplicationIdByRawApiKey.mockResolvedValue(3);
+    const context = buildContext({ 'x-api-key': ['first-key', 'second-key'] });
+
+    await expect(guard.canActivate(context)).resolves.toBe(true);
+    expect(serverApiKeysService.findApplicationIdByRawApiKey).toHaveBeenCalledWith('first-key');
+  });
+
+  it('falls back to JWT + role auth when no x-api-key header is present', async () => {
+    jwtAuthGuard.canActivate.mockResolvedValue(true);
+    rolesGuard.canActivate.mockReturnValue(true);
+    const context = buildContext({});
+
+    await expect(guard.canActivate(context)).resolves.toBe(true);
+    expect(serverApiKeysService.findApplicationIdByRawApiKey).not.toHaveBeenCalled();
+    expect(jwtAuthGuard.canActivate).toHaveBeenCalledWith(context);
+    expect(rolesGuard.canActivate).toHaveBeenCalledWith(context);
+  });
+
+  it('short-circuits when JwtAuthGuard rejects, without calling RolesGuard', async () => {
+    jwtAuthGuard.canActivate.mockResolvedValue(false);
+    const context = buildContext({});
+
+    await expect(guard.canActivate(context)).resolves.toBe(false);
+    expect(rolesGuard.canActivate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/common/guards/jwt-or-api-key/jwt-or-api-key.guard.ts
+++ b/apps/api/src/common/guards/jwt-or-api-key/jwt-or-api-key.guard.ts
@@ -1,0 +1,42 @@
+import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
+import { Request } from 'express';
+import { JwtAuthGuard } from 'src/modules/auth/guards/jwt-auth.guard';
+import { RolesGuard } from 'src/common/guards/role.guard';
+import { ServerApiKeysService } from 'src/modules/server-api-keys/server-api-keys.service';
+
+export type RequestWithApiKeyAuth = Request & { apiKeyApplicationId?: number };
+
+@Injectable()
+export class JwtOrApiKeyGuard implements CanActivate {
+  constructor(
+    private readonly jwtAuthGuard: JwtAuthGuard,
+    private readonly rolesGuard: RolesGuard,
+    private readonly serverApiKeysService: ServerApiKeysService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<RequestWithApiKeyAuth>();
+    const apiKeyHeader = request.headers['x-api-key'];
+
+    if (apiKeyHeader) {
+      const rawApiKey = Array.isArray(apiKeyHeader) ? apiKeyHeader[0] : apiKeyHeader;
+      const applicationId = await this.serverApiKeysService.findApplicationIdByRawApiKey(rawApiKey);
+
+      if (applicationId === undefined) {
+        throw new UnauthorizedException('Invalid API key');
+      }
+
+      request.apiKeyApplicationId = applicationId;
+
+      return true;
+    }
+
+    const jwtValid = await this.jwtAuthGuard.canActivate(context);
+
+    if (!jwtValid) {
+      return false;
+    }
+
+    return this.rolesGuard.canActivate(context);
+  }
+}

--- a/apps/api/src/modules/notifications/notifications.controller.ts
+++ b/apps/api/src/modules/notifications/notifications.controller.ts
@@ -18,6 +18,7 @@ import { ErrorCodes } from 'src/common/constants/error-codes';
 import {
   ApiBearerAuth,
   ApiExtraModels,
+  ApiHeader,
   ApiOperation,
   ApiQuery,
   ApiResponse,
@@ -26,7 +27,10 @@ import {
 import { NotificationsService } from './notifications.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from 'src/common/guards/role.guard';
-import { Request } from 'express';
+import {
+  JwtOrApiKeyGuard,
+  RequestWithApiKeyAuth,
+} from 'src/common/guards/jwt-or-api-key/jwt-or-api-key.guard';
 import { PaginationQueryDto } from 'src/common/dto/pagination-query.dto';
 import { PaginatedResponse } from 'src/common/dto/paginated-response.dto';
 import { LinkBuilder } from 'src/common/utils/link-builder.helper';
@@ -42,6 +46,12 @@ import { JwtPayload } from 'src/common/constants/jwtInterface';
 import { SnakeCaseInterceptor } from 'src/common/interceptors/snake-case.interceptor';
 import { resolveOrgId } from 'src/common/utils/org-resolver.helper';
 
+const API_KEY_HEADER_DOC = {
+  name: 'x-api-key',
+  required: false,
+  description: 'Server API key, scoped to a single application (alternative to Bearer JWT)',
+};
+
 @ApiTags('Notifications')
 @ApiBearerAuth()
 @ApiExtraModels(NotificationResponseDto)
@@ -56,7 +66,8 @@ export class NotificationsController {
   ) {}
 
   @Get()
-  @UseGuards(JwtAuthGuard, RolesGuard)
+  @UseGuards(JwtOrApiKeyGuard)
+  @ApiHeader(API_KEY_HEADER_DOC)
   @ApiOperation({ summary: 'List notifications' })
   @ApiQuery({
     name: 'organization_id',
@@ -158,13 +169,11 @@ export class NotificationsController {
     @Query('date_to') dateTo: string,
     @Query('provider_id') providerId: number,
     @CurrentUser() user: JwtPayload,
-    @Req() req: Request,
+    @Req() req: RequestWithApiKeyAuth,
   ): Promise<PaginatedResponse<NotificationResponseDto>> {
-    const targetOrgId = resolveOrgId(user, queryOrgId);
     const filters = {
       channelType: channelType ? Number(channelType) : undefined,
       deliveryStatus: deliveryStatus ? Number(deliveryStatus) : undefined,
-      applicationId: applicationId ? Number(applicationId) : undefined,
       providerId: providerId ? Number(providerId) : undefined,
       dateFrom: dateFrom || undefined,
       dateTo: dateTo || undefined,
@@ -175,11 +184,19 @@ export class NotificationsController {
       templateName: query.template_name,
       dataFilter: query.data_filter,
     };
-    const { items, meta } = await this.notificationsService.getAllNotificationsAsDto(
-      query,
-      targetOrgId,
-      filters,
-    );
+    const { apiKeyApplicationId } = req;
+    const { items, meta } =
+      apiKeyApplicationId !== undefined
+        ? await this.notificationsService.getAllNotificationsForApplicationAsDto(
+            query,
+            apiKeyApplicationId,
+            filters,
+          )
+        : await this.notificationsService.getAllNotificationsAsDto(
+            query,
+            resolveOrgId(user, queryOrgId),
+            { ...filters, applicationId: applicationId ? Number(applicationId) : undefined },
+          );
     const { protocol, host } = LinkBuilder.extractBaseUrl(req);
     const links = LinkBuilder.buildCollectionLinks(protocol, host, req.path, meta);
 
@@ -187,8 +204,9 @@ export class NotificationsController {
   }
 
   @Get(':id')
-  @UseGuards(JwtAuthGuard, RolesGuard)
+  @UseGuards(JwtOrApiKeyGuard)
   @Roles(UserRoles.ORG_USER)
+  @ApiHeader(API_KEY_HEADER_DOC)
   @ApiOperation({ summary: 'Get notification by ID' })
   @ApiQuery({
     name: 'organization_id',
@@ -203,10 +221,13 @@ export class NotificationsController {
     @Param('id') id: number,
     @Query('organization_id') queryOrgId: number,
     @CurrentUser() user: JwtPayload,
+    @Req() req: RequestWithApiKeyAuth,
   ): Promise<NotificationResponseDto> {
-    const targetOrgId = resolveOrgId(user, queryOrgId);
+    if (req.apiKeyApplicationId !== undefined) {
+      return this.notificationsService.findByIdForApplication(id, req.apiKeyApplicationId);
+    }
 
-    return this.notificationsService.findByIdAsDto(id, targetOrgId);
+    return this.notificationsService.findByIdAsDto(id, resolveOrgId(user, queryOrgId));
   }
 
   @Post('queue')

--- a/apps/api/src/modules/notifications/notifications.module.ts
+++ b/apps/api/src/modules/notifications/notifications.module.ts
@@ -47,6 +47,9 @@ import { ProviderChainsModule } from '../provider-chains/provider-chains.module'
 import { ProviderChainMembersModule } from '../provider-chain-members/provider-chain-members.module';
 import { MasterProvidersModule } from '../master-providers/master-providers.module';
 import { NotificationDataFilterHelper } from './helpers/notification-data-filter.helper';
+import { JwtOrApiKeyGuard } from 'src/common/guards/jwt-or-api-key/jwt-or-api-key.guard';
+import { RolesGuard } from 'src/common/guards/role.guard';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 
 const providerModules = [
   MailgunModule,
@@ -105,6 +108,9 @@ const consumers = [
     ArchivedNotificationsService,
     RequestLoggerMiddleware,
     NotificationDataFilterHelper,
+    JwtOrApiKeyGuard,
+    RolesGuard,
+    JwtAuthGuard,
     ...consumers,
   ],
   exports: [

--- a/apps/api/src/modules/notifications/notifications.service.ts
+++ b/apps/api/src/modules/notifications/notifications.service.ts
@@ -650,6 +650,19 @@ export class NotificationsService extends CoreService<Notification> {
     return this.mapNotificationToDto(notification);
   }
 
+  async findByIdForApplication(
+    notificationId: number,
+    applicationId: number,
+  ): Promise<NotificationResponseDto> {
+    const notification = await this.findById(notificationId);
+
+    if (!notification || notification.applicationId !== applicationId) {
+      throw new NotFoundException(ErrorCodes.NOTIFICATION_NOT_FOUND, 'Notification not found');
+    }
+
+    return this.mapNotificationToDto(notification);
+  }
+
   async findActiveOrArchivedNotificationById(
     notificationId: number,
   ): Promise<SingleNotificationResponse> {
@@ -787,6 +800,37 @@ export class NotificationsService extends CoreService<Notification> {
       items: items.map((n) => this.mapNotificationToDto(n)),
       meta,
     };
+  }
+
+  async getAllNotificationsForApplicationAsDto(
+    query: PaginationQueryDto,
+    applicationId: number,
+    filters?: {
+      channelType?: number;
+      deliveryStatus?: number;
+      providerId?: number;
+      dateFrom?: string;
+      dateTo?: string;
+      recipient?: string;
+      sender?: string;
+      subject?: string;
+      messageBody?: string;
+      templateName?: string;
+      dataFilter?: Record<string, string>;
+    },
+  ): Promise<{ items: NotificationResponseDto[]; meta: PaginationMeta }> {
+    const app = await this.applicationsService.findById(applicationId);
+
+    if (!app) {
+      const { page, limit } = PaginationHelper.normalizePaginationParams(query);
+
+      return { items: [], meta: PaginationHelper.buildPaginationMeta(page, limit, 0) };
+    }
+
+    return this.getAllNotificationsAsDto(query, app.organizationId, {
+      ...filters,
+      applicationId,
+    });
   }
 
   async getAllNotifications(options: QueryOptionsDto): Promise<NotificationResponse> {

--- a/apps/api/src/modules/server-api-keys/server-api-keys.service.ts
+++ b/apps/api/src/modules/server-api-keys/server-api-keys.service.ts
@@ -6,7 +6,7 @@ import { Repository } from 'typeorm/repository/Repository';
 import { In } from 'typeorm';
 import { ServerApiKey } from './entities/server-api-key.entity';
 import { Status } from 'src/common/constants/database';
-import { hashApiKey } from 'src/common/utils/bcrypt';
+import { compareApiKeys, hashApiKey } from 'src/common/utils/bcrypt';
 import * as crypto from 'crypto';
 import { ServerApiKeyResponseDto } from './dto/server-api-key-response.dto';
 import { ApplicationsService } from '../applications/applications.service';
@@ -32,6 +32,24 @@ export class ServerApiKeysService {
         status: Status.ACTIVE,
       },
     });
+  }
+
+  // Keys are bcrypt-hashed (salted), so they aren't equality-indexable in SQL — the
+  // application isn't known upfront here (unlike the providerId/providerChain-scoped
+  // lookup used for notification creation), so every active key must be compared in turn.
+  async findApplicationIdByRawApiKey(rawApiKey: string): Promise<number | undefined> {
+    const activeKeys = await this.serverApiKeyRepository.find({
+      where: { status: Status.ACTIVE },
+    });
+
+    for (const key of activeKeys) {
+      // eslint-disable-next-line no-await-in-loop -- must short-circuit on first match
+      if (await compareApiKeys(rawApiKey, key.apiKey)) {
+        return key.applicationId;
+      }
+    }
+
+    return undefined;
   }
 
   async generateApiKey(applicationId: number): Promise<string> {


### PR DESCRIPTION
## API PR Checklist

### Task Link
https://pinestem.com/dashboard.html#/tasks/REST-2420/details/?companyId=453&isPrevNext=1

### Pre-requisites

- [x] I have gone through the Contributing guidelines for [Submitting a Pull Request (PR)](https://github.com/OsmosysSoftware/osmo-x/blob/main/CONTRIBUTING.md#-submitting-a-pull-request-pr) and ensured that this is not a duplicate PR.
- [x] I have performed unit testing for the new feature added or updated to ensure the new features added are working as expected.
- [ ] I have added/updated test cases to the [test suite](https://github.com/OsmosysSoftware/osmo-x/blob/main/apps/api/OsmoX.postman_collection.json) as applicable.
- [ ] I have performed preliminary testing using the [test suite](https://github.com/OsmosysSoftware/osmo-x/blob/main/apps/api/OsmoX.postman_collection.json) to ensure that any existing features are not impacted and any new features are working as expected as a whole.
- [x] I have added/updated the required [api docs](https://github.com/OsmosysSoftware/osmo-x/tree/main/apps/api/docs) as applicable.
- [ ] I have added/updated the `.env.example` file with the required values as applicable.

### PR Details

PR details have been updated as per the given format (see below)

- [x] PR title adheres to the format specified in guidelines (e.g., `feat: add admin login endpoint`)
- [x] Description has been added
- [x] Related changes have been added (optional)
- [ ] Screenshots have been added (optional)
- [x] Query request and response examples have been added (as applicable, in case added or updated)
- [x] Documentation changes have been listed (as applicable)
- [x] Test suite/unit testing output is added (as applicable)
- [x] Pending actions have been added (optional)
- [x] Any other additional notes have been added (optional)

### Additional Information

- [x] Appropriate label(s) have been added (`ready for review` should be added if the PR is ready to be reviewed)
- [x] Assignee(s) and reviewer(s) have been added (optional)

> **Note:** Reviewer should ensure that the checklist and description have been populated and followed correctly, and the PR should be merged only after resolving all conversations and verifying that CI checks pass.

---

## Description

Adds `x-api-key` as an alternative to the existing Bearer JWT on the notification read endpoints, so server-side integrations can fetch notification status without holding a user session — matching how `POST /notifications` already authenticates via API key.

- `GET /notifications` and `GET /notifications/:id` now accept either a Bearer JWT (existing, org-scoped) or an `x-api-key` header (new, scoped strictly to the key's own application).
- New `JwtOrApiKeyGuard`: checks for `x-api-key` first — validates it against active server API keys (bcrypt compare) and stamps `request.apiKeyApplicationId` — otherwise falls through unchanged to the existing `JwtAuthGuard` + `RolesGuard` chain.
- New `ServerApiKeysService.findApplicationIdByRawApiKey` resolves an application directly from a raw key, since GET requests have no body to carry `providerId`/`providerChain` (unlike the existing `ApiKeyGuard` used for notification creation).
- New `NotificationsService.getAllNotificationsForApplicationAsDto` / `findByIdForApplication` keep API-key reads scoped to exactly that key's application — no org-wide visibility via API key, least-privilege by design.
- Swagger updated with an `x-api-key` header doc on both endpoints.
- API docs updated with dedicated REST sections for both endpoints (see **Documentation Changes** below).

## Related Changes

- `apps/api/src/common/guards/jwt-or-api-key/jwt-or-api-key.guard.ts` (new)
- `apps/api/src/common/guards/jwt-or-api-key/jwt-or-api-key.guard.spec.ts` (new)
- `apps/api/src/modules/notifications/notifications.controller.ts`
- `apps/api/src/modules/notifications/notifications.module.ts`
- `apps/api/src/modules/notifications/notifications.service.ts`
- `apps/api/src/modules/server-api-keys/server-api-keys.service.ts`
- `apps/api/docs/api-documentation.md`
- `apps/api/docs-site/api-reference/overview.mdx`

## Documentation Changes

- Added **Fetch All Notifications (REST)** and **Get Notification by ID (REST)** sections to `docs/api-documentation.md` (and synced to the Mintlify `docs-site/api-reference/overview.mdx`), documenting `GET /notifications` and `GET /notifications/:id`: dual auth (Bearer JWT vs `x-api-key`), per-mode scoping rules, all query parameters, and cURL/response examples for both auth methods.
- Renamed the pre-existing GraphQL notification-fetch sections to **"(GraphQL)"** so they read clearly now that REST sections exist alongside them (`Fetch All Notifications (GraphQL)`, `Fetch active or archived Notification by Id (GraphQL)` / `Fetch Notification by ID (GraphQL)`).

## Query Request and Response Examples

**By ID — JWT:**

```bash
curl -s http://localhost:3000/notifications/820162 \
  -H "Authorization: Bearer <jwt>"
```

**By ID — API key:**

```bash
curl -s http://localhost:3000/notifications/820162 \
  -H "x-api-key: <server-api-key>"
```

**Both return the same payload:**

```json
{
  "id": 820162,
  "provider_id": 41,
  "channel_type": 1,
  "delivery_status": 5,
  "application_id": 1,
  "created_on": "2026-08-05T07:08:13.537Z",
  "...": "..."
}
```

**List — API key (scoped to the key's own application):**

```bash
curl -s "http://localhost:3000/notifications?limit=1" \
  -H "x-api-key: <server-api-key>"
```

**No auth / invalid key:**

```json
{
  "status": 401,
  "title": "Unauthorized",
  "error_code": "AUTH_UNAUTHORIZED"
}
```

## Test Suite / Unit Testing Output

- `JwtOrApiKeyGuard` unit tests (5/5 passing): valid API key, invalid API key, multi-value `x-api-key` header, JWT fallback success, JWT fallback rejection short-circuiting `RolesGuard`.
- `eslint --max-warnings=0`, `prettier --check`, and `tsc --noEmit` clean on all touched files.
- Manual end-to-end verification against a local Docker stack: created a real SMTP-backed notification via `POST /notifications` (x-api-key), confirmed delivery (`delivery_status: 5`, accepted by Gmail), then verified `GET /notifications` and `GET /notifications/:id` both return it correctly under JWT, under x-api-key, and both correctly reject with 401 when unauthenticated or given an invalid key.

## Pending Actions

- [ ] Add Postman collection entries for `x-api-key` auth on the two GET endpoints.

## Additional Notes

- No `.env.example` changes required — no new environment variables introduced.
- Pre-existing, unrelated test failures were observed in `notifications.controller.spec.ts`, `server-api-keys.service.spec.ts`, and `archived-notifications.*.spec.ts` (broken NestJS testing-module DI setup) — confirmed present on unmodified `main` before this change, not introduced by it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added REST API support for listing and retrieving notifications with API-key authentication.
  * Added application-scoped notification access for API-key requests.
  * Added support for pagination, filtering, and notification lookup by ID.
* **Documentation**
  * Documented authentication options, scoping rules, query parameters, examples, and response formats.
  * Clarified which notification endpoints use GraphQL.
* **Tests**
  * Added coverage for API-key and JWT authentication scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->