### PR TITLE
feat: extend x-api-key auth to archived-notifications and GraphQL

### DIFF
--- a/apps/api/docs-site/api-reference/overview.mdx
+++ b/apps/api/docs-site/api-reference/overview.mdx
@@ -296,6 +296,10 @@ curl --location 'http://localhost:3000/api/notifications/92' \
 
 Retrieve notifications with filtering, sorting, and pagination.
 
+<Note>
+  Accepts **either** a Bearer token **or** an `x-api-key` header for authorization. With a Bearer token, no org/application scoping is applied — any authenticated user can query notifications across all organizations. With `x-api-key`, results are restricted to the application the key belongs to.
+</Note>
+
 **Endpoint:** `POST /graphql`
 
 **Query Options:**
@@ -352,17 +356,28 @@ query {
 }
 ```
 
-```bash cURL
+```bash cURL (Bearer token)
 curl --location 'localhost:3000/graphql' \
 --header 'Authorization: Bearer mysecuretoken' \
 --header 'Content-Type: application/json' \
 --data '{"query":"query { notifications(options: { limit: 5, offset: 0, sortBy: \"createdOn\", sortOrder: DESC }) { notifications { id channelType deliveryStatus data result } total offset limit } }","variables":{}}'
+```
+
+```bash cURL (x-api-key)
+curl --location 'localhost:3000/graphql' \
+--header 'x-api-key: mysecureserverapikey' \
+--header 'Content-Type: application/json' \
+--data '{"query":"query { notifications(options: { limit: 5 }) { notifications { id applicationId channelType deliveryStatus } total offset limit } }","variables":{}}'
 ```
 </CodeGroup>
 
 ### Fetch Notification by ID (GraphQL)
 
 Retrieve a single notification from either active or archived tables.
+
+<Note>
+  Accepts **either** a Bearer token **or** an `x-api-key` header for authorization. With a Bearer token, no org/application scoping is applied — any authenticated user can fetch any notification. With `x-api-key`, only notifications belonging to the key's own application are returned; others come back as not found.
+</Note>
 
 **Endpoint:** `POST /graphql`
 
@@ -386,13 +401,147 @@ query {
 }
 ```
 
+<CodeGroup>
+```bash cURL (Bearer token)
+curl --location 'localhost:3000/graphql' \
+--header 'Authorization: Bearer mysecuretoken' \
+--header 'Content-Type: application/json' \
+--data '{"query":"query { notification(notificationId: 150) { id applicationId channelType deliveryStatus } }","variables":{}}'
+```
+
+```bash cURL (x-api-key)
+curl --location 'localhost:3000/graphql' \
+--header 'x-api-key: mysecureserverapikey' \
+--header 'Content-Type: application/json' \
+--data '{"query":"query { notification(notificationId: 150) { id applicationId channelType deliveryStatus } }","variables":{}}'
+```
+</CodeGroup>
+
 ---
 
 ## Archived Notifications
 
-### Fetch All Archived Notifications
+### Fetch All Archived Notifications (REST)
+
+Retrieve a paginated, filterable list of archived notifications.
+
+<Note>
+  Accepts **either** a Bearer token **or** an `x-api-key` header for authorization. With a Bearer token, results are scoped to the caller's organization (or a target org via `organization_id`, `SUPER_ADMIN` only). With `x-api-key`, results are scoped strictly to the application the key belongs to — `application_id` is ignored in this mode.
+</Note>
+
+**Endpoint:** `GET /api/archived-notifications`
+
+**Query Parameters:**
+
+| Parameter | Description |
+|-----------|-------------|
+| `page` / `limit` | Pagination controls (`limit` max `1000`, default `20`) |
+| `sort` / `order` | Sort field (snake_case, e.g. `created_on`) and direction (`asc`/`desc`) |
+| `organization_id` | Target org — Bearer auth only, `SUPER_ADMIN` only |
+| `application_id` | Filter by application — Bearer auth only (ignored for `x-api-key` auth) |
+| `channel_type`, `delivery_status`, `provider_id` | Filter by the respective numeric fields |
+| `date_from` / `date_to` | Filter by `created_on` range (ISO 8601) |
+| `recipient`, `sender`, `subject`, `message_body`, `template_name` | Free-text filters matched against `data` fields (3+ characters recommended) |
+| `data_filter[key]=value` | Match top-level `data` JSON key/value pairs (repeatable, AND-combined) |
+
+<CodeGroup>
+```bash Bearer token
+curl --location 'http://localhost:3000/api/archived-notifications?limit=5&application_id=1' \
+--header 'Authorization: Bearer mysecuretoken'
+```
+
+```bash x-api-key
+curl --location 'http://localhost:3000/api/archived-notifications?limit=5' \
+--header 'x-api-key: mysecureserverapikey'
+```
+</CodeGroup>
+
+**Response:**
+```json
+{
+  "items": [
+    {
+      "id": 7,
+      "notification_id": 9,
+      "provider_id": 1,
+      "channel_type": 1,
+      "data": {
+        "from": "sender@email.com",
+        "to": "receiver@email.com",
+        "subject": "Test subject"
+      },
+      "delivery_status": 6,
+      "application_id": 1,
+      "created_on": "2024-05-07T06:44:39.000Z",
+      "updated_on": "2024-07-03T06:18:08.000Z"
+    }
+  ],
+  "self": "http://localhost:3000/api/archived-notifications?page=1&limit=5",
+  "first": "http://localhost:3000/api/archived-notifications?page=1&limit=5",
+  "next": null,
+  "prev": null,
+  "last": "http://localhost:3000/api/archived-notifications?page=1&limit=5",
+  "page_info": {
+    "page": 1,
+    "limit": 5,
+    "total_items": 1,
+    "total_pages": 1,
+    "has_next": false,
+    "has_prev": false
+  }
+}
+```
+
+### Get Archived Notification by ID (REST)
+
+Retrieve a single archived notification by its `id`. Accepts the same Bearer token / `x-api-key` authorization and scoping rules as [Fetch All Archived Notifications (REST)](#fetch-all-archived-notifications-rest). Returns `400` if the archived notification doesn't exist, or isn't visible to the caller's org/application.
+
+**Endpoint:** `GET /api/archived-notifications/:id`
+
+**Query Parameters:**
+
+| Parameter | Description |
+|-----------|-------------|
+| `organization_id` | Target org — Bearer auth only, `SUPER_ADMIN` only |
+
+<CodeGroup>
+```bash Bearer token
+curl --location 'http://localhost:3000/api/archived-notifications/7' \
+--header 'Authorization: Bearer mysecuretoken'
+```
+
+```bash x-api-key
+curl --location 'http://localhost:3000/api/archived-notifications/7' \
+--header 'x-api-key: mysecureserverapikey'
+```
+</CodeGroup>
+
+**Response:**
+```json
+{
+  "id": 7,
+  "notification_id": 9,
+  "provider_id": 1,
+  "channel_type": 1,
+  "data": {
+    "from": "sender@email.com",
+    "to": "receiver@email.com",
+    "subject": "Test subject"
+  },
+  "delivery_status": 6,
+  "application_id": 1,
+  "created_on": "2024-05-07T06:44:39.000Z",
+  "updated_on": "2024-07-03T06:18:08.000Z"
+}
+```
+
+### Fetch All Archived Notifications (GraphQL)
 
 Retrieve archived notifications with the same filtering options as active notifications.
+
+<Note>
+  Accepts **either** a Bearer token **or** an `x-api-key` header for authorization. With a Bearer token, no org/application scoping is applied — any authenticated user can query archived notifications across all organizations. With `x-api-key`, results are restricted to the application the key belongs to.
+</Note>
 
 **Endpoint:** `POST /graphql`
 
@@ -428,6 +577,22 @@ query {
   }
 }
 ```
+
+<CodeGroup>
+```bash cURL (Bearer token)
+curl --location 'localhost:3000/graphql' \
+--header 'Authorization: Bearer mysecuretoken' \
+--header 'Content-Type: application/json' \
+--data '{"query":"query { archivedNotifications(options: { limit: 5 }) { archivedNotifications { id applicationId channelType deliveryStatus } total offset limit } }","variables":{}}'
+```
+
+```bash cURL (x-api-key)
+curl --location 'localhost:3000/graphql' \
+--header 'x-api-key: mysecureserverapikey' \
+--header 'Content-Type: application/json' \
+--data '{"query":"query { archivedNotifications(options: { limit: 5 }) { archivedNotifications { id applicationId channelType deliveryStatus } total offset limit } }","variables":{}}'
+```
+</CodeGroup>
 
 ---
 

--- a/apps/api/docs/api-documentation.md
+++ b/apps/api/docs/api-documentation.md
@@ -299,7 +299,10 @@ curl --location 'http://localhost:3000/api/notifications/92' \
 
 ### Fetch All Notifications (GraphQL)
 
-Allows the user to fetch all notifications based on the passed query parameters. Requires passing bearer token for authorization.
+Allows the user to fetch all notifications based on the passed query parameters. Accepts **either** a Bearer token **or** an `x-api-key` header for authorization.
+
+- **Bearer token:** No org/application scoping is applied — any authenticated user can query notifications across all organizations.
+- **`x-api-key`:** Results are restricted to the application the key belongs to.
 
 The different options that can be used while fetching notifications are as follows:
 
@@ -358,13 +361,22 @@ query {
 }
 ```
 
-**cURL**
+**cURL (Bearer token)**
 
 ```sh
 curl --location 'YOUR_BASE_URL/graphql' \
 --header 'Authorization: Bearer mysecuretoken' \
 --header 'Content-Type: application/json' \
 --data-raw '{"query":"query {\r\n  notifications(\r\n    options: {\r\n      limit: 5\r\n      offset: 0\r\n      sortBy: \"createdOn\"\r\n      sortOrder: DESC\r\n      search: \"sender@email.com\"\r\n      filters: [{ field: \"applicationId\", operator: \"eq\", value: \"1\" }]\r\n    }\r\n  ) {\r\n    notifications {\r\n      applicationDetails {\r\n        applicationId\r\n        name\r\n        userId\r\n        status\r\n        createdOn\r\n        updatedOn\r\n      }\r\n      applicationId\r\n      channelType\r\n      createdBy\r\n      createdOn\r\n      data\r\n      deliveryStatus\r\n      id\r\n      notificationSentOn\r\n      providerId\r\n      result\r\n      status\r\n      updatedBy\r\n      updatedOn\r\n    }\r\n    total,\r\n    offset,\r\n    limit\r\n  }\r\n}","variables":{}}'
+```
+
+**cURL (x-api-key)**
+
+```sh
+curl --location 'YOUR_BASE_URL/graphql' \
+--header 'x-api-key: mysecureserverapikey' \
+--header 'Content-Type: application/json' \
+--data-raw '{"query":"query { notifications(options: { limit: 5 }) { notifications { id applicationId channelType deliveryStatus } total offset limit } }","variables":{}}'
 ```
 
 **Sample response**
@@ -429,7 +441,10 @@ curl --location 'YOUR_BASE_URL/graphql' \
 
 ### Fetch active or archived Notification by Id (GraphQL)
 
-Allows the user to fetch a single notification present in either `notify_notifications` or `notify_archived_notifications` table by passing notificationId. Requires passing bearer token for authorization.
+Allows the user to fetch a single notification present in either `notify_notifications` or `notify_archived_notifications` table by passing notificationId. Accepts **either** a Bearer token **or** an `x-api-key` header for authorization.
+
+- **Bearer token:** No org/application scoping is applied — any authenticated user can fetch any notification.
+- **`x-api-key`:** Only notifications belonging to the key's own application are returned; others come back as not found.
 
 The required parameter for fetching a single active or archived notification is as follows:
 
@@ -463,13 +478,22 @@ query {
 }
 ```
 
-**cURL**
+**cURL (Bearer token)**
 
 ```sh
 curl --location 'localhost:3000/graphql' \
 --header 'Authorization: Bearer mysecuretoken' \
 --header 'Content-Type: application/json' \
 --data '{"query":"query {\r\n  notification(\r\n    notificationId: 150\r\n  ) {\r\n      applicationId\r\n      channelType\r\n      createdBy\r\n      createdOn\r\n      data\r\n      deliveryStatus\r\n      id\r\n      notificationSentOn\r\n      providerId\r\n      result\r\n      status\r\n      updatedBy\r\n      updatedOn\r\n    }\r\n}","variables":{}}'
+```
+
+**cURL (x-api-key)**
+
+```sh
+curl --location 'localhost:3000/graphql' \
+--header 'x-api-key: mysecureserverapikey' \
+--header 'Content-Type: application/json' \
+--data '{"query":"query { notification(notificationId: 150) { id applicationId channelType deliveryStatus } }","variables":{}}'
 ```
 
 **Sample response**
@@ -508,9 +532,131 @@ curl --location 'localhost:3000/graphql' \
 
 This sections lists notification related requests such as fetching all archived notifications.
 
-### Fetch All Archived Notifications
+### Fetch All Archived Notifications (REST)
 
-Allows the user to fetch all archived notifications based on the passed query parameters. Requires passing bearer token for authorization.
+Allows fetching a paginated, filterable list of archived notifications. Accepts **either** a Bearer token **or** an `x-api-key` header for authorization:
+
+- **Bearer token:** Results are scoped to the caller's organization (or a target org via `organization_id`, `SUPER_ADMIN` only).
+- **`x-api-key`:** Results are scoped strictly to the application the key belongs to — `application_id` is ignored in this mode.
+
+**Endpoint:** `http://localhost:3000/api/archived-notifications`
+
+**Method:** `GET`
+
+**Query Parameters:**
+
+- `page` / `limit:` Pagination controls (`limit` max `1000`, default `20`)
+- `sort` / `order:` Sort field (snake_case, e.g. `created_on`) and direction (`asc`/`desc`)
+- `organization_id:` Target org — Bearer auth only, `SUPER_ADMIN` only
+- `application_id:` Filter by application — Bearer auth only (ignored for `x-api-key` auth, which is already application-scoped)
+- `channel_type`, `delivery_status`, `provider_id:` Filter by the respective numeric fields
+- `date_from` / `date_to:` Filter by `created_on` range (ISO 8601)
+- `recipient`, `sender`, `subject`, `message_body`, `template_name:` Free-text filters matched against `data` fields (3+ characters recommended)
+- `data_filter[key]=value:` Match top-level `data` JSON key/value pairs (repeatable, AND-combined)
+
+**cURL (Bearer token)**
+
+```sh
+curl --location 'http://localhost:3000/api/archived-notifications?limit=5&application_id=1' \
+--header 'Authorization: Bearer mysecuretoken'
+```
+
+**cURL (x-api-key)**
+
+```sh
+curl --location 'http://localhost:3000/api/archived-notifications?limit=5' \
+--header 'x-api-key: mysecureserverapikey'
+```
+
+**Sample response**
+
+```json
+{
+  "items": [
+    {
+      "id": 7,
+      "notification_id": 9,
+      "provider_id": 1,
+      "channel_type": 1,
+      "data": {
+        "from": "sender@email.com",
+        "to": "receiver@email.com",
+        "subject": "Test subject"
+      },
+      "delivery_status": 6,
+      "application_id": 1,
+      "created_on": "2024-05-07T06:44:39.000Z",
+      "updated_on": "2024-07-03T06:18:08.000Z"
+    }
+  ],
+  "self": "http://localhost:3000/api/archived-notifications?page=1&limit=5",
+  "first": "http://localhost:3000/api/archived-notifications?page=1&limit=5",
+  "next": null,
+  "prev": null,
+  "last": "http://localhost:3000/api/archived-notifications?page=1&limit=5",
+  "page_info": {
+    "page": 1,
+    "limit": 5,
+    "total_items": 1,
+    "total_pages": 1,
+    "has_next": false,
+    "has_prev": false
+  }
+}
+```
+
+### Get Archived Notification by ID (REST)
+
+Allows fetching a single archived notification by its `id`. Accepts **either** a Bearer token **or** an `x-api-key` header for authorization, with the same scoping rules as [Fetch All Archived Notifications (REST)](#fetch-all-archived-notifications-rest). Returns `400` if the archived notification doesn't exist, or isn't visible to the caller's org/application.
+
+**Endpoint:** `http://localhost:3000/api/archived-notifications/:id`
+
+**Method:** `GET`
+
+**Query Parameters:**
+
+- `organization_id:` Target org — Bearer auth only, `SUPER_ADMIN` only
+
+**cURL (Bearer token)**
+
+```sh
+curl --location 'http://localhost:3000/api/archived-notifications/7' \
+--header 'Authorization: Bearer mysecuretoken'
+```
+
+**cURL (x-api-key)**
+
+```sh
+curl --location 'http://localhost:3000/api/archived-notifications/7' \
+--header 'x-api-key: mysecureserverapikey'
+```
+
+**Sample response**
+
+```json
+{
+  "id": 7,
+  "notification_id": 9,
+  "provider_id": 1,
+  "channel_type": 1,
+  "data": {
+    "from": "sender@email.com",
+    "to": "receiver@email.com",
+    "subject": "Test subject"
+  },
+  "delivery_status": 6,
+  "application_id": 1,
+  "created_on": "2024-05-07T06:44:39.000Z",
+  "updated_on": "2024-07-03T06:18:08.000Z"
+}
+```
+
+### Fetch All Archived Notifications (GraphQL)
+
+Allows the user to fetch all archived notifications based on the passed query parameters. Accepts **either** a Bearer token **or** an `x-api-key` header for authorization.
+
+- **Bearer token:** No org/application scoping is applied — any authenticated user can query archived notifications across all organizations.
+- **`x-api-key`:** Results are restricted to the application the key belongs to.
 
 The different options that can be used while fetching notifications are as follows:
 
@@ -570,13 +716,22 @@ query {
 }
 ```
 
-**cURL**
+**cURL (Bearer token)**
 
 ```sh
 curl --location 'YOUR_BASE_URL/graphql' \
 --header 'Authorization: Bearer YOUR_AUTH_TOKEN' \
 --header 'Content-Type: application/json' \
 --data-raw '{"query":"query {\r\n  archivedNotifications(\r\n    options: {\r\n      limit: 5\r\n      offset: 0\r\n      sortBy: \"createdOn\"\r\n      sortOrder: DESC\r\n      search: \"sender@email.com\"\r\n      filters: [{ field: \"applicationId\", operator: \"eq\", value: \"1\" }]\r\n    }\r\n  ) {\r\n    archivedNotifications {\r\n      applicationDetails {\r\n        applicationId\r\n        name\r\n        userId\r\n        status\r\n        createdOn\r\n        updatedOn\r\n      }\r\n      applicationId\r\n      channelType\r\n      createdBy\r\n      createdOn\r\n      data\r\n      deliveryStatus\r\n      id\r\n      notificationId\r\n      notificationSentOn\r\n      providerId\r\n      result\r\n      status\r\n      updatedBy\r\n      updatedOn\r\n    }\r\n    total,\r\n    offset,\r\n    limit\r\n  }\r\n}","variables":{}}'
+```
+
+**cURL (x-api-key)**
+
+```sh
+curl --location 'YOUR_BASE_URL/graphql' \
+--header 'x-api-key: mysecureserverapikey' \
+--header 'Content-Type: application/json' \
+--data-raw '{"query":"query { archivedNotifications(options: { limit: 5 }) { archivedNotifications { id applicationId channelType deliveryStatus } total offset limit } }","variables":{}}'
 ```
 
 **Sample response**

--- a/apps/api/src/common/filters/problem-json.filter.ts
+++ b/apps/api/src/common/filters/problem-json.filter.ts
@@ -4,6 +4,11 @@
  *
  * This filter is applied ONLY to v1 endpoints (via controller-level @UseFilters).
  * Existing endpoints continue to use HttpExceptionFilter + JSend format.
+ *
+ * Registered globally in main.ts, so it also receives exceptions thrown from
+ * GraphQL resolvers/guards. Those aren't HTTP requests (no request.protocol,
+ * no response to write to), so they're passed through unchanged for Nest's
+ * GraphQL layer to format instead of being forced into Problem+JSON here.
  */
 
 import {
@@ -15,16 +20,21 @@ import {
   BadRequestException,
   Logger,
 } from '@nestjs/common';
+import { GqlExceptionFilter } from '@nestjs/graphql';
 import { Request, Response } from 'express';
 import { ErrorCode, ErrorCodes } from '../constants/error-codes';
 import { ProblemJsonBuilder } from '../exceptions/problem-json.builder';
 import { ValidationError } from 'class-validator';
 
 @Catch()
-export class ProblemJsonFilter implements ExceptionFilter {
+export class ProblemJsonFilter implements ExceptionFilter, GqlExceptionFilter {
   private readonly logger = new Logger(ProblemJsonFilter.name);
 
-  catch(exception: unknown, host: ArgumentsHost): void {
+  catch(exception: unknown, host: ArgumentsHost): unknown {
+    if (host.getType<'graphql' | 'http'>() === 'graphql') {
+      return exception;
+    }
+
     const ctx = host.switchToHttp();
     const response = ctx.getResponse<Response>();
     const request = ctx.getRequest<Request>();

--- a/apps/api/src/common/guards/jwt-or-api-key/jwt-or-api-key.guard.spec.ts
+++ b/apps/api/src/common/guards/jwt-or-api-key/jwt-or-api-key.guard.spec.ts
@@ -1,31 +1,48 @@
 import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
 import { JwtOrApiKeyGuard, RequestWithApiKeyAuth } from './jwt-or-api-key.guard';
 import { JwtAuthGuard } from 'src/modules/auth/guards/jwt-auth.guard';
+import { GqlAuthGuard } from 'src/common/guards/gql-auth.guard';
 import { RolesGuard } from 'src/common/guards/role.guard';
 import { ServerApiKeysService } from 'src/modules/server-api-keys/server-api-keys.service';
 
 describe('JwtOrApiKeyGuard', () => {
   let guard: JwtOrApiKeyGuard;
   let jwtAuthGuard: { canActivate: jest.Mock };
+  let gqlAuthGuard: { canActivate: jest.Mock };
   let rolesGuard: { canActivate: jest.Mock };
   let serverApiKeysService: { findApplicationIdByRawApiKey: jest.Mock };
 
-  const buildContext = (headers: Record<string, string | string[]>): ExecutionContext => {
+  const buildHttpContext = (headers: Record<string, string | string[]>): ExecutionContext => {
     const request = { headers } as RequestWithApiKeyAuth;
 
     return {
+      getType: () => 'http',
       switchToHttp: () => ({
         getRequest: () => request,
       }),
     } as unknown as ExecutionContext;
   };
 
+  const buildGraphqlContext = (headers: Record<string, string | string[]>): ExecutionContext => {
+    const req = { headers } as RequestWithApiKeyAuth;
+
+    return {
+      getType: () => 'graphql',
+      getArgs: () => [{}, {}, { req }, {}],
+      getClass: () => class {},
+      getHandler: () => function handler(): void {},
+      req,
+    } as unknown as ExecutionContext & { req: RequestWithApiKeyAuth };
+  };
+
   beforeEach(() => {
     jwtAuthGuard = { canActivate: jest.fn() };
+    gqlAuthGuard = { canActivate: jest.fn() };
     rolesGuard = { canActivate: jest.fn() };
     serverApiKeysService = { findApplicationIdByRawApiKey: jest.fn() };
     guard = new JwtOrApiKeyGuard(
       jwtAuthGuard as unknown as JwtAuthGuard,
+      gqlAuthGuard as unknown as GqlAuthGuard,
       rolesGuard as unknown as RolesGuard,
       serverApiKeysService as unknown as ServerApiKeysService,
     );
@@ -33,7 +50,7 @@ describe('JwtOrApiKeyGuard', () => {
 
   it('authenticates via x-api-key and stamps apiKeyApplicationId on the request', async () => {
     serverApiKeysService.findApplicationIdByRawApiKey.mockResolvedValue(7);
-    const context = buildContext({ 'x-api-key': 'raw-key' });
+    const context = buildHttpContext({ 'x-api-key': 'raw-key' });
 
     await expect(guard.canActivate(context)).resolves.toBe(true);
     expect(serverApiKeysService.findApplicationIdByRawApiKey).toHaveBeenCalledWith('raw-key');
@@ -43,35 +60,56 @@ describe('JwtOrApiKeyGuard', () => {
 
   it('rejects an unrecognized x-api-key', async () => {
     serverApiKeysService.findApplicationIdByRawApiKey.mockResolvedValue(undefined);
-    const context = buildContext({ 'x-api-key': 'bad-key' });
+    const context = buildHttpContext({ 'x-api-key': 'bad-key' });
 
     await expect(guard.canActivate(context)).rejects.toThrow(UnauthorizedException);
   });
 
   it('uses the first value when x-api-key is sent as multiple headers', async () => {
     serverApiKeysService.findApplicationIdByRawApiKey.mockResolvedValue(3);
-    const context = buildContext({ 'x-api-key': ['first-key', 'second-key'] });
+    const context = buildHttpContext({ 'x-api-key': ['first-key', 'second-key'] });
 
     await expect(guard.canActivate(context)).resolves.toBe(true);
     expect(serverApiKeysService.findApplicationIdByRawApiKey).toHaveBeenCalledWith('first-key');
   });
 
-  it('falls back to JWT + role auth when no x-api-key header is present', async () => {
+  it('falls back to JWT + role auth when no x-api-key header is present (HTTP)', async () => {
     jwtAuthGuard.canActivate.mockResolvedValue(true);
     rolesGuard.canActivate.mockReturnValue(true);
-    const context = buildContext({});
+    const context = buildHttpContext({});
 
     await expect(guard.canActivate(context)).resolves.toBe(true);
     expect(serverApiKeysService.findApplicationIdByRawApiKey).not.toHaveBeenCalled();
     expect(jwtAuthGuard.canActivate).toHaveBeenCalledWith(context);
+    expect(gqlAuthGuard.canActivate).not.toHaveBeenCalled();
     expect(rolesGuard.canActivate).toHaveBeenCalledWith(context);
   });
 
   it('short-circuits when JwtAuthGuard rejects, without calling RolesGuard', async () => {
     jwtAuthGuard.canActivate.mockResolvedValue(false);
-    const context = buildContext({});
+    const context = buildHttpContext({});
 
     await expect(guard.canActivate(context)).resolves.toBe(false);
     expect(rolesGuard.canActivate).not.toHaveBeenCalled();
+  });
+
+  it('authenticates GraphQL requests via x-api-key and stamps the underlying req', async () => {
+    serverApiKeysService.findApplicationIdByRawApiKey.mockResolvedValue(9);
+    const context = buildGraphqlContext({ 'x-api-key': 'raw-key' });
+
+    await expect(guard.canActivate(context)).resolves.toBe(true);
+    expect((context as unknown as { req: RequestWithApiKeyAuth }).req.apiKeyApplicationId).toBe(9);
+    expect(gqlAuthGuard.canActivate).not.toHaveBeenCalled();
+  });
+
+  it('falls back to GqlAuthGuard + role auth for GraphQL requests with no x-api-key', async () => {
+    gqlAuthGuard.canActivate.mockResolvedValue(true);
+    rolesGuard.canActivate.mockReturnValue(true);
+    const context = buildGraphqlContext({});
+
+    await expect(guard.canActivate(context)).resolves.toBe(true);
+    expect(gqlAuthGuard.canActivate).toHaveBeenCalledWith(context);
+    expect(jwtAuthGuard.canActivate).not.toHaveBeenCalled();
+    expect(rolesGuard.canActivate).toHaveBeenCalledWith(context);
   });
 });

--- a/apps/api/src/common/guards/jwt-or-api-key/jwt-or-api-key.guard.ts
+++ b/apps/api/src/common/guards/jwt-or-api-key/jwt-or-api-key.guard.ts
@@ -1,21 +1,41 @@
 import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
+import { GqlExecutionContext } from '@nestjs/graphql';
+import { ApiHeaderOptions } from '@nestjs/swagger';
 import { Request } from 'express';
 import { JwtAuthGuard } from 'src/modules/auth/guards/jwt-auth.guard';
+import { GqlAuthGuard } from 'src/common/guards/gql-auth.guard';
 import { RolesGuard } from 'src/common/guards/role.guard';
 import { ServerApiKeysService } from 'src/modules/server-api-keys/server-api-keys.service';
 
 export type RequestWithApiKeyAuth = Request & { apiKeyApplicationId?: number };
 
+// Swagger doc for @ApiHeader() on any endpoint guarded by JwtOrApiKeyGuard.
+export const API_KEY_HEADER_DOC: ApiHeaderOptions = {
+  name: 'x-api-key',
+  required: false,
+  description: 'Server API key, scoped to a single application (alternative to Bearer JWT)',
+};
+
 @Injectable()
 export class JwtOrApiKeyGuard implements CanActivate {
   constructor(
     private readonly jwtAuthGuard: JwtAuthGuard,
+    private readonly gqlAuthGuard: GqlAuthGuard,
     private readonly rolesGuard: RolesGuard,
     private readonly serverApiKeysService: ServerApiKeysService,
   ) {}
 
+  private getRequest(context: ExecutionContext, isGraphql: boolean): RequestWithApiKeyAuth {
+    if (isGraphql) {
+      return GqlExecutionContext.create(context).getContext().req;
+    }
+
+    return context.switchToHttp().getRequest<RequestWithApiKeyAuth>();
+  }
+
   async canActivate(context: ExecutionContext): Promise<boolean> {
-    const request = context.switchToHttp().getRequest<RequestWithApiKeyAuth>();
+    const isGraphql = context.getType<'graphql' | 'http'>() === 'graphql';
+    const request = this.getRequest(context, isGraphql);
     const apiKeyHeader = request.headers['x-api-key'];
 
     if (apiKeyHeader) {
@@ -31,7 +51,9 @@ export class JwtOrApiKeyGuard implements CanActivate {
       return true;
     }
 
-    const jwtValid = await this.jwtAuthGuard.canActivate(context);
+    const jwtValid = isGraphql
+      ? await this.gqlAuthGuard.canActivate(context)
+      : await this.jwtAuthGuard.canActivate(context);
 
     if (!jwtValid) {
       return false;

--- a/apps/api/src/modules/archived-notifications/archived-notifications.controller.ts
+++ b/apps/api/src/modules/archived-notifications/archived-notifications.controller.ts
@@ -14,17 +14,20 @@ import {
 import {
   ApiBearerAuth,
   ApiExtraModels,
+  ApiHeader,
   ApiOperation,
   ApiQuery,
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
 import { ArchivedNotificationsService } from './archived-notifications.service';
-import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
-import { RolesGuard } from 'src/common/guards/role.guard';
+import {
+  API_KEY_HEADER_DOC,
+  JwtOrApiKeyGuard,
+  RequestWithApiKeyAuth,
+} from 'src/common/guards/jwt-or-api-key/jwt-or-api-key.guard';
 import { Roles } from 'src/common/decorators/roles.decorator';
 import { UserRoles } from 'src/common/constants/database';
-import { Request } from 'express';
 import { PaginationQueryDto } from 'src/common/dto/pagination-query.dto';
 import { PaginatedResponse } from 'src/common/dto/paginated-response.dto';
 import { LinkBuilder } from 'src/common/utils/link-builder.helper';
@@ -45,7 +48,8 @@ export class ArchivedNotificationsController {
   constructor(private readonly archivedNotificationsService: ArchivedNotificationsService) {}
 
   @Get()
-  @UseGuards(JwtAuthGuard, RolesGuard)
+  @UseGuards(JwtOrApiKeyGuard)
+  @ApiHeader(API_KEY_HEADER_DOC)
   @ApiOperation({ summary: 'List archived notifications' })
   @ApiQuery({
     name: 'organization_id',
@@ -147,13 +151,11 @@ export class ArchivedNotificationsController {
     @Query('date_to') dateTo: string,
     @Query('provider_id') providerId: number,
     @CurrentUser() user: JwtPayload,
-    @Req() req: Request,
+    @Req() req: RequestWithApiKeyAuth,
   ): Promise<PaginatedResponse<ArchivedNotificationResponseDto>> {
-    const targetOrgId = resolveOrgId(user, queryOrgId);
     const filters = {
       channelType: channelType ? Number(channelType) : undefined,
       deliveryStatus: deliveryStatus ? Number(deliveryStatus) : undefined,
-      applicationId: applicationId ? Number(applicationId) : undefined,
       dateFrom: dateFrom || undefined,
       providerId: providerId ? Number(providerId) : undefined,
       dateTo: dateTo || undefined,
@@ -164,12 +166,19 @@ export class ArchivedNotificationsController {
       templateName: query.template_name,
       dataFilter: query.data_filter,
     };
+    const { apiKeyApplicationId } = req;
     const { items, meta } =
-      await this.archivedNotificationsService.getAllArchivedNotificationsAsDto(
-        query,
-        targetOrgId,
-        filters,
-      );
+      apiKeyApplicationId !== undefined
+        ? await this.archivedNotificationsService.getAllArchivedNotificationsForApplicationAsDto(
+            query,
+            apiKeyApplicationId,
+            filters,
+          )
+        : await this.archivedNotificationsService.getAllArchivedNotificationsAsDto(
+            query,
+            resolveOrgId(user, queryOrgId),
+            { ...filters, applicationId: applicationId ? Number(applicationId) : undefined },
+          );
     const { protocol, host } = LinkBuilder.extractBaseUrl(req);
     const links = LinkBuilder.buildCollectionLinks(protocol, host, req.path, meta);
 
@@ -177,8 +186,9 @@ export class ArchivedNotificationsController {
   }
 
   @Get(':id')
-  @UseGuards(JwtAuthGuard, RolesGuard)
+  @UseGuards(JwtOrApiKeyGuard)
   @Roles(UserRoles.ORG_USER)
+  @ApiHeader(API_KEY_HEADER_DOC)
   @ApiOperation({ summary: 'Get archived notification by ID' })
   @ApiQuery({
     name: 'organization_id',
@@ -197,10 +207,13 @@ export class ArchivedNotificationsController {
     @Param('id') id: number,
     @Query('organization_id') queryOrgId: number,
     @CurrentUser() user: JwtPayload,
+    @Req() req: RequestWithApiKeyAuth,
   ): Promise<ArchivedNotificationResponseDto> {
-    const targetOrgId = resolveOrgId(user, queryOrgId);
+    if (req.apiKeyApplicationId !== undefined) {
+      return this.archivedNotificationsService.findByIdForApplication(id, req.apiKeyApplicationId);
+    }
 
-    return this.archivedNotificationsService.findByIdAsDto(id, targetOrgId);
+    return this.archivedNotificationsService.findByIdAsDto(id, resolveOrgId(user, queryOrgId));
   }
 
   @Post('archive')

--- a/apps/api/src/modules/archived-notifications/archived-notifications.module.ts
+++ b/apps/api/src/modules/archived-notifications/archived-notifications.module.ts
@@ -8,6 +8,10 @@ import { ConfigService } from '@nestjs/config';
 import { ArchivedNotificationsController } from './archived-notifications.controller';
 import { ArchivedNotificationsResolver } from './archived-notifications.resolver';
 import { ApplicationsModule } from '../applications/applications.module';
+import { JwtOrApiKeyGuard } from 'src/common/guards/jwt-or-api-key/jwt-or-api-key.guard';
+import { RolesGuard } from 'src/common/guards/role.guard';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { GqlAuthGuard } from 'src/common/guards/gql-auth.guard';
 
 @Module({
   imports: [
@@ -15,7 +19,16 @@ import { ApplicationsModule } from '../applications/applications.module';
     forwardRef(() => NotificationsModule),
     ApplicationsModule,
   ],
-  providers: [ArchivedNotificationsService, ArchivedNotificationsResolver, Logger, ConfigService],
+  providers: [
+    ArchivedNotificationsService,
+    ArchivedNotificationsResolver,
+    Logger,
+    ConfigService,
+    JwtOrApiKeyGuard,
+    RolesGuard,
+    JwtAuthGuard,
+    GqlAuthGuard,
+  ],
   exports: [TypeOrmModule, ArchivedNotificationsService],
   controllers: [ArchivedNotificationsController],
 })

--- a/apps/api/src/modules/archived-notifications/archived-notifications.resolver.ts
+++ b/apps/api/src/modules/archived-notifications/archived-notifications.resolver.ts
@@ -4,19 +4,31 @@ import { ArchivedNotification } from './entities/archived-notification.entity';
 import { UseGuards } from '@nestjs/common';
 import { ArchivedNotificationResponse } from './dtos/archived-notification-response.dto';
 import { QueryOptionsDto } from 'src/common/graphql/dtos/query-options.dto';
-import { GqlAuthGuard } from 'src/common/guards/gql-auth.guard';
+import {
+  JwtOrApiKeyGuard,
+  RequestWithApiKeyAuth,
+} from 'src/common/guards/jwt-or-api-key/jwt-or-api-key.guard';
 
 @Resolver(() => ArchivedNotification)
-@UseGuards(GqlAuthGuard)
+@UseGuards(JwtOrApiKeyGuard)
 export class ArchivedNotificationsResolver {
   constructor(private readonly archivedNotificationsService: ArchivedNotificationsService) {}
 
   @Query(() => ArchivedNotificationResponse, { name: 'archivedNotifications' })
   async findAll(
-    @Context() context,
+    @Context() context: { req: RequestWithApiKeyAuth },
     @Args('options', { type: () => QueryOptionsDto, nullable: true, defaultValue: {} })
     options: QueryOptionsDto,
   ): Promise<ArchivedNotificationResponse> {
+    const { apiKeyApplicationId } = context.req;
+
+    if (apiKeyApplicationId !== undefined) {
+      return this.archivedNotificationsService.getAllArchivedNotificationsForApplication(
+        options,
+        apiKeyApplicationId,
+      );
+    }
+
     return this.archivedNotificationsService.getAllArchivedNotifications(options);
   }
 }

--- a/apps/api/src/modules/archived-notifications/archived-notifications.service.ts
+++ b/apps/api/src/modules/archived-notifications/archived-notifications.service.ts
@@ -173,6 +173,19 @@ export class ArchivedNotificationsService extends CoreService<ArchivedNotificati
     return this.mapToDto(notification);
   }
 
+  async findByIdForApplication(
+    archivedNotificationId: number,
+    applicationId: number,
+  ): Promise<ArchivedNotificationResponseDto> {
+    const notification = await this.findById(archivedNotificationId);
+
+    if (!notification || notification.applicationId !== applicationId) {
+      throw new BadRequestException('Archived notification not found');
+    }
+
+    return this.mapToDto(notification);
+  }
+
   async getAllArchivedNotificationsAsDto(
     query: PaginationQueryDto,
     organizationId: number,
@@ -264,12 +277,64 @@ export class ArchivedNotificationsService extends CoreService<ArchivedNotificati
     };
   }
 
+  async getAllArchivedNotificationsForApplicationAsDto(
+    query: PaginationQueryDto,
+    applicationId: number,
+    filters?: {
+      channelType?: number;
+      deliveryStatus?: number;
+      providerId?: number;
+      dateFrom?: string;
+      dateTo?: string;
+      recipient?: string;
+      sender?: string;
+      subject?: string;
+      messageBody?: string;
+      templateName?: string;
+      dataFilter?: Record<string, string>;
+    },
+  ): Promise<{ items: ArchivedNotificationResponseDto[]; meta: PaginationMeta }> {
+    const app = await this.applicationsService.findById(applicationId);
+
+    if (!app) {
+      const { page, limit } = PaginationHelper.normalizePaginationParams(query);
+
+      return { items: [], meta: PaginationHelper.buildPaginationMeta(page, limit, 0) };
+    }
+
+    return this.getAllArchivedNotificationsAsDto(query, app.organizationId, {
+      ...filters,
+      applicationId,
+    });
+  }
+
   async getAllArchivedNotifications(
     options: QueryOptionsDto,
   ): Promise<ArchivedNotificationResponse> {
     this.logger.log('Getting all archived notifications with options.');
 
     const baseConditions = [{ field: 'status', value: Status.ACTIVE }];
+    const searchableFields = ['createdBy', 'data', 'result'];
+
+    const { items, total } = await super.findAll(
+      options,
+      'archivedNotification',
+      searchableFields,
+      baseConditions,
+    );
+    return new ArchivedNotificationResponse(items, total, options.offset, options.limit);
+  }
+
+  async getAllArchivedNotificationsForApplication(
+    options: QueryOptionsDto,
+    applicationId: number,
+  ): Promise<ArchivedNotificationResponse> {
+    this.logger.log(`Getting all archived notifications for applicationId: ${applicationId}`);
+
+    const baseConditions = [
+      { field: 'status', value: Status.ACTIVE },
+      { field: 'applicationId', value: applicationId },
+    ];
     const searchableFields = ['createdBy', 'data', 'result'];
 
     const { items, total } = await super.findAll(

--- a/apps/api/src/modules/notifications/notifications.controller.ts
+++ b/apps/api/src/modules/notifications/notifications.controller.ts
@@ -28,6 +28,7 @@ import { NotificationsService } from './notifications.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from 'src/common/guards/role.guard';
 import {
+  API_KEY_HEADER_DOC,
   JwtOrApiKeyGuard,
   RequestWithApiKeyAuth,
 } from 'src/common/guards/jwt-or-api-key/jwt-or-api-key.guard';
@@ -45,12 +46,6 @@ import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { JwtPayload } from 'src/common/constants/jwtInterface';
 import { SnakeCaseInterceptor } from 'src/common/interceptors/snake-case.interceptor';
 import { resolveOrgId } from 'src/common/utils/org-resolver.helper';
-
-const API_KEY_HEADER_DOC = {
-  name: 'x-api-key',
-  required: false,
-  description: 'Server API key, scoped to a single application (alternative to Bearer JWT)',
-};
 
 @ApiTags('Notifications')
 @ApiBearerAuth()

--- a/apps/api/src/modules/notifications/notifications.module.ts
+++ b/apps/api/src/modules/notifications/notifications.module.ts
@@ -50,6 +50,7 @@ import { NotificationDataFilterHelper } from './helpers/notification-data-filter
 import { JwtOrApiKeyGuard } from 'src/common/guards/jwt-or-api-key/jwt-or-api-key.guard';
 import { RolesGuard } from 'src/common/guards/role.guard';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { GqlAuthGuard } from 'src/common/guards/gql-auth.guard';
 
 const providerModules = [
   MailgunModule,
@@ -111,6 +112,7 @@ const consumers = [
     JwtOrApiKeyGuard,
     RolesGuard,
     JwtAuthGuard,
+    GqlAuthGuard,
     ...consumers,
   ],
   exports: [

--- a/apps/api/src/modules/notifications/notifications.resolver.ts
+++ b/apps/api/src/modules/notifications/notifications.resolver.ts
@@ -4,25 +4,49 @@ import { Notification } from './entities/notification.entity';
 import { UseGuards } from '@nestjs/common';
 import { NotificationResponse } from './dtos/notification-response.dto';
 import { QueryOptionsDto } from 'src/common/graphql/dtos/query-options.dto';
-import { GqlAuthGuard } from 'src/common/guards/gql-auth.guard';
+import {
+  JwtOrApiKeyGuard,
+  RequestWithApiKeyAuth,
+} from 'src/common/guards/jwt-or-api-key/jwt-or-api-key.guard';
 import { SingleNotificationResponse } from './dtos/single-notification.response.dto';
 
 @Resolver(() => Notification)
-@UseGuards(GqlAuthGuard)
+@UseGuards(JwtOrApiKeyGuard)
 export class NotificationsResolver {
   constructor(private readonly notificationsService: NotificationsService) {}
 
   @Query(() => NotificationResponse, { name: 'notifications' })
   async findAll(
-    @Context() context,
+    @Context() context: { req: RequestWithApiKeyAuth },
     @Args('options', { type: () => QueryOptionsDto, nullable: true, defaultValue: {} })
     options: QueryOptionsDto,
   ): Promise<NotificationResponse> {
+    const { apiKeyApplicationId } = context.req;
+
+    if (apiKeyApplicationId !== undefined) {
+      return this.notificationsService.getAllNotificationsForApplication(
+        options,
+        apiKeyApplicationId,
+      );
+    }
+
     return this.notificationsService.getAllNotifications(options);
   }
 
   @Query(() => Notification, { name: 'notification' })
-  async find(@Args('notificationId') notificationId: number): Promise<SingleNotificationResponse> {
+  async find(
+    @Context() context: { req: RequestWithApiKeyAuth },
+    @Args('notificationId') notificationId: number,
+  ): Promise<SingleNotificationResponse> {
+    const { apiKeyApplicationId } = context.req;
+
+    if (apiKeyApplicationId !== undefined) {
+      return this.notificationsService.findActiveOrArchivedNotificationByIdForApplication(
+        notificationId,
+        apiKeyApplicationId,
+      );
+    }
+
     return this.notificationsService.findActiveOrArchivedNotificationById(notificationId);
   }
 }

--- a/apps/api/src/modules/notifications/notifications.service.ts
+++ b/apps/api/src/modules/notifications/notifications.service.ts
@@ -692,6 +692,31 @@ export class NotificationsService extends CoreService<Notification> {
     }
   }
 
+  async findActiveOrArchivedNotificationByIdForApplication(
+    notificationId: number,
+    applicationId: number,
+  ): Promise<SingleNotificationResponse> {
+    const activeEntry = await this.findById(notificationId);
+
+    if (activeEntry && activeEntry.applicationId === applicationId) {
+      return new SingleNotificationResponse(activeEntry);
+    }
+
+    const archivedEntry =
+      await this.archivedNotificationsService.getArchivedNotificationFromNotificationId(
+        notificationId,
+      );
+
+    if (archivedEntry && archivedEntry.applicationId === applicationId) {
+      return new SingleNotificationResponse(archivedEntry);
+    }
+
+    throw new NotFoundException(
+      ErrorCodes.NOTIFICATION_NOT_FOUND,
+      `Notification with ID ${notificationId} not found in any table`,
+    );
+  }
+
   private mapNotificationToDto(n: Notification): NotificationResponseDto {
     return {
       id: n.id,
@@ -837,6 +862,27 @@ export class NotificationsService extends CoreService<Notification> {
     this.logger.log('Getting all notifications with options.');
 
     const baseConditions = [{ field: 'status', value: Status.ACTIVE }];
+    const searchableFields = ['createdBy', 'data', 'result'];
+
+    const { items, total } = await super.findAll(
+      options,
+      'notification',
+      searchableFields,
+      baseConditions,
+    );
+    return new NotificationResponse(items, total, options.offset, options.limit);
+  }
+
+  async getAllNotificationsForApplication(
+    options: QueryOptionsDto,
+    applicationId: number,
+  ): Promise<NotificationResponse> {
+    this.logger.log(`Getting all notifications for applicationId: ${applicationId}`);
+
+    const baseConditions = [
+      { field: 'status', value: Status.ACTIVE },
+      { field: 'applicationId', value: applicationId },
+    ];
     const searchableFields = ['createdBy', 'data', 'result'];
 
     const { items, total } = await super.findAll(


### PR DESCRIPTION
## API PR Checklist

### Task Link
https://pinestem.com/dashboard.html#/tasks/REST-2420/details/?companyId=453&isPrevNext=1

### Pre-requisites

- [x] I have gone through the Contributing guidelines for [Submitting a Pull Request (PR)](https://github.com/OsmosysSoftware/osmo-x/blob/main/CONTRIBUTING.md#-submitting-a-pull-request-pr) and ensured that this is not a duplicate PR.
- [x] I have performed unit testing for the new feature added or updated to ensure the new features added are working as expected.
- [ ] I have added/updated test cases to the [test suite](https://github.com/OsmosysSoftware/osmo-x/blob/main/apps/api/OsmoX.postman_collection.json) as applicable.
- [ ] I have performed preliminary testing using the [test suite](https://github.com/OsmosysSoftware/osmo-x/blob/main/apps/api/OsmoX.postman_collection.json) to ensure that any existing features are not impacted and any new features are working as expected as a whole.
- [x] I have added/updated the required [api docs](https://github.com/OsmosysSoftware/osmo-x/tree/main/apps/api/docs) as applicable.
- [ ] I have added/updated the `.env.example` file with the required values as applicable.

### PR Details

PR details have been updated as per the given format (see below)

- [x] PR title adheres to the format specified in guidelines (e.g., `feat: add admin login endpoint`)
- [x] Description has been added
- [x] Related changes have been added (optional)
- [ ] Screenshots have been added (optional)
- [x] Query request and response examples have been added (as applicable, in case added or updated)
- [x] Documentation changes have been listed (as applicable)
- [x] Test suite/unit testing output is added (as applicable)
- [x] Pending actions have been added (optional)
- [x] Any other additional notes have been added (optional)

### Additional Information

- [x] Appropriate label(s) have been added (`ready for review` should be added if the PR is ready to be reviewed)
- [x] Assignee(s) and reviewer(s) have been added (optional)

> **Note:** Reviewer should ensure that the checklist and description have been populated and followed correctly, and the PR should be merged only after resolving all conversations and verifying that CI checks pass.

---

## Description

Extends `x-api-key` support (added for `GET /notifications` and `GET /notifications/:id` in a prior PR) to the remaining notification read surfaces: the `archived-notifications` REST endpoints and all three GraphQL notification queries. Same auth model throughout — Bearer JWT or `x-api-key`, with `x-api-key` strictly scoped to the key's own application.

- `GET /archived-notifications` and `GET /archived-notifications/:id` now accept either Bearer JWT (org-scoped) or `x-api-key` (application-scoped), mirroring the notifications controller exactly.
- `JwtOrApiKeyGuard` now understands GraphQL execution context, not just HTTP: it detects `context.getType()` once, reads/stamps `apiKeyApplicationId` on the underlying request via `GqlExecutionContext` for GraphQL, and falls back to `GqlAuthGuard` (instead of `JwtAuthGuard`) on the no-api-key GraphQL path.
- `notifications`, `notification`, and `archivedNotifications` GraphQL queries now accept `x-api-key` the same way. The Bearer JWT path is left intentionally unscoped for these — that's pre-existing behavior (no org/application filtering was ever applied to the GraphQL JWT path), unchanged by this PR.
- `x-api-key` on GraphQL is properly scoped: verified a key can list its own application's notifications/archived notifications, fetch its own notifications by ID, and is correctly rejected when querying a notification belonging to a different application.
- `API_KEY_HEADER_DOC` moved out of `notifications.controller.ts` into `jwt-or-api-key.guard.ts` so both REST controllers share one Swagger doc constant instead of duplicating it.
- Fixed `ProblemJsonFilter` (registered globally, so it also catches GraphQL exceptions): it assumed every request was HTTP-shaped and read `request.protocol` unconditionally, which is `undefined` for a GraphQL execution context — so every GraphQL error (auth failures, not-found, anything) came back as a generic `"Cannot read properties of undefined (reading 'protocol')"` instead of the real error. This surfaced while testing this PR's GraphQL rejection cases. Now detects the execution context type up front and passes GraphQL exceptions through unchanged for Nest's GraphQL layer to format normally; REST/HTTP error formatting is untouched.

## Related Changes

- `apps/api/src/common/guards/jwt-or-api-key/jwt-or-api-key.guard.ts`
- `apps/api/src/common/guards/jwt-or-api-key/jwt-or-api-key.guard.spec.ts`
- `apps/api/src/modules/notifications/notifications.controller.ts`
- `apps/api/src/modules/notifications/notifications.module.ts`
- `apps/api/src/modules/notifications/notifications.resolver.ts`
- `apps/api/src/modules/notifications/notifications.service.ts`
- `apps/api/src/modules/archived-notifications/archived-notifications.controller.ts`
- `apps/api/src/modules/archived-notifications/archived-notifications.module.ts`
- `apps/api/src/modules/archived-notifications/archived-notifications.resolver.ts`
- `apps/api/src/modules/archived-notifications/archived-notifications.service.ts`
- `apps/api/src/common/filters/problem-json.filter.ts`
- `apps/api/docs/api-documentation.md`
- `apps/api/docs-site/api-reference/overview.mdx`

## Documentation Changes

- Added **Fetch All Archived Notifications (REST)** and **Get Archived Notification by ID (REST)** sections to `docs/api-documentation.md` (and synced `docs-site/api-reference/overview.mdx`), matching the existing notifications REST doc style: dual auth, scoping rules, query parameters, cURL/response examples.
- Added `x-api-key` notes and cURL examples to all three existing GraphQL sections — **Fetch All Notifications (GraphQL)**, **Fetch active or archived Notification by Id (GraphQL)** / **Fetch Notification by ID (GraphQL)**, **Fetch All Archived Notifications (GraphQL)** — documenting that Bearer stays unscoped there while `x-api-key` is application-scoped.

## Query Request and Response Examples

**REST — Archived notifications list, JWT vs API key (scoped):**

```bash
curl -s "http://localhost:3000/archived-notifications?limit=1&application_id=1" \
  -H "Authorization: Bearer <jwt>"
# => HTTP 200

curl -s "http://localhost:3000/archived-notifications?limit=1" \
  -H "x-api-key: <server-api-key>"
# => HTTP 200, page_info.total_items: 164, every item application_id: 1
```

**REST — Archived notification by ID, JWT vs API key:**

```bash
curl -s http://localhost:3000/archived-notifications/820157 \
  -H "Authorization: Bearer <jwt>"

curl -s http://localhost:3000/archived-notifications/820157 \
  -H "x-api-key: <server-api-key>"
```

Both return the same payload:

```json
{
  "id": 820157,
  "application_id": 1,
  "delivery_status": 6,
  "...": "..."
}
```

**GraphQL — `notifications` list, JWT (unscoped) vs API key (scoped):**

```bash
curl -s -X POST http://localhost:3000/graphql \
  -H "Content-Type: application/json" -H "Authorization: Bearer <jwt>" \
  -d '{"query":"query { notifications(options: {limit: 1}) { total } }"}'
# => {"data":{"notifications":{"total":5}}}   (all orgs)

curl -s -X POST http://localhost:3000/graphql \
  -H "Content-Type: application/json" -H "x-api-key: <server-api-key>" \
  -d '{"query":"query { notifications(options: {limit: 1}) { total } }"}'
# => {"data":{"notifications":{"total":4}}}   (own application only)
```

**GraphQL — `archivedNotifications` list, JWT (unscoped) vs API key (scoped):**

```bash
curl -s -X POST http://localhost:3000/graphql \
  -H "Content-Type: application/json" -H "Authorization: Bearer <jwt>" \
  -d '{"query":"query { archivedNotifications(options: {limit: 1}) { total } }"}'
# => {"data":{"archivedNotifications":{"total":59496}}}   (all orgs)

curl -s -X POST http://localhost:3000/graphql \
  -H "Content-Type: application/json" -H "x-api-key: <server-api-key>" \
  -d '{"query":"query { archivedNotifications(options: {limit: 1}) { total } }"}'
# => {"data":{"archivedNotifications":{"total":164}}}   (own application only — matches the REST scoped count exactly)
```

**GraphQL — `notification` by ID, own application via API key (succeeds):**

```bash
curl -s -X POST http://localhost:3000/graphql \
  -H "Content-Type: application/json" -H "x-api-key: <server-api-key-for-app-1>" \
  -d '{"query":"query { notification(notificationId: 820163) { id applicationId deliveryStatus } }"}'
# => {"data":{"notification":{"id":820163,"applicationId":1,"deliveryStatus":5}}}
```

**GraphQL — `notification` by ID, cross-application access via API key (correctly rejected):**

```bash
curl -s -X POST http://localhost:3000/graphql \
  -H "Content-Type: application/json" -H "x-api-key: <server-api-key-for-app-1>" \
  -d '{"query":"query { notification(notificationId: 507911) { id applicationId } }"}'
# notification 507911 belongs to application 2:
# => {"errors":[{"message":"Notification with ID 507911 not found in any table", ...}],"data":null}
```

**GraphQL — invalid `x-api-key` (correctly rejected):**

```bash
curl -s -X POST http://localhost:3000/graphql \
  -H "Content-Type: application/json" -H "x-api-key: not-a-real-key" \
  -d '{"query":"query { notification(notificationId: 820163) { id } }"}'
# => {"errors":[{"message":"Invalid API key","extensions":{"code":"UNAUTHENTICATED", ...}}],"data":null}
```

## Test Suite / Unit Testing Output

- `JwtOrApiKeyGuard` unit tests (7/7 passing): valid API key, invalid API key, multi-value `x-api-key` header, JWT fallback success, JWT fallback rejection short-circuiting `RolesGuard`, plus two new GraphQL-context cases (API key auth stamping the underlying req, `GqlAuthGuard` fallback).
- `eslint --max-warnings=0`, `prettier --check`, and `tsc --noEmit` clean on all touched files.
- Manual end-to-end verification against a local Docker stack: created a real SMTP-backed notification via `POST /notifications` (x-api-key), confirmed delivery (`delivery_status: 5`, accepted by Gmail), then exercised all 4 REST endpoints and all 3 GraphQL queries under both JWT and `x-api-key`:
  - REST list/by-id for both `notifications` and `archived-notifications`: 200 under JWT and API key, 401 unauthenticated.
  - GraphQL `notifications`/`archivedNotifications` list under API key correctly scoped to the key's own application (verified count parity with the REST scoped results).
  - GraphQL `notification` by-id under API key succeeds for the key's own application and is correctly rejected for a notification belonging to a different application.
- `ProblemJsonFilter` fix verified: before the fix, all three GraphQL rejection cases (invalid key, cross-application access, unauthenticated) returned the generic `"Cannot read properties of undefined (reading 'protocol')"` crash. After the fix, each returns its real, specific error (`"Invalid API key"`, `"Notification with ID X not found in any table"`, `"Unauthorized"`) with no change to REST/HTTP error formatting (same Problem+JSON shape and `content-type` confirmed via a direct before/after comparison).

## Pending Actions

- [ ] Add Postman collection entries for `x-api-key` auth on the `archived-notifications` REST endpoints and the three GraphQL queries.

## Additional Notes

- No `.env.example` changes required — no new environment variables introduced.
- Pre-existing, unrelated test failures observed in `notifications.controller.spec.ts`, `notifications.resolver.spec.ts`, `archived-notifications.resolver.spec.ts`, `server-api-keys.service.spec.ts`, and `archived-notifications.*.spec.ts` (broken NestJS testing-module DI setup — bare `providers: [X]` with no dependencies registered) — confirmed present on unmodified `main`, not introduced by this change.
- This PR also fixes a pre-existing, previously-unrelated bug in `ProblemJsonFilter` (see Description above) — found while testing this PR's GraphQL rejection cases, confirmed as pre-existing (not introduced by this PR) via a control test against an untouched resolver (`applications`), and fixed here since it was actively blocking verification of the new GraphQL auth behavior, both locally and on the R&D deployment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API-key authentication support for active and archived notification REST and GraphQL queries.
  * Added application-scoped notification access for API-key requests.
  * Added filtering, pagination, authorization, and retrieval support for archived notifications.
* **Bug Fixes**
  * Improved GraphQL error handling while preserving existing HTTP error responses.
* **Documentation**
  * Expanded notification API documentation with authentication guidance, cURL examples, and sample responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->